### PR TITLE
CLI/add projects labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 /target/
 lib/target/
+bindings/python/target/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -107,6 +107,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +397,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -766,6 +780,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,10 +879,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "ansi_term",
  "base64 0.11.0",
+ "chrono",
  "clap",
  "clap_generate",
  "env_logger",
@@ -1326,6 +1360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tinyvec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1566,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -10,7 +10,7 @@ use phylum_cli::api::PhylumApi as RustPhylumApi;
 use phylum_cli::types::ApiToken as RustApiToken;
 use phylum_cli::types::JwtToken as RustJwtToken;
 use phylum_cli::types::Key;
-use phylum_cli::types::{JobId, PackageDescriptor, PackageType, UserId};
+use phylum_cli::types::{JobId, PackageDescriptor, PackageType, ProjectId, UserId};
 use phylum_cli::Error;
 
 #[pyclass]
@@ -191,19 +191,26 @@ impl PhylumApi {
     ///     The package version (e.g. `16.13.1`)
     ///   type
     ///     The package type (currently only supports `npm`)
+    ///   project
+    ///     The project id to associate with this request (default: None)
+    ///   label
+    ///     The label to associate with this request (default: None)
     ///
     /// Returns a job id
-    #[text_signature = "(name, version, type=\"npm\")"]
-    #[args(name, version, r#type = "\"npm\"")]
-    pub fn submit_request(&mut self, name: &str, version: &str, r#type: &str) -> PyResult<String> {
+    #[text_signature = "(name, version, type=\"npm\", project=None, label=None)"]
+    #[args(name, version, r#type = "\"npm\"", project = "None", label = "None")]
+    pub fn submit_request(&mut self, name: &str, version: &str, r#type: &str, project: Option<String>, label: Option<String>) -> PyResult<String> {
         let pkg_type = PackageType::from_str(r#type).unwrap_or(PackageType::Npm);
         let pkg = PackageDescriptor {
             name: name.to_string(),
             version: version.to_string(),
             r#type: pkg_type.to_owned(),
         };
+        let proj_id = project
+            .and_then(|s| ProjectId::from_str(&s).ok());
+
         self.api
-            .submit_request(&pkg_type, &[pkg], true, true)
+            .submit_request(&pkg_type, &[pkg], true, true, proj_id, label)
             .map(|j: JobId| j.to_string())
             .map_err(|e: Error| {
                 PyRuntimeError::new_err(format!("Failed to submit package request: {:?}", e))

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -185,29 +185,29 @@ impl PhylumApi {
 
     /// Submit a package request to the system
     ///
+    ///   project
+    ///     The project id to associate with this request
     ///   name
     ///     The package name (e.g. `react`)
     ///   version
     ///     The package version (e.g. `16.13.1`)
     ///   type
     ///     The package type (currently only supports `npm`)
-    ///   project
-    ///     The project id to associate with this request (default: None)
     ///   label
     ///     The label to associate with this request (default: None)
     ///
     /// Returns a job id
-    #[text_signature = "(name, version, type=\"npm\", project=None, label=None)"]
-    #[args(name, version, r#type = "\"npm\"", project = "None", label = "None")]
-    pub fn submit_request(&mut self, name: &str, version: &str, r#type: &str, project: Option<String>, label: Option<String>) -> PyResult<String> {
+    #[text_signature = "(project, name, version, type=\"npm\", label=None)"]
+    #[args(project, name, version, r#type = "\"npm\"", label = "None")]
+    pub fn submit_request(&mut self, project: &str, name: &str, version: &str, r#type: &str, label: Option<String>) -> PyResult<String> {
         let pkg_type = PackageType::from_str(r#type).unwrap_or(PackageType::Npm);
         let pkg = PackageDescriptor {
             name: name.to_string(),
             version: version.to_string(),
             r#type: pkg_type.to_owned(),
         };
-        let proj_id = project
-            .and_then(|s| ProjectId::from_str(&s).ok());
+        let proj_id = ProjectId::from_str(project)
+            .map_err(|e| PyRuntimeError::new_err(format!("Invalid project id: {:?}", e)))?;
 
         self.api
             .submit_request(&pkg_type, &[pkg], true, true, proj_id, label)

--- a/lib/CHANGELOG
+++ b/lib/CHANGELOG
@@ -1,3 +1,4 @@
+* 0.0.5 - Add support for projects and project labels
 * 0.0.4 - Minor update to API response format; add `--threshold` argument to `status` command
 * 0.0.3 - Update response format of the `status` command to match API changes.
 * 0.0.2 - Add support for listing / submitting heuristics.

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -118,6 +118,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +409,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -722,6 +736,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,10 +790,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "ansi_term",
  "base64 0.11.0",
+ "chrono",
  "clap",
  "clap_generate",
  "env_logger",
@@ -1200,6 +1234,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tinyvec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1434,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 build = "build.rs"
@@ -12,10 +12,8 @@ clap_generate = "3.0.0-beta.2"
 clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 
 [dependencies]
-#reqwest = { version = "0.10.7", features = ["json", "rustls-tls"], default-features = false }
 clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 hyper = "^0.13.2"
-#hyper-tls = "^0.4.1"
 hyper-rustls = "0.21.0"
 futures = "^0.3"
 env_logger = "0.7.1"
@@ -33,6 +31,7 @@ shellexpand = "2.0.0"
 lazy_static = "1.4.0"
 yaml-rust = "*"
 home = "0.5.3"
+chrono = { version = "^0.4", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "0.27.0"

--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -350,6 +350,8 @@ mod tests {
                 "started_at": 1603311564,
                 "last_updated": 1603311584,
                 "status": "NEW",
+                "score": 1.0,
+                "label": "",
                 "packages": [
                     {
                     "name": "foo",

--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -117,7 +117,7 @@ impl PhylumApi {
         package_list: &[PackageDescriptor],
         is_user: bool,
         no_recurse: bool,
-        project: Option<ProjectId>,
+        project: ProjectId,
         label: Option<String>,
     ) -> Result<JobId, Error> {
         let req = PackageRequest {
@@ -126,7 +126,7 @@ impl PhylumApi {
             is_user,
             norecurse: no_recurse,
             project,
-            label,
+            label: label.unwrap_or_else(|| "uncategorized".to_string()),
         };
         log::debug!("==> Sending package submission: {:?}", req);
         let resp: PackageSubmissionResponse = self.client.put_capture((), &req)?;
@@ -247,14 +247,7 @@ mod tests {
         };
         let project_id = Uuid::new_v4();
         let label = Some("mylabel".to_string());
-        let res = client.submit_request(
-            &PackageType::Npm,
-            &[pkg],
-            true,
-            true,
-            Some(project_id),
-            label,
-        );
+        let res = client.submit_request(&PackageType::Npm, &[pkg], true, true, project_id, label);
         assert!(res.is_ok(), format!("{:?}", res));
     }
 

--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -27,6 +27,15 @@ impl PhylumApi {
         Ok(resp.msg)
     }
 
+    /// Create a new project
+    pub fn create_project(&mut self, name: &str) -> Result<ProjectId, Error> {
+        let req = ProjectCreateRequest {
+            name: name.to_string(),
+        };
+        let resp: ProjectCreateResponse = self.client.put_capture((), &req)?;
+        Ok(resp.id)
+    }
+
     /// Register new user
     pub fn register(
         &mut self,
@@ -108,12 +117,16 @@ impl PhylumApi {
         package_list: &[PackageDescriptor],
         is_user: bool,
         no_recurse: bool,
+        project: Option<ProjectId>,
+        label: Option<String>,
     ) -> Result<JobId, Error> {
         let req = PackageRequest {
             r#type: req_type.to_owned(),
             packages: package_list.to_vec(),
             is_user,
             norecurse: no_recurse,
+            project,
+            label,
         };
         log::debug!("==> Sending package submission: {:?}", req);
         let resp: PackageSubmissionResponse = self.client.put_capture((), &req)?;
@@ -173,6 +186,7 @@ impl PhylumApi {
 mod tests {
     use mockito::{mock, Matcher};
     use std::str::FromStr;
+    use uuid::Uuid;
 
     use super::*;
     #[test]
@@ -231,7 +245,16 @@ mod tests {
             version: "16.13.1".to_string(),
             r#type: PackageType::Npm,
         };
-        let res = client.submit_request(&PackageType::Npm, &[pkg], true, true);
+        let project_id = Uuid::new_v4();
+        let label = Some("mylabel".to_string());
+        let res = client.submit_request(
+            &PackageType::Npm,
+            &[pkg],
+            true,
+            true,
+            Some(project_id),
+            label,
+        );
         assert!(res.is_ok(), format!("{:?}", res));
     }
 

--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -1,6 +1,6 @@
 name: phylum-cli
 bin_name: phylum-cli
-version: "0.0.4"
+version: "0.0.5"
 author: Phylum, Inc.
 about: Client interface to the Phylum system
 args:
@@ -40,6 +40,14 @@ subcommands:
                 help: Last name
                 takes_value: true
                 required: true
+    - init:
+        about: Initialize a new project
+        args:
+            - project:
+                short: p
+                help: The project name.
+                takes_value: true
+                required: true
     - submit:
         about: Submits a request to the processing system
         args:
@@ -66,6 +74,10 @@ subcommands:
                 short: R
                 takes_value: false
                 required: false
+            - label:
+                short: l
+                takes_value: true
+                required: false
     - batch:
         about: Submits a batch of requests to the processing system
         args:
@@ -86,6 +98,10 @@ subcommands:
             - recurse: 
                 short: R
                 takes_value: false
+                required: false
+            - label:
+                short: l
+                takes_value: true
                 required: false
     - status:
         about: Polls the system for request / job / package status

--- a/lib/src/bin/phylum-cli.bash
+++ b/lib/src/bin/phylum-cli.bash
@@ -25,6 +25,9 @@ _phylum-cli() {
             heuristics)
                 cmd+="__heuristics"
                 ;;
+            init)
+                cmd+="__init"
+                ;;
             ping)
                 cmd+="__ping"
                 ;;
@@ -50,7 +53,7 @@ _phylum-cli() {
 
     case "${cmd}" in
         phylum__cli)
-            opts=" -c -v -h -V  --config --help --version  ping register submit batch status cancel tokens heuristics version help"
+            opts=" -c -v -h -V  --config --help --version  ping register init submit batch status cancel tokens heuristics version help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -78,7 +81,7 @@ _phylum-cli() {
             ;;
         
         phylum__cli__batch)
-            opts=" -f -t -L -R -h -V  --help --version  "
+            opts=" -f -t -L -R -l -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -90,6 +93,10 @@ _phylum-cli() {
                     return 0
                     ;;
                     -t)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -l)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -166,6 +173,25 @@ _phylum-cli() {
                     return 0
                     ;;
                     -h)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        phylum__cli__init)
+            opts=" -p -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                    -p)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -258,7 +284,7 @@ _phylum-cli() {
             return 0
             ;;
         phylum__cli__submit)
-            opts=" -n -v -t -L -R -h -V  --help --version  "
+            opts=" -n -v -t -L -R -l -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -274,6 +300,10 @@ _phylum-cli() {
                     return 0
                     ;;
                     -t)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -l)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -1,4 +1,5 @@
 use ansi_term::Color::{Green, Red};
+use chrono::Local;
 use clap::{load_yaml, App, AppSettings, ArgMatches};
 use home::home_dir;
 use serde::Serialize;
@@ -8,8 +9,8 @@ use std::process;
 use std::str::FromStr;
 
 use phylum_cli::api::PhylumApi;
-use phylum_cli::config::{parse_config, save_config};
-use phylum_cli::types::{JobId, Key, PackageDescriptor, PackageType};
+use phylum_cli::config::{find_project_conf, parse_config, save_config, Config, ProjectConfig};
+use phylum_cli::types::*;
 
 macro_rules! print_user_success {
     ($($tts:tt)*) => {
@@ -60,6 +61,87 @@ fn parse_package(options: &ArgMatches, request_type: &PackageType) -> PackageDes
     }
 }
 
+fn handle_submission(api: &mut PhylumApi, config: Config, matches: clap::ArgMatches) {
+    // If any packages were listed in the config file, include
+    //  those as well.
+    let mut packages = config.packages.unwrap_or_default();
+    let mut request_type = config.request_type;
+    let mut is_user = true;
+    let mut no_recurse = true;
+
+    let project = find_project_conf(".")
+        .and_then(|s| parse_config(&s).ok())
+        .map(|p: ProjectConfig| p.id);
+
+    let mut label = None;
+
+    if let Some(matches) = matches.subcommand_matches("submit") {
+        let pkg = parse_package(matches, &request_type);
+        request_type = pkg.r#type.to_owned();
+        packages.push(pkg);
+        is_user = !matches.is_present("low-priority");
+        no_recurse = !matches.is_present("recurse");
+        label = matches.value_of("label");
+    } else if let Some(matches) = matches.subcommand_matches("batch") {
+        let mut eof = false;
+        let mut line = String::new();
+        let mut reader: Box<dyn BufRead> = if let Some(file) = matches.value_of("file") {
+            // read entries from the file
+            Box::new(BufReader::new(std::fs::File::open(file).unwrap()))
+        } else {
+            // read from stdin
+            log::info!("Waiting on stdin...");
+            Box::new(BufReader::new(io::stdin()))
+        };
+
+        // If a package type was provided on the command line, prefer that
+        //  to the global setting
+        if matches.is_present("type") {
+            request_type =
+                PackageType::from_str(matches.value_of("type").unwrap()).unwrap_or(request_type);
+        }
+        label = matches.value_of("label");
+
+        while !eof {
+            match reader.read_line(&mut line) {
+                Ok(0) => eof = true,
+                Ok(_) => {
+                    line.pop();
+                    let pkg_info = line.split(':').collect::<Vec<&str>>();
+                    if pkg_info.len() != 2 {
+                        log::debug!("Invalid package input: `{}`", line);
+                        continue;
+                    }
+                    packages.push(PackageDescriptor {
+                        name: pkg_info[0].to_owned(),
+                        version: pkg_info[1].to_owned(),
+                        r#type: request_type.to_owned(),
+                    });
+                    line.clear();
+                }
+                Err(err) => {
+                    exit(err, "Error reading input", -6);
+                }
+            }
+        }
+        is_user = !matches.is_present("low-priority");
+        no_recurse = !matches.is_present("recurse");
+    }
+    log::debug!("Submitting request...");
+    let resp = api
+        .submit_request(
+            &request_type,
+            &packages,
+            is_user,
+            no_recurse,
+            project,
+            label.map(|s| s.to_string()),
+        )
+        .unwrap_or_else(|err| exit(err, "Error submitting package", -2));
+    log::info!("Response => {:?}", resp);
+    print_user_success!("Job ID: {}", resp);
+}
+
 fn main() {
     env_logger::init();
 
@@ -93,7 +175,7 @@ fn main() {
         }));
     log::debug!("Reading config from {}", config_path);
 
-    let mut config = parse_config(config_path).unwrap_or_else(|err| {
+    let mut config: Config = parse_config(config_path).unwrap_or_else(|err| {
         log::error!("Failed to parse config: {:?}", err);
         print_user_failure!(
             "Unable to parse configuration file at `{}`: {}",
@@ -113,6 +195,7 @@ fn main() {
         process::exit(0);
     }
 
+    let should_init = matches.subcommand_matches("init").is_some();
     let should_submit = matches.subcommand_matches("submit").is_some()
         || matches.subcommand_matches("batch").is_some();
     let should_get_status = matches.subcommand_matches("status").is_some();
@@ -120,7 +203,8 @@ fn main() {
     let should_manage_tokens = matches.subcommand_matches("tokens").is_some();
     let should_do_heuristics = matches.subcommand_matches("heuristics").is_some();
 
-    if should_submit
+    if should_init
+        || should_submit
         || should_get_status
         || should_cancel
         || should_manage_tokens
@@ -151,7 +235,22 @@ fn main() {
         }
     }
 
-    if let Some(matches) = matches.subcommand_matches("register") {
+    if let Some(matches) = matches.subcommand_matches("init") {
+        let project = matches.value_of("project").unwrap();
+        log::info!("Initializing new project: `{}`", project);
+        let project_id = api.create_project(&project).unwrap_or_else(|err| {
+            exit(err, "Error initializing project", -1);
+        });
+        let proj_conf = ProjectConfig {
+            id: project_id.to_owned(),
+            name: project.to_owned(),
+            created_at: Local::now(),
+        };
+        save_config(PROJ_CONF_FILE, &proj_conf).unwrap_or_else(|err| {
+            log::error!("Failed to save user credentials to config: {}", err)
+        });
+        print_user_success!("Successfully created new project. ID: {}", project_id);
+    } else if let Some(matches) = matches.subcommand_matches("register") {
         log::debug!("Registering new user");
         let email = matches.value_of("email").unwrap();
         let pass = matches.value_of("password").unwrap();
@@ -165,75 +264,12 @@ fn main() {
         log::debug!("Registered user with id: `{}`", user_id);
         config.auth_info.user = email.to_string();
         config.auth_info.pass = pass.to_string();
-        save_config(config_path, &config).unwrap();
         save_config(config_path, &config).unwrap_or_else(|err| {
             log::error!("Failed to save user credentials to config: {}", err)
         });
         print_user_success!("{}", "Successfully registered.");
     } else if should_submit {
-        // If any packages were listed in the config file, include
-        //  those as well.
-        let mut packages = config.packages.unwrap_or_default();
-        let mut request_type = config.request_type;
-        let mut is_user = true;
-        let mut no_recurse = true;
-
-        if let Some(matches) = matches.subcommand_matches("submit") {
-            let pkg = parse_package(matches, &request_type);
-            request_type = pkg.r#type.to_owned();
-            packages.push(pkg);
-            is_user = !matches.is_present("low-priority");
-            no_recurse = !matches.is_present("recurse");
-        } else if let Some(matches) = matches.subcommand_matches("batch") {
-            let mut eof = false;
-            let mut line = String::new();
-            let mut reader: Box<dyn BufRead> = if let Some(file) = matches.value_of("file") {
-                // read entries from the file
-                Box::new(BufReader::new(std::fs::File::open(file).unwrap()))
-            } else {
-                // read from stdin
-                log::info!("Waiting on stdin...");
-                Box::new(BufReader::new(io::stdin()))
-            };
-
-            // If a package type was provided on the command line, prefer that
-            //  to the global setting
-            if matches.is_present("type") {
-                request_type = PackageType::from_str(matches.value_of("type").unwrap())
-                    .unwrap_or(request_type);
-            }
-
-            while !eof {
-                match reader.read_line(&mut line) {
-                    Ok(0) => eof = true,
-                    Ok(_) => {
-                        line.pop();
-                        let pkg_info = line.split(':').collect::<Vec<&str>>();
-                        if pkg_info.len() != 2 {
-                            log::debug!("Invalid package input: `{}`", line);
-                            continue;
-                        }
-                        packages.push(PackageDescriptor {
-                            name: pkg_info[0].to_owned(),
-                            version: pkg_info[1].to_owned(),
-                            r#type: request_type.to_owned(),
-                        });
-                        line.clear();
-                    }
-                    Err(err) => {
-                        exit(err, "Error reading input", -6);
-                    }
-                }
-            }
-            is_user = !matches.is_present("low-priority");
-            no_recurse = !matches.is_present("recurse");
-        }
-        log::debug!("Submitting request...");
-        let resp = api
-            .submit_request(&request_type, &packages, is_user, no_recurse)
-            .unwrap_or_else(|err| exit(err, "Error submitting package", -2));
-        log::info!("Response => {:?}", resp);
-        print_user_success!("Job ID: {}", resp);
+        handle_submission(&mut api, config, matches);
     } else if should_get_status {
         if let Some(matches) = matches.subcommand_matches("status") {
             let mut threshold: f64 = 0.0;

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -71,7 +71,13 @@ fn handle_submission(api: &mut PhylumApi, config: Config, matches: clap::ArgMatc
 
     let project = find_project_conf(".")
         .and_then(|s| parse_config(&s).ok())
-        .map(|p: ProjectConfig| p.id);
+        .map(|p: ProjectConfig| p.id)
+        .unwrap_or_else(|| {
+            print_user_failure!(
+                "Failed to find a valid project configuration. Did you run `phylum-cli init`?"
+            );
+            process::exit(-1)
+        });
 
     let mut label = None;
 

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -6,34 +6,14 @@ use uuid::Uuid;
 
 use crate::restson::{Error, RestPath};
 
+pub type ProjectId = Uuid;
 pub type JobId = Uuid;
 pub type UserId = Uuid;
 pub type Key = Uuid;
 pub type PackageId = String;
 
 pub const API_PATH: &str = "api/v0";
-
-#[serde(rename_all = "UPPERCASE")]
-#[derive(Debug, Serialize, Deserialize)]
-pub enum RequestState {
-    New,
-    Processing,
-    Completed,
-    Error,
-}
-
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[derive(Debug, Serialize, Deserialize)]
-pub enum PackageState {
-    New,                       // Brand new request, nothing has been processed yet.
-    DownloadRequested,         // A download has been requested
-    PendingDownload,           // We have issued the download but it has not started yet.
-    Downloading,               // We are downloading the package files.
-    Processing,                // We are processing the package files.
-    PendingExternalProcessing, // Processing of package files is complete; waiting on external processing (e.g. VCS)
-    PendingPackageProcessing, // External processing is complete; waiting on processing of package files
-    Completed,                // We have completed both downloading and processing.
-}
+pub const PROJ_CONF_FILE: &str = ".phylum_project";
 
 #[serde(rename_all = "lowercase")]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -194,6 +174,10 @@ pub struct PackageRequest {
     pub packages: Vec<PackageDescriptor>,
     pub is_user: bool,
     pub norecurse: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<ProjectId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 impl RestPath<()> for PackageRequest {
@@ -258,6 +242,23 @@ impl<'a> RestPath<PackageDescriptor> for PackageStatus {
     }
 }
 
+/// PUT /projects
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectCreateRequest {
+    pub name: String,
+}
+
+impl RestPath<()> for ProjectCreateRequest {
+    fn get_path(_: ()) -> Result<String, Error> {
+        Ok(format!("{}/job/projects", API_PATH))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectCreateResponse {
+    pub id: ProjectId,
+}
+
 /// GET /heuristics
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HeuristicsListResponse {
@@ -313,10 +314,8 @@ pub struct HeuristicResult {
 pub struct Package {
     #[serde(flatten)]
     pub package: PackageDescriptor,
-    pub last_updated: u64, // epoch seconds
     pub license: Option<String>,
     pub package_score: f64,
-    pub status: PackageState,
     pub vulnerabilities: Vec<Value>, // TODO: parse this using a strong type
     pub heuristics: Value,           // TODO: parse this using a strong type
 }
@@ -334,7 +333,9 @@ pub struct RequestStatusResponse {
     pub user_id: UserId,
     pub started_at: u64,   // epoch seconds
     pub last_updated: u64, // epoch seconds
-    pub status: RequestState,
+    pub score: f64,
+    pub project: Option<ProjectId>,
+    pub label: String,
     pub packages: Vec<PackageStatus>,
 }
 

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -174,10 +174,8 @@ pub struct PackageRequest {
     pub packages: Vec<PackageDescriptor>,
     pub is_user: bool,
     pub norecurse: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub project: Option<ProjectId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
+    pub project: ProjectId,
+    pub label: String,
 }
 
 impl RestPath<()> for PackageRequest {

--- a/lib/tests/headers.rs
+++ b/lib/tests/headers.rs
@@ -60,7 +60,7 @@ fn default_user_agent() {
     let data: HttpBinAnything = client.get(()).unwrap();
     assert_eq!(
         data.headers.user_agent,
-        "restson/".to_owned() + env!("CARGO_PKG_VERSION")
+        "phylum-cli/".to_owned() + env!("CARGO_PKG_VERSION")
     );
 }
 


### PR DESCRIPTION
This PR adds support for projects and labels to the CLI to correspond with updates to the api.  Specifically:

* An `init` subcommand has been added which will create a new project and associated local config file for that project
* The `submit` subcommand has been modified to include the configured project id (if available) and to accept an optional `label` argument when creating a new job.
* The project id and label are included in the status response when checking job status

In addition, status for jobs and packages has been removed to correspond with corresponding api updates.