### PR TITLE
Decreased verbosity of job status response

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: Build
-        with:
-          command: build
-          args: --release --manifest-path lib/Cargo.toml
+      - name: Build
+        run: docker build lib/ --file lib/Dockerfile --tag static-build
+      - name: Copy
+        run: docker run --rm --entrypoint cat static-build target/x86_64-unknown-linux-musl/release/phylum-cli > phylum-cli
       - uses: softprops/action-gh-release@v1
         name: Release
         with:
           files: |
-            lib/target/release/phylum-cli
+            phylum-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             

--- a/lib/CHANGELOG
+++ b/lib/CHANGELOG
@@ -1,4 +1,4 @@
-* 0.0.5 - Add support for projects and project labels
+* 0.0.5 - Add support for projects and project labels / decrease verbosity of package status
 * 0.0.4 - Minor update to API response format; add `--threshold` argument to `status` command
 * 0.0.3 - Update response format of the `status` command to match API changes.
 * 0.0.2 - Add support for listing / submitting heuristics.

--- a/lib/Dockerfile
+++ b/lib/Dockerfile
@@ -41,31 +41,3 @@ COPY . .
 COPY --from=cacher ${APP_PATH}/target target
 COPY --from=cacher /opt/rust/cargo /opt/rust/cargo
 RUN cargo build --release --offline
-# Create a regular user to copy into the `scratch` container
-RUN useradd -M phylum
-
-FROM busybox as runtime
-ARG APP_PATH
-ARG APP_ARGS
-ARG RUST_TARGET
-ARG BUILD_CONFIG
-ARG APP_NAME
-WORKDIR ${APP_PATH}
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder ${APP_PATH}/target/${RUST_TARGET}/${BUILD_CONFIG}/${APP_NAME} ${APP_NAME}
-
-USER phylum
-
-# set to DEBUG for verbose output
-ENV RUST_LOG INFO
-
-# get full backtrace on panic
-ENV RUST_BACKTRACE=1
-
-# Overridden by skaffold build
-ENV APP_NAME ${APP_NAME}
-ENV APP_ARGS ${APP_ARGS}
-
-## Modify to set a different entrypoing / args
-ENTRYPOINT "./$APP_NAME" "$APP_ARGS"
-

--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -131,6 +131,12 @@ subcommands:
                 help: Set a package score threshold (packages with a score below this will cause the application to exit with an error code `STATUS_THRESHOLD_BREACHED [1]`
                 takes_value: true
                 required: false
+            - verbose:
+                short: V 
+                long: verbose
+                help: Increase verbosity of api response.
+                takes_value: false
+                required: false
     - cancel:
         about: Cancels a request currently in progress
         args:

--- a/lib/src/bin/phylum-cli.bash
+++ b/lib/src/bin/phylum-cli.bash
@@ -249,7 +249,7 @@ _phylum-cli() {
             return 0
             ;;
         phylum__cli__status)
-            opts=" -i -n -v -t -T -h -V  --help --version  "
+            opts=" -i -n -v -t -T -V -h  --verbose --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -9,7 +9,7 @@ use std::process;
 use std::str::FromStr;
 
 use phylum_cli::api::PhylumApi;
-use phylum_cli::config::{find_project_conf, parse_config, save_config, Config, ProjectConfig};
+use phylum_cli::config::*;
 use phylum_cli::types::*;
 
 macro_rules! print_user_success {
@@ -179,13 +179,9 @@ fn main() {
     });
     log::debug!("Reading config from {}", config_path);
 
-    let mut config: Config = parse_config(config_path).unwrap_or_else(|err| {
-        log::error!("Failed to parse config: {:?}", err);
-        print_user_failure!(
-            "Unable to parse configuration file at `{}`: {}",
-            config_path,
-            err
-        );
+    let mut config: Config = read_configuration(config_path).unwrap_or_else(|err| {
+        log::error!("Failed to read configuration: {:?}", err);
+        print_user_failure!("Failed to read configuration [`{}`]: {}", config_path, err);
         process::exit(-1)
     });
 

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -14,15 +14,15 @@ use phylum_cli::types::*;
 
 macro_rules! print_user_success {
     ($($tts:tt)*) => {
-        print!("[{}] ", Green.paint("success"));
-        println!($($tts)*);
+        eprint!("[{}] ", Green.paint("success"));
+        eprintln!($($tts)*);
     }
 }
 
 macro_rules! print_user_failure {
     ($($tts:tt)*) => {
-        print!("[{}] ", Red.paint("failure"));
-        println!($($tts)*);
+        eprint!("[{}] ", Red.paint("failure"));
+        eprintln!($($tts)*);
     }
 }
 
@@ -32,10 +32,8 @@ where
 {
     match resp {
         Ok(resp) => {
-            print_user_success!(
-                "Response object:\n{}",
-                serde_json::to_string_pretty(&resp).unwrap()
-            );
+            print_user_success!("Response object:");
+            println!("{}", serde_json::to_string_pretty(&resp).unwrap());
         }
         Err(err) => {
             print_user_failure!("Response error:\n{}", err);


### PR DESCRIPTION
This PR primarily adds:

* Changes to support revised (and more concise) job status response
* Add a `-V`/`--verbose` for returning more detailed job status information

In addition, the following modifications are included:

* Check the environment for a api token first (`PHYLUM_API_KEY`), and prefer that to one provided in the configuration file
* Send json object output to `stdout`, all other messages to `stderr`
* Build a static musl binary for the release