### PR TITLE
Fix release.yml and install.sh for GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,15 @@ jobs:
       - name: Copy
         run: |
           docker run --rm --entrypoint cat static-build target/x86_64-unknown-linux-musl/release/phylum-cli > phylum-cli
+          mkdir phylum-cli-release
+          cp lib/install.sh phylum-cli-release/
+          cp lib/src/bin/settings.yaml phylum-cli-release/
+          cp lib/src/bin/phylum-cli.bash phylum-cli-release/
           cp lib/install.sh .
           cp lib/src/bin/settings.yaml .
           cp lib/src/bin/phylum-cli.bash .
       - name: Build zipfile
-        run: zip phylum-cli-release.zip phylum-cli install.sh settings.yaml phylum-cli.bash
+        run: zip -r phylum-cli-release.zip phylum-cli-release/
       - uses: softprops/action-gh-release@v1
         name: Release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           cp lib/install.sh phylum-cli-release/
           cp lib/src/bin/settings.yaml phylum-cli-release/
           cp lib/src/bin/phylum-cli.bash phylum-cli-release/
+          cp phylum-cli phylum-cli-release/
           cp lib/install.sh .
           cp lib/src/bin/settings.yaml .
           cp lib/src/bin/phylum-cli.bash .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cp lib/src/bin/settings.yaml .
           cp lib/src/bin/phylum-cli.bash .
       - name: Build zipfile
-        run: zip -r phylum-cli-release.zip phylum-cli-release/
+        run: zip -r phylum-cli-release phylum-cli-release
       - uses: softprops/action-gh-release@v1
         name: Release
         with:

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -3,24 +3,24 @@ mkdir -p ${HOME}/.phylum
 
 if [ -f src/bin/settings.yaml ]; then
   cp -f src/bin/settings.yaml ${HOME}/.phylum/
-elif [ -f phylum-cli-release/settings.yaml ]; then
-  cp -f phylum-cli-release/settings.yaml ${HOME}/.phylum/
+elif [ -f settings.yaml ]; then
+  cp -f settings.yaml ${HOME}/.phylum/
 else
   echo "Can't find settings.yaml"
 fi
 
 if [ -f src/bin/phylum-cli.bash ]; then
   cp -f src/bin/phylum-cli.bash ${HOME}/.phylum/
-elif [ -f phylum-cli-release/phylum-cli.bash ]; then
-  cp -f phylum-cli-release/phylum-cli.bash ${HOME}/.phylum/
+elif [ -f phylum-cli.bash ]; then
+  cp -f phylum-cli.bash ${HOME}/.phylum/
 else
   echo "Can't find phylum-cli.bash"
 fi
 
 if [ -f src/bin/phylum-cli ]; then
   cp -f src/bin/phylum-cli ${HOME}/.phylum/
-elif [ -f phylum-cli-release/phylum-cli ]; then
-  cp -f phylum-cli-release/phylum-cli ${HOME}/.phylum/
+elif [ -f phylum-cli ]; then
+  cp -f phylum-cli ${HOME}/.phylum/
 else
   echo "Can't find phylum-cli"
 fi

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -1,7 +1,29 @@
 #!/bin/bash
 mkdir -p ${HOME}/.phylum
-cp -n src/bin/settings.yaml ${HOME}/.phylum/
-cp -f src/bin/phylum-cli.bash ${HOME}/.phylum/
+
+if [ -f src/bin/settings.yaml ]; then
+  cp -f src/bin/settings.yaml ${HOME}/.phylum/
+elif [ -f phylum-cli-release/settings.yaml ]; then
+  cp -f phylum-cli-release/settings.yaml ${HOME}/.phylum/
+else
+  echo "Can't find settings.yaml"
+fi
+
+if [ -f src/bin/phylum-cli.bash ]; then
+  cp -f src/bin/phylum-cli.bash ${HOME}/.phylum/
+elif [ -f phylum-cli-release/phylum-cli.bash ]; then
+  cp -f phylum-cli-release/phylum-cli.bash ${HOME}/.phylum/
+else
+  echo "Can't find phylum-cli.bash"
+fi
+
+if [ -f src/bin/phylum-cli ]; then
+  cp -f src/bin/phylum-cli ${HOME}/.phylum/
+elif [ -f phylum-cli-release/phylum-cli ]; then
+  cp -f phylum-cli-release/phylum-cli ${HOME}/.phylum/
+else
+  echo "Can't find phylum-cli"
+fi
 
 if ! grep -q 'phylum-cli.bash' $HOME/.bashrc ;
 then

--- a/lib/src/bin/settings.yaml
+++ b/lib/src/bin/settings.yaml
@@ -1,6 +1,6 @@
 ---
 connection:
-  uri: "http://127.0.0.1"
+  uri: "https://api.phylum.io"
 auth_info:
   user: someone@someorg.com
   pass: abcd1234


### PR DESCRIPTION
This PR fixes both the release.yml and install.sh to handle GH releases and building phylum-cli from source from a common code path. 

Previously, there were some hiccups if one installed the GH release package vs building from source. This also gives a consistent way to pull phylum-cli with automation by using:
`curl --silent "https://api.github.com/repos/phylum-dev/cli/releases/latest" | jq -r '.assets[] | select(.name | contains("phylum-cli-release.zip")) | .browser_download_url' | xargs curl -sLO`