### PR TITLE
Fix settings overwrite and binary install paths

### DIFF
--- a/lib/install.sh
+++ b/lib/install.sh
@@ -1,25 +1,38 @@
 #!/bin/bash
-mkdir -p ${HOME}/.phylum
-
-if [ -f src/bin/settings.yaml ]; then
-  cp -f src/bin/settings.yaml ${HOME}/.phylum/
-elif [ -f settings.yaml ]; then
-  cp -f settings.yaml ${HOME}/.phylum/
-else
-  echo "Can't find settings.yaml"
+if [ ! -d ${HOME}/.phylum ]; then
+  echo '[*] Creating ~/.phylum'
+  mkdir -p ${HOME}/.phylum
 fi
 
-if [ -f src/bin/phylum-cli.bash ]; then
-  cp -f src/bin/phylum-cli.bash ${HOME}/.phylum/
-elif [ -f phylum-cli.bash ]; then
-  cp -f phylum-cli.bash ${HOME}/.phylum/
-else
-  echo "Can't find phylum-cli.bash"
+if [ ! -f ${HOME}/.phylum/settings.yaml ]; then
+  if [ -f src/bin/settings.yaml ]; then
+    echo '[*] Copying settings.yaml to ~/.phylum'
+    cp -f src/bin/settings.yaml ${HOME}/.phylum/
+  elif [ -f settings.yaml ]; then
+    echo '[*] Copying settings.yaml to ~/.phylum'
+    cp -f settings.yaml ${HOME}/.phylum/
+  else
+    echo "Can't find settings.yaml"
+  fi
+fi
+
+if [ ! -f ${HOME}/.phylum/phylum-cli.bash ]; then
+  if [ -f src/bin/phylum-cli.bash ]; then
+    echo '[*] Copying phylum-cli.bash to ~/.phylum'
+    cp -f src/bin/phylum-cli.bash ${HOME}/.phylum/
+  elif [ -f phylum-cli.bash ]; then
+    echo '[*] Copying phylum-cli.bash to ~/.phylum'
+    cp -f phylum-cli.bash ${HOME}/.phylum/
+  else
+    echo "Can't find phylum-cli.bash"
+  fi
 fi
 
 if [ -f src/bin/phylum-cli ]; then
+  echo '[*] Copying phylum-cli binary to ~/.phylum'
   cp -f src/bin/phylum-cli ${HOME}/.phylum/
 elif [ -f phylum-cli ]; then
+  echo '[*] Copying phylum-cli binary to ~/.phylum'
   cp -f phylum-cli ${HOME}/.phylum/
 else
   echo "Can't find phylum-cli"
@@ -31,6 +44,7 @@ then
 fi
 if ! grep -q '.phylum/:\$PATH' $HOME/.bashrc;
 then
+  echo '[*] Updating path to include ~/.phylum'
   echo 'export PATH="$HOME/.phylum/:$PATH"' >> ${HOME}/.bashrc
 fi
 

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -28,9 +28,9 @@ if [ ! -f ${HOME}/.phylum/phylum-cli.bash ]; then
   fi
 fi
 
-if [ -f src/bin/phylum-cli ]; then
+if [ -f target/release/phylum-cli ]; then
   echo '[*] Copying phylum-cli binary to ~/.phylum'
-  cp -f src/bin/phylum-cli ${HOME}/.phylum/
+  cp -f target/release/phylum-cli ${HOME}/.phylum/
 elif [ -f phylum-cli ]; then
   echo '[*] Copying phylum-cli binary to ~/.phylum'
   cp -f phylum-cli ${HOME}/.phylum/


### PR DESCRIPTION
This PR does 2 things:
1. ensure that settings won't be overwritten if a file already exists at `~/.phylum/settings.yaml`.
2. update the path to copy the phylum-cli binary when building from source