### PR TITLE
Adding support for immediate status after package submission

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 0.0.7 - Adding synch submit requests
 * 0.0.5 - Add support for projects and project labels / decrease verbosity of package status
 * 0.0.4 - Minor update to API response format; add `--threshold` argument to `status` command
 * 0.0.3 - Update response format of the `status` command to match API changes.

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "cli-python"
-version = "0.1.0"
+version = "0.0.7"
 dependencies = [
  "phylum-cli",
  "pyo3",
@@ -879,7 +879,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "0.0.5"
+version = "0.0.7"
 dependencies = [
  "ansi_term",
  "base64 0.11.0",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-python"
-version = "0.1.0"
+version = "0.0.7"
 authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -35,8 +35,10 @@ struct ApiToken {
 /// 
 ///   base_url
 ///     The base url for the api to connect to.
+///   timeout
+///     The timeout (in seconds) for requests to the api (default: 30s).
 #[pyclass]
-#[text_signature = "(base_url)"]
+#[text_signature = "(base_url, timeout=None)"]
 struct PhylumApi {
     api: RustPhylumApi,
 }
@@ -44,9 +46,9 @@ struct PhylumApi {
 #[pymethods]
 impl PhylumApi {
     #[new]
-    #[args(base_url = "\"https://api.phylum.io\"")]
-    pub fn new(base_url: &str) -> PyResult<Self> {
-        RustPhylumApi::new(base_url)
+    #[args(base_url = "\"https://api.phylum.io\"", timeout = "None")]
+    pub fn new(base_url: &str, timeout: Option<u64>) -> PyResult<Self> {
+        RustPhylumApi::new(base_url, timeout)
             .map(|api| PhylumApi { api })
             .map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to create new api instance: {:?}", e))
@@ -210,7 +212,7 @@ impl PhylumApi {
             .map_err(|e| PyRuntimeError::new_err(format!("Invalid project id: {:?}", e)))?;
 
         self.api
-            .submit_request(&pkg_type, &[pkg], true, true, proj_id, label)
+            .submit_request(&pkg_type, &[pkg], true, proj_id, label)
             .map(|j: JobId| j.to_string())
             .map_err(|e: Error| {
                 PyRuntimeError::new_err(format!("Failed to submit package request: {:?}", e))

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+printf "version: "
+read version
+
+printf "changelog: "
+read changelog
+
+sed -E -i "1 s/^/* $version - $changelog\n/" CHANGELOG
+sed -E -i "s/^version = \"([^\"]*)\"/version = \"$version\"/" lib/Cargo.toml
+sed -E -i "s/^version: \"([^\"]*)\"/version: \"$version\"/" lib/src/bin/.conf/cli.yaml
+
+sed -E -i "0,/^$/s/^version = \"([^\"]*)\"/version = \"$version\"/" bindings/python/Cargo.toml

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -48,6 +48,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,10 +108,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -252,6 +283,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -790,9 +827,10 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "ansi_term",
+ "assert_cmd",
  "base64 0.11.0",
  "chrono",
  "clap",
@@ -853,6 +891,32 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "predicates"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
+dependencies = [
+ "difference",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -982,6 +1046,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1339,6 +1412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1497,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "phylum-cli"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 build = "build.rs"
+
+[features]
+phylum-online = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -35,3 +38,5 @@ chrono = { version = "^0.4", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "0.27.0"
+assert_cmd = "1.0.3"
+

--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -1,6 +1,6 @@
 name: phylum-cli
 bin_name: phylum-cli
-version: "0.0.6"
+version: "0.0.7"
 author: Phylum, Inc.
 about: Client interface to the Phylum system
 args:
@@ -10,10 +10,12 @@ args:
         value_name: FILE
         help: Sets a custom config file
         takes_value: true
-    - verbose:
-        short: v
-        multiple: true
-        help: Sets the level of verbosity
+    - timeout:
+        short: t
+        long: timeout
+        value_name: TIMEOUT
+        help: Set the timeout (in seconds) for requests to the Phylum api
+        takes_value: true
 subcommands:
     - ping:
         about: Ping the remote system to verify it is available
@@ -70,8 +72,9 @@ subcommands:
                 short: L
                 takes_value: false
                 required: false
-            - recurse: 
-                short: R
+            - synch: 
+                short: S
+                help: "After submitting a request, immediately request status (default: false)"
                 takes_value: false
                 required: false
             - label:
@@ -95,8 +98,9 @@ subcommands:
                 short: L
                 takes_value: false
                 required: false
-            - recurse: 
-                short: R
+            - synch: 
+                short: S
+                help: "After submitting a request, immediately request status (default: false)"
                 takes_value: false
                 required: false
             - label:

--- a/lib/src/bin/phylum-cli.bash
+++ b/lib/src/bin/phylum-cli.bash
@@ -53,7 +53,7 @@ _phylum-cli() {
 
     case "${cmd}" in
         phylum__cli)
-            opts=" -c -v -h -V  --config --help --version  ping register init submit batch status cancel tokens heuristics version help"
+            opts=" -c -t -h -V  --config --timeout --help --version  ping register init submit batch status cancel tokens heuristics version help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -68,7 +68,11 @@ _phylum-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -v)
+                --timeout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -t)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -81,7 +85,7 @@ _phylum-cli() {
             ;;
         
         phylum__cli__batch)
-            opts=" -f -t -L -R -l -h -V  --help --version  "
+            opts=" -f -t -L -S -l -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -284,7 +288,7 @@ _phylum-cli() {
             return 0
             ;;
         phylum__cli__submit)
-            opts=" -n -v -t -L -R -l -h -V  --help --version  "
+            opts=" -n -v -t -L -S -l -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -69,6 +69,13 @@ impl FromStr for Role {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Complete,
+    Incomplete,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct JwtToken {
     pub access_token: String,
     pub refresh_token: Option<String>,
@@ -173,7 +180,6 @@ pub struct PackageRequest {
     pub r#type: PackageType,
     pub packages: Vec<PackageDescriptor>,
     pub is_user: bool,
-    pub norecurse: bool,
     pub project: ProjectId,
     pub label: String,
 }
@@ -318,8 +324,10 @@ pub struct HeuristicResult {
 pub struct PackageStatus {
     pub name: String,
     pub version: String,
+    pub status: Status,
+    pub last_updated: u64,
     pub license: Option<String>,
-    pub package_score: f64,
+    pub package_score: Option<f64>,
     pub num_dependencies: u32,
     pub num_vulnerabilities: u32,
 }
@@ -339,7 +347,11 @@ pub struct RequestStatusResponse<T> {
     pub id: JobId,
     pub user_id: UserId,
     pub created_at: u64, // epoch seconds
+    pub status: Status,
     pub score: f64,
+    #[serde(default)]
+    pub num_incomplete: u32,
+    pub last_updated: u64,
     pub project: Option<ProjectId>,
     pub label: Option<String>,
     pub packages: Vec<T>,

--- a/lib/tests/cmd.rs
+++ b/lib/tests/cmd.rs
@@ -1,0 +1,97 @@
+use assert_cmd::Command;
+
+use phylum_cli::types::JobDescriptor;
+
+fn is_sub<T: PartialEq>(haystack: &[T], needle: &[T]) -> bool {
+    haystack.windows(needle.len()).any(|c| c == needle)
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn ping_system() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.arg("ping").assert();
+    assert.success().stdout("\"Alive\"\n");
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn get_basic_status() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.arg("status").assert();
+
+    let output = &assert.get_output().stderr;
+    assert!(is_sub(output, b"success"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn get_job_status() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.arg("status").assert();
+
+    let resp = String::from_utf8_lossy(&assert.get_output().stdout);
+    let obj: Vec<JobDescriptor> = serde_json::from_str(&resp).unwrap();
+
+    let job_id = obj[0].job_id;
+
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.args(&["status", "-i", &job_id.to_string()]).assert();
+
+    let output = &assert.get_output().stderr;
+    assert!(is_sub(output, b"success"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn get_job_status_non_existent_job() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd
+        .args(&["status", "-i", "ffffffff-ffff-ffff-ffff-ffffffffffff"])
+        .assert();
+
+    let output = assert.get_output();
+    assert_eq!(output.stdout, b"");
+    assert!(is_sub(&output.stderr, b"404 Not Found"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn get_package_status() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.arg("status").assert();
+
+    let resp = String::from_utf8_lossy(&assert.get_output().stdout);
+    let jobs: Vec<JobDescriptor> = serde_json::from_str(&resp).unwrap();
+
+    let name = jobs[0].packages[0].name.to_string();
+    let version = jobs[0].packages[0].version.to_string();
+
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.args(&["status", "-n", &name, "-v", &version]).assert();
+
+    let output = &assert.get_output().stderr;
+    assert!(is_sub(output, b"success"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "phylum-online"), ignore)]
+fn get_package_status_detailed() {
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd.arg("status").assert();
+
+    let resp = String::from_utf8_lossy(&assert.get_output().stdout);
+    let jobs: Vec<JobDescriptor> = serde_json::from_str(&resp).unwrap();
+
+    let name = jobs[0].packages[0].name.to_string();
+    let version = jobs[0].packages[0].version.to_string();
+
+    let mut cmd = Command::cargo_bin("phylum-cli").unwrap();
+    let assert = cmd
+        .args(&["status", "-n", &name, "-v", &version])
+        .arg("-V")
+        .assert();
+
+    let output = &assert.get_output().stderr;
+    assert!(is_sub(output, b"success"));
+}


### PR DESCRIPTION
This PR addresses #13 , specifically adding support for immediately returning status on package submission, and updates to indicate the completion status of jobs along with their constituent packages.

In addition, a timeout setting for api requests has been provided.