### PR TITLE
Remove trailing `/` from `~/.phylum` path addition

### DIFF
--- a/lib/install.sh
+++ b/lib/install.sh
@@ -45,7 +45,7 @@ fi
 if ! grep -q '.phylum/:\$PATH' $HOME/.bashrc;
 then
   echo '[*] Updating path to include ~/.phylum'
-  echo 'export PATH="$HOME/.phylum/:$PATH"' >> ${HOME}/.bashrc
+  echo 'export PATH="$HOME/.phylum:$PATH"' >> ${HOME}/.bashrc
 fi
 
 if ! grep -q 'alias ph=' $HOME/.bashrc ;


### PR DESCRIPTION
Trivial change
I happened upon this while Derrik was helping me get localdev going.

The trailing `/` in the addition to `$PATH` resulted in a path with an empty segment:
```shell
$ which phylum
<home dir>/.phylum//phylum
```
so I removed the trailing `/`.