### PR TITLE
Show vulnerabilities when checking package status

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.12.1",
  "unicode-width",
  "vec_map",
  "yaml-rust",
@@ -1210,6 +1210,7 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "spinners",
+ "textwrap 0.13.4",
  "tokio 0.2.25",
  "url",
  "uuid",
@@ -1766,6 +1767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +1952,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+dependencies = [
+ "smawk",
  "unicode-width",
 ]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "^0.4", features = ["serde"] }
 nom = "6.1.2"
 prettytable-rs = "0.8.0"
 histogram = "0.6.9"
+textwrap = "0.13.4"
 
 ## TODO: remove these when all fakes replaced
 fake = { version = "2.4", features=['derive']}

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use uuid::Uuid;
 
 use fake::Dummy;
@@ -443,7 +442,7 @@ pub struct PackageStatusExtended {
     #[serde(rename = "riskVectors")]
     pub risk_vectors: HashMap<String, f64>,
     pub dependencies: Vec<PackageDescriptor>,
-    pub vulnerabilities: Vec<Value>, // TODO: parse this using a strong type
+    pub vulnerabilities: Vec<Vulnerability>,
     pub heuristics: HashMap<String, HeuristicResult>,
 }
 
@@ -500,6 +499,13 @@ pub struct HeuristicResult {
     pub description: String,
     pub domain: RiskDomain,
     pub score: f64,
+}
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Vulnerability {
+    pub cve: Vec<String>,
+    pub base_severity: f32,
+    pub description: String,
+    pub remediation: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Prints a formatted table showing the package vulnerabilities when running either of:

* `phylum package <pkg_name> <pkg_version>`
* `phylum history <job_id> --verbose`