### PR TITLE
Include the project name in the display

### DIFF
--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -406,6 +406,7 @@ mod tests {
                 "score": 1.0,
                 "last_updated": 1603311780,
                 "project": "86bb664a-5331-489b-8901-f052f155ec79",
+                "project_name": "some_project",
                 "label": "some_label",
                 "packages": [
                     {
@@ -442,7 +443,8 @@ mod tests {
                 "job_id": "59482a54-423b-448d-8325-f171c9dc336b",
                 "user_id": "86bb664a-5331-489b-8901-f052f155ec79",
                 "ecosystem": "npm",
-                "project": "some project",
+                "project": "86bb664a-5331-489b-8901-f052f155ec79",
+                "project_name": "some project",
                 "user_email": "foo@bar.com",
                 "thresholds": {
                     "author": 0.4,

--- a/lib/src/summarize.rs
+++ b/lib/src/summarize.rs
@@ -117,7 +117,7 @@ where
     let details = [
         (
             "Project",
-            resp.project.to_string(),
+            resp.project_name.to_string(),
             "Label",
             resp.label.as_ref().unwrap_or(&"".to_string()).to_owned(),
         ),

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -520,7 +520,8 @@ pub struct RequestStatusResponse<T> {
     #[serde(default)]
     pub num_incomplete: u32,
     pub last_updated: u64,
-    pub project: String,
+    pub project: String, // project id
+    pub project_name: String,
     pub label: Option<String>,
     pub thresholds: ProjectThresholds,
     pub packages: Vec<T>,


### PR DESCRIPTION
Display the project name (rather than the project id) in the summary output.