### PR TITLE
Include packages with perfect (1.0) scores in the histogram count

### DIFF
--- a/lib/src/render.rs
+++ b/lib/src/render.rs
@@ -253,13 +253,25 @@ impl Renderable for PackageStatus {
     }
 }
 
+impl Renderable for PackageType {
+    fn render(&self) -> String {
+        let s = match self {
+            PackageType::Npm => "NPM",
+            PackageType::Ruby => "Ruby",
+            PackageType::PyPi => "Python",
+            PackageType::Java => "Java",
+        };
+        s.to_string()
+    }
+}
+
 impl Renderable for PackageStatusExtended {
     fn render(&self) -> String {
         let mut overview_table = table!(
             ["Package Name:", rB -> self.basic_status.name, "Package Version:", r -> self.basic_status.version],
             ["License:", r -> self.basic_status.license.as_ref().unwrap_or(&"Unknown".to_string()), "Last updated:", r -> self.basic_status.last_updated],
             ["Num Deps:", r -> self.basic_status.num_dependencies, "Num Vulns:", r -> self.basic_status.num_vulnerabilities],
-            ["Type", r -> self.r#type.to_string().to_uppercase(), "Language", r -> self.r#type.language()]
+            ["Type", r -> self.r#type.render(), "Language", r -> self.r#type.language()]
         );
         overview_table.set_format(table_format(0, 3));
         overview_table.to_string()

--- a/lib/src/summarize.rs
+++ b/lib/src/summarize.rs
@@ -28,7 +28,15 @@ impl Histogram {
                 continue;
             }
 
-            let bucket_id = ((y - min) / step) as usize;
+            let mut bucket_id = ((y - min) / step) as usize;
+
+            // Account for packages with a "perfect" (i.e. 1.0) score
+            // This is generally unlikely but possible with packages that have
+            //  not yet had analytics run on them
+            if bucket_id == values.len() {
+                bucket_id -= 1;
+            }
+
             if bucket_id < values.len() {
                 values[bucket_id as usize] += 1;
             }


### PR DESCRIPTION
Likely fix for #45.  Holding off on linking that issue to close till we've performed additional testing / verification.