### PR TITLE
Make build scripts more location robust

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+
+pushd "$SCRIPT_DIR" || exit
+
 cargo install --path .
+
+popd || exit

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+
+pushd "$SCRIPT_DIR" || exit
+
 if [ ! -d ${HOME}/.phylum ]; then
   echo '[*] Creating ~/.phylum'
   mkdir -p ${HOME}/.phylum
@@ -50,3 +55,5 @@ if ! grep -q 'alias ph=' $HOME/.bashrc ;
 then
     echo "alias ph='phylum'" >> ${HOME}/.bashrc
 fi
+
+popd || exit


### PR DESCRIPTION
* Use dirname to get location of script, then invoke build
  relative to that