### PR TITLE
Allow additional entries before the `GEM` header

### DIFF
--- a/lib/src/lockfiles/parsers.rs
+++ b/lib/src/lockfiles/parsers.rs
@@ -123,6 +123,7 @@ pub mod gem {
     }
 
     fn gem_header(input: &str) -> Result<&str, &str> {
+        let (input, _) = recognize(take_until("GEM"))(input)?;
         recognize(tuple((tag("GEM"), line_ending)))(input)
     }
 


### PR DESCRIPTION
Some `Gemfile.lock` files have `GIT` or other entries before the `GEM` header.  Relaxed parsing to allow for that.