### PR TITLE
Updates to support threshold actions and issues templates

### DIFF
--- a/lib/src/api.rs
+++ b/lib/src/api.rs
@@ -300,12 +300,13 @@ mod tests {
                              ],
                             "msg": "Project met threshold requirements",
                             "pass": true,
+                            "action": "warn",
                             "project": "test-project",
                             "total_jobs": 1,
                             "score": 1.0,
                             "ecosystem": "npm"
                         },
-                       {
+                        {
                             "date": "Mon, 17 May 2021 17:39:34 GMT",
                             "job_id": "f8e8cb21-a4c0-4718-9cd2-8f631e95b951",
                             "label": "uncategorized",
@@ -319,6 +320,7 @@ mod tests {
                              ],
                             "msg": "Project met threshold requirements",
                             "pass": true,
+                            "action": "break",
                             "project": "test-project",
                             "total_jobs": 1,
                             "score": 1.0,
@@ -352,6 +354,9 @@ mod tests {
                 "package_score": 1.0,
                 "num_dependencies": 2,
                 "num_vulnerabilities": 4,
+                "msg": "Project met threshold requirements",
+                "pass": true,
+                "action": "warn",
                 "status": "complete",
                 "vulnerabilities": [],
                 "riskVectors": {
@@ -361,6 +366,17 @@ mod tests {
                     "malicious_code": 1.0,
                     "vulnerability": 1.0
                 },
+                "issues": [
+                    {
+                    "title": "Commercial license risk in xmlrpc@0.3.0",
+                    "description": "license is medium risk",
+                    "risk_level": "medium",
+                    "risk_domain": "LicenseRisk",
+                    "pkg_name": "xmlrpc",
+                    "pkg_version": "0.3.0",
+                    "score": 0.7
+                    }
+                ],
                 "heuristics": {
                     "something": {
                         "description": "do stuff",
@@ -415,6 +431,9 @@ mod tests {
                 "project": "86bb664a-5331-489b-8901-f052f155ec79",
                 "project_name": "some_project",
                 "label": "some_label",
+                "msg": "Project met threshold requirements",
+                "pass": true,
+                "action": "none",
                 "packages": [
                     {
                     "name": "foo",
@@ -466,6 +485,9 @@ mod tests {
                 "label": "",
                 "status": "incomplete",
                 "last_updated": 1603311864,
+                "msg": "Project met threshold requirements",
+                "pass": true,
+                "action": "warn",
                 "packages": [
                     {
                     "name": "foo",
@@ -478,6 +500,17 @@ mod tests {
                     "package_score": 0.3,
                     "status": "incomplete",
                     "vulnerabilities": [],
+                    "issues": [
+                        {
+                        "title": "Commercial license risk in xmlrpc@0.3.0",
+                        "description": "license is medium risk",
+                        "risk_level": "medium",
+                        "risk_domain": "LicenseRisk",
+                        "pkg_name": "xmlrpc",
+                        "pkg_version": "0.3.0",
+                        "score": 0.7
+                        }
+                    ],
                     "heuristics": {
                         "something": {
                             "description": "do stuff",

--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -24,6 +24,7 @@ subcommands:
         args:
             - JOB_ID:
                 required: false
+                help: The job id to query (or `current` for the most recent job)
             - verbose:
                 short: V 
                 long: verbose

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -25,6 +25,8 @@ use phylum_cli::lockfiles::{GemLock, PackageLock, YarnLock};
 use phylum_cli::summarize::Summarize;
 use phylum_cli::types::*;
 
+const STATUS_THRESHOLD_BREACHED: i32 = 1;
+
 macro_rules! print_user_success {
     ($($tts:tt)*) => {
         eprint!("✅ ",);
@@ -98,28 +100,41 @@ fn get_project_list(api: &mut PhylumApi, pretty_print: bool) {
     println!();
 }
 
-/// Display user-friendly overview of a job
-fn get_job_status(api: &mut PhylumApi, job_id: &JobId, verbose: bool, pretty: bool) {
-    if verbose {
-        let resp = api.get_job_status_ext(job_id);
-        if let Err(phylum_cli::Error::HttpError(404, _)) = resp {
-            print_user_warning!(
-                "No results found. Submit a lockfile for processing:\n\n\t{}\n",
-                Blue.paint("phylum analyze <lock_file>")
-            );
-        } else {
-            print_response(&resp, pretty);
-        }
+fn handle_status<T>(
+    resp: Result<RequestStatusResponse<T>, phylum_cli::Error>,
+    pretty: bool,
+) -> Action
+where
+    T: std::fmt::Debug + Serialize + Summarize,
+    phylum_cli::types::RequestStatusResponse<T>: Summarize,
+{
+    let mut action = Action::None;
+
+    if let Err(phylum_cli::Error::HttpError(404, _)) = resp {
+        print_user_warning!(
+            "No results found. Submit a lockfile for processing:\n\n\t{}\n",
+            Blue.paint("phylum analyze <lock_file>")
+        );
     } else {
-        let resp = api.get_job_status(job_id);
-        if let Err(phylum_cli::Error::HttpError(404, _)) = resp {
-            print_user_warning!(
-                "No results found. Submit a lockfile for processing:\n\n\t{}\n",
-                Blue.paint("phylum analyze <lock_file>")
-            );
-        } else {
-            print_response(&resp, pretty);
+        if let Ok(ref resp) = resp {
+            if !resp.pass {
+                action = resp.action.to_owned();
+            }
         }
+        print_response(&resp, pretty);
+    }
+
+    action
+}
+
+/// Display user-friendly overview of a job
+fn get_job_status(api: &mut PhylumApi, job_id: &JobId, verbose: bool, pretty: bool) -> Action {
+    if verbose {
+        let resp = api.get_job_status_ext(&job_id);
+        handle_status(resp, pretty)
+    } else {
+        let resp = api.get_job_status(&job_id);
+        handle_status(resp, pretty)
     }
 }
 
@@ -128,9 +143,10 @@ fn get_job_status(api: &mut PhylumApi, job_id: &JobId, verbose: bool, pretty: bo
 /// This allows us to list last N job runs, list the projects, list runs
 /// associated with projects, and get the detailed run results for a specific
 /// job run.
-fn handle_history(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatches) -> i32 {
+fn handle_history(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatches) -> Action {
     let pretty_print = !matches.is_present("json");
     let verbose = matches.is_present("verbose");
+    let mut ret = Action::None;
 
     let mut get_job = |job_id: Option<&str>| {
         let job_id_str = job_id.unwrap();
@@ -140,9 +156,9 @@ fn handle_history(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatche
         } else {
             JobId::from_str(job_id_str).ok()
         }
-        .unwrap_or_else(|| exit(&format!("Invalid job id: {}", job_id_str), -3));
+        .unwrap_or_else(|| exit(Some(&format!("Invalid job id: {}", job_id_str)), -3));
 
-        get_job_status(api, &job_id, verbose, pretty_print);
+        get_job_status(api, &job_id, verbose, pretty_print)
     };
 
     if let Some(matches) = matches.subcommand_matches("project") {
@@ -154,13 +170,13 @@ fn handle_history(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatche
                 let resp = api.get_project_details(project_name);
                 print_response(&resp, pretty_print);
             } else {
-                get_job(project_job_id);
+                ret = get_job(project_job_id);
             }
         } else {
             get_project_list(api, pretty_print);
         }
     } else if matches.is_present("JOB_ID") {
-        get_job(matches.value_of("JOB_ID"));
+        ret = get_job(matches.value_of("JOB_ID"));
     } else {
         let resp = api.get_status();
         if let Err(phylum_cli::Error::HttpError(404, _)) = resp {
@@ -177,7 +193,7 @@ fn handle_history(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatche
         }
     }
 
-    0
+    ret
 }
 
 /// Attempt to get packages from an unknown lockfile type
@@ -240,7 +256,7 @@ fn get_packages_from_lockfile(path: &str) -> Option<(Vec<PackageDescriptor>, Pac
 
 /// Handles submission of packages to the system for analysis and
 /// displays summary information about the submitted package(s)
-fn handle_submission(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatches) {
+fn handle_submission(api: &mut PhylumApi, config: Config, matches: &clap::ArgMatches) -> Action {
     let mut packages = vec![];
     let mut request_type = config.request_type; // default request type
     let mut synch = false; // get status after submission
@@ -248,12 +264,13 @@ fn handle_submission(api: &mut PhylumApi, config: Config, matches: &clap::ArgMat
     let mut pretty_print = false;
     let mut label = None;
     let mut is_user = true; // is a user (non-batch) request
+    let mut ret = Action::None;
 
     let project = get_current_project()
         .map(|p: ProjectConfig| p.id)
         .unwrap_or_else(|| {
             exit(
-                "Failed to find a valid project configuration. Did you run `phylum projects create <project-name>`?",
+                Some("Failed to find a valid project configuration. Did you run `phylum projects create <project-name>`?"),
                 -1
             );
         });
@@ -261,8 +278,12 @@ fn handle_submission(api: &mut PhylumApi, config: Config, matches: &clap::ArgMat
     if let Some(matches) = matches.subcommand_matches("analyze") {
         // Should never get here if `LOCKFILE` was not specified
         let lockfile = matches.value_of("LOCKFILE").unwrap();
-        let res = get_packages_from_lockfile(lockfile)
-            .unwrap_or_else(|| exit("Unable to locate any valid package in package lockfile", -1));
+        let res = get_packages_from_lockfile(lockfile).unwrap_or_else(|| {
+            exit(
+                Some("Unable to locate any valid package in package lockfile"),
+                -1,
+            )
+        });
 
         packages = res.0;
         request_type = res.1;
@@ -333,8 +354,10 @@ fn handle_submission(api: &mut PhylumApi, config: Config, matches: &clap::ArgMat
 
     if synch {
         log::debug!("Requesting status...");
-        get_job_status(api, &job_id, verbose, pretty_print);
+        ret = get_job_status(api, &job_id, verbose, pretty_print);
     }
+
+    ret
 }
 
 /// Register a user. Drops the user into an interactive mode to get the user's
@@ -997,6 +1020,7 @@ fn main() {
 
     let matches = app.get_matches();
     let mut exit_status: i32 = 0;
+    let mut action = Action::None;
 
     let latest_version = get_latest_version();
     if matches.subcommand_matches("update").is_none() && needs_update(&latest_version, ver) {
@@ -1008,12 +1032,12 @@ fn main() {
     if let Some(matches) = matches.subcommand_matches("analyze") {
         if !matches.is_present("LOCKFILE") {
             print_sc_help(app_helper, "analyze");
-            process::exit(0);
+            exit(None, 0);
         }
     } else if let Some(matches) = matches.subcommand_matches("package") {
         if !(matches.is_present("name") && matches.is_present("version")) {
             print_sc_help(app_helper, "package");
-            process::exit(0);
+            exit(None, 0);
         }
     }
 
@@ -1021,10 +1045,10 @@ fn main() {
         let name = yml["name"].as_str().unwrap_or("");
         let version = yml["version"].as_str().unwrap_or("");
         print_user_success!("{} (Version {})", name, version);
-        process::exit(0);
+        exit(None, 0);
     }
     let home_path = home_dir().unwrap_or_else(|| {
-        exit("Couldn't find the user's home directory", -1);
+        exit(Some("Couldn't find the user's home directory"), -1);
     });
     let settings_path = home_path.as_path().join(".phylum").join("settings.yaml");
 
@@ -1032,10 +1056,10 @@ fn main() {
         settings_path.to_str().unwrap_or_else(|| {
             log::error!("Unicode parsing error in configuration file path");
             exit(
-                &format!(
+                Some(&format!(
                     "Unable to read path to configuration file at '{:?}'",
                     settings_path
-                ),
+                )),
                 -1,
             );
         })
@@ -1044,7 +1068,10 @@ fn main() {
 
     let mut config: Config = read_configuration(config_path).unwrap_or_else(|err| {
         exit(
-            &format!("Failed to read configuration at `{}`: {}", config_path, err),
+            Some(&format!(
+                "Failed to read configuration at `{}`: {}",
+                config_path, err
+            )),
             -1,
         );
     });
@@ -1059,7 +1086,7 @@ fn main() {
     if matches.subcommand_matches("ping").is_some() {
         let resp = api.ping();
         print_response(&resp, true);
-        process::exit(0);
+        exit(None, 0);
     }
 
     let should_projects = matches.subcommand_matches("projects").is_some();
@@ -1111,9 +1138,9 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("package") {
         exit_status = handle_get_package(&mut api, &config.request_type, matches);
     } else if should_submit {
-        handle_submission(&mut api, config, &matches);
+        action = handle_submission(&mut api, config, &matches);
     } else if let Some(matches) = matches.subcommand_matches("history") {
-        exit_status = handle_history(&mut api, config, matches);
+        action = handle_history(&mut api, config, &matches);
     } else if should_cancel {
         if let Some(matches) = matches.subcommand_matches("cancel") {
             let request_id = matches.value_of("request_id").unwrap().to_string();
@@ -1124,8 +1151,17 @@ fn main() {
         }
     }
 
-    log::debug!("Exiting with status {}", exit_status);
-    process::exit(exit_status);
+    match action {
+        Action::None => {
+            log::debug!("Exiting with status {}", exit_status);
+            exit(None, exit_status)
+        }
+        Action::Warn => exit(Some("Project failed threshold requirements!"), exit_status),
+        Action::Break => exit(
+            Some("Project failed threshold requirements, failing the build!"),
+            STATUS_THRESHOLD_BREACHED,
+        ),
+    }
 }
 
 fn err_exit(error: impl Error, message: &str, code: i32) -> ! {
@@ -1134,8 +1170,15 @@ fn err_exit(error: impl Error, message: &str, code: i32) -> ! {
     process::exit(code);
 }
 
-fn exit(message: &str, code: i32) -> ! {
-    log::warn!("{}", message);
-    print_user_failure!("Error: {}", message);
+fn exit(message: Option<&str>, code: i32) -> ! {
+    if let Some(message) = message {
+        if code != 0 {
+            log::warn!("{}", message);
+            print_user_failure!("Error: {}", message);
+        } else {
+            log::debug!("{}", message);
+            print_user_warning!("{}", message);
+        }
+    }
     process::exit(code);
 }

--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -130,10 +130,10 @@ where
 /// Display user-friendly overview of a job
 fn get_job_status(api: &mut PhylumApi, job_id: &JobId, verbose: bool, pretty: bool) -> Action {
     if verbose {
-        let resp = api.get_job_status_ext(&job_id);
+        let resp = api.get_job_status_ext(job_id);
         handle_status(resp, pretty)
     } else {
-        let resp = api.get_job_status(&job_id);
+        let resp = api.get_job_status(job_id);
         handle_status(resp, pretty)
     }
 }
@@ -1140,7 +1140,7 @@ fn main() {
     } else if should_submit {
         action = handle_submission(&mut api, config, &matches);
     } else if let Some(matches) = matches.subcommand_matches("history") {
-        action = handle_history(&mut api, config, &matches);
+        action = handle_history(&mut api, config, matches);
     } else if should_cancel {
         if let Some(matches) = matches.subcommand_matches("cancel") {
             let request_id = matches.value_of("request_id").unwrap().to_string();

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -89,6 +89,13 @@ pub fn find_project_conf(starting_directory: &str) -> Option<String> {
     }
 }
 
+pub fn get_current_project() -> Option<ProjectConfig> {
+    find_project_conf(".").and_then(|s| {
+        log::info!("Found project configuration file at {}", s);
+        parse_config(&s).ok()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/render.rs
+++ b/lib/src/render.rs
@@ -293,6 +293,7 @@ impl Renderable for PingResponse {
 impl Renderable for ProjectThresholds {
     fn render(&self) -> String {
         let mut t = table!(
+            [r => "Thresholds:"],
             [r => "Project Score:", self.total],
             [r => "Malicious Code Risk MAL:", self.malicious],
             [r => "Vulnerability Risk VLN:", self.vulnerability],
@@ -305,8 +306,8 @@ impl Renderable for ProjectThresholds {
     }
 }
 
-impl From<RiskLevel> for color::Color {
-    fn from(level: RiskLevel) -> Self {
+impl From<&RiskLevel> for color::Color {
+    fn from(level: &RiskLevel) -> Self {
         match level {
             RiskLevel::Crit => color::BRIGHT_RED,
             RiskLevel::High => color::YELLOW,
@@ -317,29 +318,24 @@ impl From<RiskLevel> for color::Color {
     }
 }
 
-impl From<Issue> for Vec<Row> {
-    fn from(issue: Issue) -> Vec<Row> {
+impl From<&Issue> for Vec<Row> {
+    fn from(issue: &Issue) -> Vec<Row> {
         let r1 = Row::new(vec![
             Cell::new_align(&issue.risk_level.to_string(), format::Alignment::LEFT)
-                .with_style(Attr::ForegroundColor(color::Color::from(issue.risk_level))),
-            Cell::new_align(&issue.name, format::Alignment::LEFT).with_style(Attr::Bold),
+                .with_style(Attr::ForegroundColor(color::Color::from(&issue.risk_level))),
             Cell::new_align(
-                &format!(
-                    "{:>47}@{} {}\n",
-                    issue.pkg_name,
-                    issue.pkg_version,
-                    issue.risk_domain.to_string(),
-                ),
-                format::Alignment::RIGHT,
-            ),
+                &format!("{} [{}]", &issue.title, issue.risk_domain.to_string()),
+                format::Alignment::LEFT,
+            )
+            .with_style(Attr::Bold),
         ]);
 
         let r2 = Row::new(vec![
             Cell::new(""),
-            Cell::new(&issue.description),
+            Cell::new(&textwrap::fill(&issue.description, 80)),
             Cell::new(""),
         ]);
 
-        vec![r1, r2]
+        vec![r1, row![], r2]
     }
 }

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -35,6 +35,14 @@ pub struct ProjectThresholds {
     pub vulnerability: f32,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    None,
+    Warn,
+    Break,
+}
+
 impl FromStr for PackageType {
     type Err = ();
 
@@ -454,6 +462,7 @@ pub struct PackageStatusExtended {
     pub dependencies: Vec<PackageDescriptor>,
     pub vulnerabilities: Vec<Vulnerability>,
     pub heuristics: HashMap<String, HeuristicResult>,
+    pub issues: Vec<Issue>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -499,12 +508,12 @@ impl fmt::Display for RiskDomain {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Issue {
-    pub name: String,
+    pub title: String,
+    pub description: String,
     pub risk_level: RiskLevel,
     pub risk_domain: RiskDomain,
-    pub description: String,
     pub pkg_name: String,
     pub pkg_version: String,
     pub score: f64,
@@ -521,6 +530,7 @@ pub struct Vulnerability {
     pub cve: Vec<String>,
     pub base_severity: f32,
     pub risk_level: RiskLevel,
+    pub title: String,
     pub description: String,
     pub remediation: String,
 }
@@ -534,6 +544,9 @@ pub struct RequestStatusResponse<T> {
     pub created_at: i64, // epoch seconds
     pub status: Status,
     pub score: f64,
+    pub pass: bool,
+    pub msg: String,
+    pub action: Action,
     #[serde(default)]
     pub num_incomplete: u32,
     pub last_updated: u64,


### PR DESCRIPTION
* Take appropriate action when a threshold is not met (warn, break the build, or do nothing)
* Use the templated issues set up for heuristics when displaying verbose output (formatted and json)
* Clean up text formatting for issues and vulnerabilities
* Add the ability to run `phylum history current` to see results for the most recent job in the current project