### PR TITLE
Support updating for macOS builds.

### DIFF
--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -912,7 +912,17 @@ fn update_in_place(latest: GithubRelease) -> Result<String, std::io::Error> {
     // The data comes back to us as a JSON response of assets. We do not need
     // every asset. We need the updated binary and the bash file. This simply
     // loops over this data to find the download URLs for each pertinent asset.
-    let bin_asset = &latest.assets.iter().find(|x| x.name == "phylum").unwrap();
+    let bin_asset_name = if cfg!(target_os = "macos") {
+        "phylum-macos-x86_64"
+    } else {
+        "phylum-linux-x86_64"
+    };
+
+    let bin_asset = &latest
+        .assets
+        .iter()
+        .find(|x| x.name == bin_asset_name)
+        .unwrap();
 
     let bash_asset = &latest
         .assets


### PR DESCRIPTION
We previously only supported Linux builds. We now have a PR out for
building the macOS distribution as well. This means that we need to also
support updates for macOS.

This adds a compile time check for the various operating systems we
support to ensure we are pulling the correct binary.

This depends on #74 and closes #75.