### PR TITLE
Fix update issue for tmpfs

### DIFF
--- a/lib/src/bin/phylum-cli.rs
+++ b/lib/src/bin/phylum-cli.rs
@@ -1070,7 +1070,10 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches("auth") {
         handle_auth(&mut api, &mut config, config_path, matches, app_helper);
     } else if matches.subcommand_matches("update").is_some() {
-        let sp = Spinner::new(Spinners::Dots12, "Downloading update...".into());
+        let sp = Spinner::new(
+            Spinners::Dots12,
+            "Downloading update and verifying binary signatures...".into(),
+        );
         let updater = ApplicationUpdater::default();
         match updater.get_latest_version() {
             Some(ver) => match updater.do_update(ver) {


### PR DESCRIPTION
There was an issue moving update files after they had been downloaded
and the signatures had been verified on tmpfs. Update files would be
downloaded and temporarily stored in `/tmp` which existed on tmpfs. Any
attempts to *move* the files to the disk (a separate file system) would
trigger a panic due to crossing boundaries.

This update changes to a *copy* and remove operation from the temporary file
location.

Also added an additional signature verification that occurs after the
files have been moved to the final install location. This is to address
a possible race condition where an attacker may change the file in
`tmp/` after the signature verification has occurred, but before we have
copied the file to the final location.

closes #90 