### PR TITLE
Use proper name during update

### DIFF
--- a/lib/src/update.rs
+++ b/lib/src/update.rs
@@ -182,7 +182,7 @@ impl ApplicationUpdater {
 
         // Find location of assets on disk
         debug!("Locating the installed paths for the update");
-        let installed_bin_path = self.installed_asset(bin_asset_name)?;
+        let installed_bin_path = self.installed_asset("phylum")?;
         let installed_bash_path = self.installed_asset("phylum.bash")?;
 
         // Get the URL for each asset from the Github JSON response in `latest`.


### PR DESCRIPTION
Previously, when an update occurred we were moving the binary to the
final install location after verifying the signatures. We changed this
to a move in a recent change to ensure that we could avoid crossing
filesystem boundaries in the event a user was using tmpfs or similar.

The name in the copy ended up being the binary asset name, which took on
the form of `phylum-<os>-<arch>`. However. the installer (and the user)
expects this to be `phylum`. This change simply ensures that we use the
`phylum` name for binaries after update/install.