### PR TITLE
Fix deserialization bug and confusing shorthands

### DIFF
--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -32,7 +32,7 @@ subcommands:
                 required: false
                 about: The job id to query (or `current` for the most recent job)
             - verbose:
-                short: V 
+                short: v 
                 long: verbose
                 about: Increase verbosity of api response.
                 takes_value: false
@@ -168,7 +168,7 @@ subcommands:
                 takes_value: true
                 required: false
             - verbose:
-                short: V 
+                short: v
                 long: verbose
                 about: Increase verbosity of api response.
                 takes_value: false

--- a/lib/src/bin/_phylum
+++ b/lib/src/bin/_phylum
@@ -218,7 +218,7 @@ _arguments "${_arguments_options[@]}" \
 (analyze)
 _arguments "${_arguments_options[@]}" \
 '-l+[]' \
-'-V[Increase verbosity of api response.]' \
+'-v[Increase verbosity of api response.]' \
 '--verbose[Increase verbosity of api response.]' \
 '-j[Produce output in json format (default: false)]' \
 '--json[Produce output in json format (default: false)]' \

--- a/lib/src/bin/phylum.bash
+++ b/lib/src/bin/phylum.bash
@@ -112,7 +112,7 @@ _phylum() {
             ;;
         
         phylum__analyze)
-            opts=" -l -V -j -F -h -V  --verbose --json --help --version  <LOCKFILE> "
+            opts=" -l -v -j -F -h -V  --verbose --json --help --version  <LOCKFILE> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/lib/src/bin/phylum.fish
+++ b/lib/src/bin/phylum.fish
@@ -68,7 +68,7 @@ complete -c phylum -n "__fish_seen_subcommand_from ping" -s h -l help -d 'Print 
 complete -c phylum -n "__fish_seen_subcommand_from ping" -s V -l version -d 'Print version information'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s l -r
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -d 'The package lock file to submit.'
-complete -c phylum -n "__fish_seen_subcommand_from analyze" -s V -l verbose -d 'Increase verbosity of api response.'
+complete -c phylum -n "__fish_seen_subcommand_from analyze" -s v -l verbose -d 'Increase verbosity of api response.'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s j -l json -d 'Produce output in json format (default: false)'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s F -d 'Force re-processing of packages (even if they already exist in the system)'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s h -l help -d 'Print help information'

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -530,7 +530,6 @@ pub struct Issue {
 }
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HeuristicResult {
-    pub description: String,
     pub domain: RiskDomain,
     pub score: f64,
     pub risk_level: RiskLevel,


### PR DESCRIPTION
We recently changed how the descriptions were being handled. This caused a deserialization failure when verbosity was specified.

Additionally, removed the confusing `-V` flag for verbosity that conflicted with the default clap `-V` flag for version. Made the lowercase v (i.e. `-v`) the shorthand for verbosity to avoid confusion.