### PR TITLE
Add support for filtering issues based on severity / domain

### DIFF
--- a/lib/src/bin/.conf/cli.yaml
+++ b/lib/src/bin/.conf/cli.yaml
@@ -37,6 +37,26 @@ subcommands:
                 about: Increase verbosity of api response.
                 takes_value: false
                 required: false
+            - filter:
+                long: filter
+                about: "Provide a filter used to limit the issues displayed
+
+
+                        EXAMPLES
+
+                            # Show only issues with severity of at least 'high'
+
+                            \t--filter=high
+
+
+                            # Show issues with severity of 'critical' in the 'author'
+                            and 'engineering' domains
+
+                        \t--filter=crit,aut,eng
+
+                        "
+                takes_value: true
+                required: false
             - json:
                 short: j
                 long: json
@@ -177,6 +197,26 @@ subcommands:
                 short: j
                 long: json
                 about: "Produce output in json format (default: false)"
+            - filter:
+                long: filter
+                about: "Provide a filter used to limit the issues displayed
+
+
+                        EXAMPLES
+
+                            # Show only issues with severity of at least 'high'
+
+                            \t--filter=high
+
+
+                            # Show issues with severity of 'critical' in the 'author'
+                            and 'engineering' domains
+
+                        \t--filter=crit,aut,eng
+
+                        "
+                takes_value: true
+                required: false
             - force:
                 short: F
                 about: Force re-processing of packages (even if they already exist in the system)

--- a/lib/src/bin/_phylum
+++ b/lib/src/bin/_phylum
@@ -44,6 +44,15 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (history)
 _arguments "${_arguments_options[@]}" \
+'--filter=[Provide a filter used to limit the issues displayed
+
+EXAMPLES
+# Show only issues with severity of at least '\''high'\''
+	--filter=high
+
+# Show issues with severity of '\''critical'\'' in the '\''author'\'' and '\''engineering'\'' domains
+	--filter=crit,aut,eng
+]' \
 '-v[Increase verbosity of api response.]' \
 '--verbose[Increase verbosity of api response.]' \
 '-j[Produce output in json format (default: false)]' \
@@ -218,6 +227,15 @@ _arguments "${_arguments_options[@]}" \
 (analyze)
 _arguments "${_arguments_options[@]}" \
 '-l+[]' \
+'--filter=[Provide a filter used to limit the issues displayed
+
+EXAMPLES
+# Show only issues with severity of at least '\''high'\''
+	--filter=high
+
+# Show issues with severity of '\''critical'\'' in the '\''author'\'' and '\''engineering'\'' domains
+	--filter=crit,aut,eng
+]' \
 '-v[Increase verbosity of api response.]' \
 '--verbose[Increase verbosity of api response.]' \
 '-j[Produce output in json format (default: false)]' \

--- a/lib/src/bin/phylum-cli/commands/auth.rs
+++ b/lib/src/bin/phylum-cli/commands/auth.rs
@@ -169,7 +169,7 @@ fn handle_auth_keys(
 
         let res = Ok(keys);
         println!("{:-^65}", "");
-        print_response(&res, true);
+        print_response(&res, true, None);
         println!();
     }
 }

--- a/lib/src/bin/phylum-cli/commands/packages.rs
+++ b/lib/src/bin/phylum-cli/commands/packages.rs
@@ -51,7 +51,7 @@ pub fn handle_get_package(
             Blue.paint("phylum analyze <lock_file>")
         );
     } else {
-        print_response(&resp, pretty_print);
+        print_response(&resp, pretty_print, None);
     }
 
     0

--- a/lib/src/bin/phylum-cli/commands/projects.rs
+++ b/lib/src/bin/phylum-cli/commands/projects.rs
@@ -19,7 +19,7 @@ pub fn get_project_list(api: &mut PhylumApi, pretty_print: bool) {
     let proj_title = format!("{}", Blue.paint("Project Name"));
     let id_title = format!("{}", Blue.paint("Project ID"));
     println!("{:<38}{}", proj_title, id_title);
-    print_response(&resp, pretty_print);
+    print_response(&resp, pretty_print, None);
     println!();
 }
 

--- a/lib/src/bin/phylum-cli/main.rs
+++ b/lib/src/bin/phylum-cli/main.rs
@@ -130,7 +130,7 @@ fn main() {
 
     if matches.subcommand_matches("ping").is_some() {
         let resp = api.ping();
-        print_response(&resp, true);
+        print_response(&resp, true, None);
         exit_ok(None::<&str>);
     }
 
@@ -203,7 +203,7 @@ fn main() {
             let request_id = JobId::from_str(&request_id)
                 .unwrap_or_else(|err| exit_error(err, Some("Received invalid request id. Request id's should be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")));
             let resp = api.cancel(&request_id);
-            print_response(&resp, true);
+            print_response(&resp, true, None);
         }
     }
 

--- a/lib/src/bin/phylum-cli/print.rs
+++ b/lib/src/bin/phylum-cli/print.rs
@@ -5,6 +5,7 @@ use ansi_term::Color::{Blue, Cyan};
 use clap::App;
 use serde::Serialize;
 
+use phylum_cli::filter::Filter;
 use phylum_cli::summarize::Summarize;
 
 #[macro_export]
@@ -31,8 +32,11 @@ macro_rules! print_user_failure {
     }
 }
 
-pub fn print_response<T>(resp: &Result<T, phylum_cli::Error>, pretty_print: bool)
-where
+pub fn print_response<T>(
+    resp: &Result<T, phylum_cli::Error>,
+    pretty_print: bool,
+    filter: Option<Filter>,
+) where
     T: std::fmt::Debug + Serialize + Summarize,
 {
     log::debug!("==> {:?}", resp);
@@ -40,7 +44,7 @@ where
     match resp {
         Ok(resp) => {
             if pretty_print {
-                resp.summarize();
+                resp.summarize(filter);
             } else {
                 // Use write! as a workaround to avoid https://github.com/rust-lang/rust/issues/46016
                 //  when piping output to an external program

--- a/lib/src/bin/phylum.bash
+++ b/lib/src/bin/phylum.bash
@@ -112,7 +112,7 @@ _phylum() {
             ;;
         
         phylum__analyze)
-            opts=" -l -v -j -F -h -V  --verbose --json --help --version  <LOCKFILE> "
+            opts=" -l -v -j -F -h -V  --verbose --json --filter --help --version  <LOCKFILE> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -120,6 +120,10 @@ _phylum() {
             case "${prev}" in
                 
                 -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --filter)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -293,13 +297,17 @@ _phylum() {
             return 0
             ;;
         phylum__history)
-            opts=" -v -j -h -V  --verbose --json --help --version  <JOB_ID> project"
+            opts=" -v -j -h -V  --verbose --filter --json --help --version  <JOB_ID> project"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
+                --filter)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/lib/src/bin/phylum.fish
+++ b/lib/src/bin/phylum.fish
@@ -15,6 +15,15 @@ complete -c phylum -n "__fish_use_subcommand" -f -a "help" -d 'Print this messag
 complete -c phylum -n "__fish_seen_subcommand_from update" -s p -l prerelease -d 'Update to the latest prerelease (vs. stable, default: false)'
 complete -c phylum -n "__fish_seen_subcommand_from update" -s h -l help -d 'Print help information'
 complete -c phylum -n "__fish_seen_subcommand_from update" -s V -l version -d 'Print version information'
+complete -c phylum -n "__fish_seen_subcommand_from history" -l filter -d 'Provide a filter used to limit the issues displayed
+
+EXAMPLES
+# Show only issues with severity of at least \'high\'
+	--filter=high
+
+# Show issues with severity of \'critical\' in the \'author\' and \'engineering\' domains
+	--filter=crit,aut,eng
+' -r
 complete -c phylum -n "__fish_seen_subcommand_from history" -d 'The job id to query (or `current` for the most recent job)'
 complete -c phylum -n "__fish_seen_subcommand_from history" -s v -l verbose -d 'Increase verbosity of api response.'
 complete -c phylum -n "__fish_seen_subcommand_from history" -s j -l json -d 'Produce output in json format (default: false)'
@@ -67,6 +76,15 @@ complete -c phylum -n "__fish_seen_subcommand_from status" -l version -d 'Print 
 complete -c phylum -n "__fish_seen_subcommand_from ping" -s h -l help -d 'Print help information'
 complete -c phylum -n "__fish_seen_subcommand_from ping" -s V -l version -d 'Print version information'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s l -r
+complete -c phylum -n "__fish_seen_subcommand_from analyze" -l filter -d 'Provide a filter used to limit the issues displayed
+
+EXAMPLES
+# Show only issues with severity of at least \'high\'
+	--filter=high
+
+# Show issues with severity of \'critical\' in the \'author\' and \'engineering\' domains
+	--filter=crit,aut,eng
+' -r
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -d 'The package lock file to submit.'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s v -l verbose -d 'Increase verbosity of api response.'
 complete -c phylum -n "__fish_seen_subcommand_from analyze" -s j -l json -d 'Produce output in json format (default: false)'

--- a/lib/src/filter.rs
+++ b/lib/src/filter.rs
@@ -1,0 +1,118 @@
+use std::collections::HashSet;
+use std::iter::FromIterator;
+use std::str::FromStr;
+
+use crate::types::{RiskDomain, RiskLevel};
+
+pub struct Filter {
+    pub level: Option<RiskLevel>,
+    pub domains: Option<Vec<RiskDomain>>,
+}
+
+impl FromStr for Filter {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut tokens = input.split(',').collect::<Vec<&str>>();
+
+        tokens.sort_unstable();
+        tokens.dedup();
+
+        let level = tokens
+            .iter()
+            .filter_map(|t| match *t {
+                "crit" => Some(RiskLevel::Crit),
+                "critical" => Some(RiskLevel::Crit),
+                "high" => Some(RiskLevel::High),
+                "hi" => Some(RiskLevel::High),
+                "med" => Some(RiskLevel::Med),
+                "medium" => Some(RiskLevel::Med),
+                "info" => Some(RiskLevel::Info),
+                "low" => Some(RiskLevel::Low),
+                "lo" => Some(RiskLevel::Low),
+                _ => None,
+            })
+            .min();
+
+        let domains = tokens
+            .iter()
+            .filter_map(|t| match *t {
+                "AUT" => Some(RiskDomain::AuthorRisk),
+                "auth" => Some(RiskDomain::AuthorRisk),
+                "author" => Some(RiskDomain::AuthorRisk),
+                "eng" => Some(RiskDomain::EngineeringRisk),
+                "ENG" => Some(RiskDomain::EngineeringRisk),
+                "engineering" => Some(RiskDomain::EngineeringRisk),
+                "code" => Some(RiskDomain::MaliciousCode),
+                "malicious_code" => Some(RiskDomain::MaliciousCode),
+                "MAL" => Some(RiskDomain::MaliciousCode),
+                "vuln" => Some(RiskDomain::Vulnerabilities),
+                "vulnerability" => Some(RiskDomain::Vulnerabilities),
+                "VLN" => Some(RiskDomain::Vulnerabilities),
+                "license" => Some(RiskDomain::LicenseRisk),
+                "LIC" => Some(RiskDomain::LicenseRisk),
+                _ => None,
+            })
+            .collect::<HashSet<RiskDomain>>();
+
+        let domains = if domains.is_empty() {
+            None
+        } else {
+            Some(Vec::from_iter(domains))
+        };
+
+        if level.is_none() && domains.is_none() {
+            Err(())
+        } else {
+            Ok(Filter { level, domains })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_parse_filter_levels() {
+        let filter_string = "crit,author,med,engineering";
+
+        let filter = Filter::from_str(filter_string).expect("Failed to parse filter string: {}");
+
+        assert_eq!(filter.level, Some(RiskLevel::Med));
+
+        let filter_string = "foo,crit,author,engineering";
+
+        let filter = Filter::from_str(filter_string).expect("Failed to parse filter string: {}");
+
+        assert_eq!(filter.level, Some(RiskLevel::Crit));
+    }
+
+    #[test]
+    fn it_can_parse_filter_domains() {
+        let filter_string = "crit,author,med,engineering";
+
+        let filter = Filter::from_str(filter_string).expect("Failed to parse filter string: {}");
+
+        let domains = filter
+            .domains
+            .expect("No risk domains parsed from filter string");
+
+        assert_eq!(domains.len(), 2);
+        assert!(domains.contains(&RiskDomain::AuthorRisk));
+        assert!(domains.contains(&RiskDomain::EngineeringRisk));
+
+        let filter_string = "crit,author,AUT,med,ENG,foo,engineering,VLN";
+
+        let filter = Filter::from_str(filter_string).expect("Failed to parse filter string: {}");
+
+        let domains = filter
+            .domains
+            .expect("No risk domains parsed from filter string");
+
+        assert_eq!(domains.len(), 3);
+        assert!(domains.contains(&RiskDomain::AuthorRisk));
+        assert!(domains.contains(&RiskDomain::EngineeringRisk));
+        assert!(domains.contains(&RiskDomain::Vulnerabilities));
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod config;
+pub mod filter;
 pub mod lockfiles;
 pub mod render;
 pub mod restson;

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -477,18 +477,18 @@ pub struct PackageStatusExtended {
     pub issues: Vec<Issue>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub enum RiskLevel {
-    #[serde(rename = "critical")]
-    Crit,
-    #[serde(rename = "high")]
-    High,
-    #[serde(rename = "medium")]
-    Med,
-    #[serde(rename = "low")]
-    Low,
     #[serde(rename = "info")]
     Info,
+    #[serde(rename = "low")]
+    Low,
+    #[serde(rename = "medium")]
+    Med,
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "critical")]
+    Crit,
 }
 
 impl fmt::Display for RiskLevel {
@@ -498,7 +498,7 @@ impl fmt::Display for RiskLevel {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum RiskDomain {
     MaliciousCode,
     Vulnerabilities,
@@ -520,7 +520,7 @@ impl fmt::Display for RiskDomain {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Issue {
     pub title: String,
     pub description: String,
@@ -584,4 +584,20 @@ pub struct GithubRelease {
 pub struct GithubReleaseAsset {
     pub browser_download_url: String,
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_risk_level_ordering() {
+        assert!(
+            RiskLevel::Info < RiskLevel::Low
+                && RiskLevel::Low < RiskLevel::Med
+                && RiskLevel::Med < RiskLevel::High
+                && RiskLevel::High < RiskLevel::Crit,
+            "Ordering of risk levels is invalid"
+        );
+    }
 }


### PR DESCRIPTION
Adds support for basic filtering of the issues displayed based on the severity and the risk domain of each issue.  For example, providing the option

    `--filter=high,auth,engineering`

to either the `phylum analyze` or `phylum history` subcommands will filter the displayed issues to include only those at risk level "high" or higher and that are included in the "Author" or "Engineering" risk domains.