### PR TITLE
Adjust bucket_id creation

### DIFF
--- a/lib/src/summarize.rs
+++ b/lib/src/summarize.rs
@@ -23,13 +23,14 @@ impl Histogram {
         let mut values: Vec<usize> = vec![0; bins];
 
         let step = (max - min) / bins as f64;
+        let scale = 100.0;
 
         for &y in data.iter() {
             if y < min || y > max {
                 continue;
             }
 
-            let mut bucket_id = ((y - min) / step).round() as usize;
+            let mut bucket_id = ((y * scale).floor() / (step * scale)) as usize;
 
             // Account for packages with a "perfect" (i.e. 1.0) score
             // This is generally unlikely but possible with packages that have


### PR DESCRIPTION
Adjusted bucket id creation due to have certain scores still appearing in wrong buckets.