### PR TITLE
Add a config file option for ignoring cert check

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub request_type: PackageType,
     pub packages: Option<Packages>,
     pub last_update: Option<usize>,
+    pub ignore_certs: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -145,6 +146,7 @@ mod tests {
             request_type: PackageType::Npm,
             packages: Some(packages),
             last_update: None,
+            ignore_certs: None,
         };
         let temp_dir = temp_dir();
         let test_config_file = temp_dir.as_path().join("test_config");

--- a/lib/src/restson.rs
+++ b/lib/src/restson.rs
@@ -281,7 +281,6 @@ impl RestClient {
             Some(client) => client,
             None => {
                 if builder.ignore_certs {
-                    log::warn!("Not validating server certificate per user request.");
                     Client::builder().build(HttpsConnector::without_cert_validation())
                 } else {
                     Client::builder().build(HttpsConnector::with_native_roots())


### PR DESCRIPTION
Adds a new top-level option `ignore_certs` to the configuration file that introduces a persistent setting for ignoring certificate verification.

Logs a warning to the console on `stderr` whenever this option is set.

@furi0us333 I'll cut a new RC as soon as this is merged.

closes #135 