### PR TITLE
Update sha2 crate due to RUSTSEC-2021-0100

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "^1.0"
 serde_yaml = "0.8.14"
-sha2 = "0.9.8"
+sha2 = "0.9.9"
 shellexpand = "2.0.0"
 spinners = "1.2.0"
 textwrap = "0.13.4"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0100.html

Says 0.9.8 isn't affected but 0.9.8 has been yanked, so bumped up the version.