### PR TITLE
Allow for manually running GitHub workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 # Modified Release github action. Replace the current with this when ready.
+---
 name: Release New
 
 on:
   push:
     tags:
-      - '*' 
+      - '*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   release:
@@ -22,7 +26,7 @@ jobs:
         run: cargo xtask dist
       - name: Sign files
         run: |
-          echo -e $MINISIGN_KEY > minisign.key 
+          echo -e $MINISIGN_KEY > minisign.key
           echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-linux-x86_64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
           echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-x86_64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
           echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-aarch64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
@@ -32,16 +36,16 @@ jobs:
       - name: Build zipfiles
         working-directory: ./target/dist
         run: |
-          zip -r phylum-linux-x86_64 phylum-linux-x86_64 
-          zip -r phylum-macos-x86_64 phylum-macos-x86_64 
-          zip -r phylum-macos-aarch64 phylum-macos-aarch64 
+          zip -r phylum-linux-x86_64 phylum-linux-x86_64
+          zip -r phylum-macos-x86_64 phylum-macos-x86_64
+          zip -r phylum-macos-aarch64 phylum-macos-aarch64
       - name: Determine prerelease status
         uses: haya14busa/action-cond@v1
         id: preRelease
         with:
           cond: ${{ contains(github.ref, 'rc') }}
           if_true: 'true'  # string value
-          if_false: 'false' # string value
+          if_false: 'false'  # string value
       - uses: softprops/action-gh-release@v0.1.7
         name: Release
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -7,13 +8,16 @@ on:
       - master
       - development
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - run: |
           sudo apt update
-          sudo apt install -yq build-essential 
+          sudo apt install -yq build-essential
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -35,4 +39,3 @@ jobs:
         with:
           command: test
           args: --lib --manifest-path Cargo.toml
-


### PR DESCRIPTION
# Overview
The `cli` repo is not currently able to build release artifacts locally. This makes it hard to test changes and iterate locally. Further, the ability to manually run GitHub workflows was not enabled for this repository. This PR changes that, making it possible to manually run all the workflows for this repository, for any branch. There was also some light formatting changes...to fix most of what `yamllint` found (line length is the main exception).

# Checklist
- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
  * Partial...can't be confirmed until the changes here make it into the `development` branch
- [ ] ~Have you created sufficient tests?~

# Issue
closes #183
