### PR TITLE
Fix release workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
 # Overview
+
 Provide information on what this PR does and any context necessary to understand its implementation.
 
-# Checklist
+## Checklist
+
 - [ ] Does this PR have an associated issue?
 - [ ] Have you ensured that you have met the expected acceptance criteria?
 - [ ] Have you created sufficient tests?
 - [ ] Have you updated all affected documentation?
 
-# Issue
-What issue(s) does this PR close. Use the `closes #<issueNum>` here.
+## Issue
+
+What issue(s) does this PR close? Use the `closes #<issueNum>` here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Provide information on what this PR does and any context necessary to understand
 - [ ] Does this PR have an associated issue?
 - [ ] Have you ensured that you have met the expected acceptance criteria?
 - [ ] Have you created sufficient tests?
+- [ ] Have you updated all affected documentation?
 
 # Issue
 What issue(s) does this PR close. Use the `closes #<issueNum>` here.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - master
       - development
+    tags:
+      - '*'
 
 jobs:
   Build-Release-Artifacts:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,18 +73,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: release-archives
-      # TODO: see if it is possible to replace this action with an inline expression
-      - name: Determine prerelease status
-        uses: haya14busa/action-cond@v1
-        id: preRelease
-        with:
-          cond: ${{ contains(github.ref, 'rc') }}
-          if_true: 'true'  # string value
-          if_false: 'false'  # string value
-      - name: Release
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v0.1.14
         with:
-          prerelease: ${{ steps.preRelease.outputs.value }}
+          # This check is already filtered down to only 'refs/tags/' and shouldn't "overmatch"
+          prerelease: ${{ contains(github.ref, 'rc') }}
           fail_on_unmatched_files: true
           token: ${{ secrets.GITHUB_TOKEN }}
           files: phylum-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,28 +3,31 @@
 name: Release New
 
 on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
   push:
     tags:
       - '*'
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Install host dependencies
+        run: |
           sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
           sudo apt update
           sudo apt install -yq build-essential zip minisign
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout the repo
+        uses: actions/checkout@master
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Build Linux
+      - name: Build Distributions
         run: cargo xtask dist
-      - name: Sign files
+      # TODO: determine if it makes more sense to sign the entire zipfile or just the binaries w/i the zipfiles
+      - name: Sign binaries
         run: |
           echo -e $MINISIGN_KEY > minisign.key
           echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-linux-x86_64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
@@ -36,9 +39,9 @@ jobs:
       - name: Build zipfiles
         working-directory: ./target/dist
         run: |
-          zip -r phylum-linux-x86_64 phylum-linux-x86_64
-          zip -r phylum-macos-x86_64 phylum-macos-x86_64
-          zip -r phylum-macos-aarch64 phylum-macos-aarch64
+          zip -r phylum-linux-x86_64.zip phylum-linux-x86_64
+          zip -r phylum-macos-x86_64.zip phylum-macos-x86_64
+          zip -r phylum-macos-aarch64.zip phylum-macos-aarch64
       - name: Determine prerelease status
         uses: haya14busa/action-cond@v1
         id: preRelease
@@ -46,16 +49,10 @@ jobs:
           cond: ${{ contains(github.ref, 'rc') }}
           if_true: 'true'  # string value
           if_false: 'false'  # string value
-      - uses: softprops/action-gh-release@v0.1.7
-        name: Release
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
         with:
           prerelease: ${{ steps.preRelease.outputs.value }}
-          files: |
-            phylum-linux-x86_64.zip
-            phylum-macos-x86_64.zip
-            phylum-macos-aarch64.zip
-            phylum-linux-x86_64.minisig
-            phylum-macos-x86_64.minisig
-            phylum-macos-aarch64.minisig
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_unmatched_files: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./target/dist/phylum-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 name: Release
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Allow running this workflow manually from the Actions tab
   workflow_dispatch:
   pull_request:
   push:
@@ -24,15 +24,19 @@ jobs:
           sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
           sudo apt update
           sudo apt install -yq build-essential zip minisign
+
       - name: Checkout the repo
         uses: actions/checkout@master
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+
       # TODO: determine if it is possible to break out the build into multiple targets, to enable parallel job execution
       - name: Build Distributions
         run: cargo xtask dist
+
       - name: Sign binaries
         run: |
           echo -e $MINISIGN_KEY > minisign.key
@@ -42,12 +46,14 @@ jobs:
         env:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
           MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+
       - name: Build zipfiles
         working-directory: ./target/dist
         run: |
           zip -r phylum-linux-x86_64.zip phylum-linux-x86_64
           zip -r phylum-macos-x86_64.zip phylum-macos-x86_64
           zip -r phylum-macos-aarch64.zip phylum-macos-aarch64
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -67,6 +73,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: release-archives
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v0.1.14
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,7 @@ jobs:
           toolchain: stable
       # TODO: determine if it is possible to break out the build into multiple targets, to enable parallel job execution
       - name: Build Distributions
-        # TODO: re-enable the 'real' step
-        # run: cargo xtask dist
-        run: |
-          mkdir -p target/dist/{phylum-linux-x86_64,phylum-macos-x86_64,phylum-macos-aarch64}
-          echo test > target/dist/phylum-linux-x86_64/phylum
-          echo test > target/dist/phylum-macos-x86_64/phylum
-          echo test > target/dist/phylum-macos-aarch64/phylum
+        run: cargo xtask dist
       - name: Sign binaries
         run: |
           echo -e $MINISIGN_KEY > minisign.key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,20 @@
-# Modified Release github action. Replace the current with this when ready.
+# This is the workflow for building release artifacts.
+# Optionally, creating a release with those artifacts is possible by pushing a tag.
 ---
-name: Release New
+name: Release
 
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  pull_request:
   push:
-    tags:
-      - '*'
+    branches:
+      - master
+      - development
 
 jobs:
-  release:
+  Build-Release-Artifacts:
+    name: Build the release artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Install host dependencies
@@ -24,15 +28,21 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      # TODO: determine if it is possible to break out the build into multiple targets, to enable parallel job execution
       - name: Build Distributions
-        run: cargo xtask dist
-      # TODO: determine if it makes more sense to sign the entire zipfile or just the binaries w/i the zipfiles
+        # TODO: re-enable the 'real' step
+        # run: cargo xtask dist
+        run: |
+          mkdir -p target/dist/{phylum-linux-x86_64,phylum-macos-x86_64,phylum-macos-aarch64}
+          echo test > target/dist/phylum-linux-x86_64/phylum
+          echo test > target/dist/phylum-macos-x86_64/phylum
+          echo test > target/dist/phylum-macos-aarch64/phylum
       - name: Sign binaries
         run: |
           echo -e $MINISIGN_KEY > minisign.key
-          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-linux-x86_64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
-          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-x86_64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
-          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-aarch64/phylum -s minisign.key -t 'Phylum - Future of software supply chain security'
+          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-linux-x86_64/phylum -s minisign.key -t 'Phylum - the future of software supply chain security'
+          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-x86_64/phylum -s minisign.key -t 'Phylum - the future of software supply chain security'
+          echo $MINISIGN_PASSWORD | minisign -Sm target/dist/phylum-macos-aarch64/phylum -s minisign.key -t 'Phylum - the future of software supply chain security'
         env:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
           MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
@@ -42,6 +52,26 @@ jobs:
           zip -r phylum-linux-x86_64.zip phylum-linux-x86_64
           zip -r phylum-macos-x86_64.zip phylum-macos-x86_64
           zip -r phylum-macos-aarch64.zip phylum-macos-aarch64
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-archives
+          path: ./target/dist/phylum-*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  Release:
+    name: Create release from tag
+    needs: Build-Release-Artifacts
+    # Only run this job when pushing a tag
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: release-archives
+      # TODO: see if it is possible to replace this action with an inline expression
       - name: Determine prerelease status
         uses: haya14busa/action-cond@v1
         id: preRelease
@@ -55,4 +85,4 @@ jobs:
           prerelease: ${{ steps.preRelease.outputs.value }}
           fail_on_unmatched_files: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: ./target/dist/phylum-*.zip
+          files: phylum-*.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,40 +2,42 @@
 name: Test
 
 on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
   pull_request:
   push:
     branches:
       - master
       - development
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Install host dependencies
+        run: |
           sudo apt update
           sudo apt install -yq build-essential
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout the repo
+        uses: actions/checkout@master
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - name: Build
         run: cargo build --release
-      - uses: actions-rs/cargo@v1
-        name: Format check
+      - name: Format check
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --manifest-path cli/Cargo.toml -- --check
-      - uses: actions-rs/cargo@v1
-        name: Lint
+      - name: Lint
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --manifest-path Cargo.toml --all-features --all --tests --examples -- -D clippy::all -D warnings
-      - uses: actions-rs/cargo@v1
-        name: Test
+      - name: Test
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --lib --manifest-path Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,24 +18,30 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -yq build-essential
+
       - name: Checkout the repo
         uses: actions/checkout@master
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+
       - name: Build
         run: cargo build --release
+
       - name: Format check
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --manifest-path cli/Cargo.toml -- --check
+
       - name: Lint
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --manifest-path Cargo.toml --all-features --all --tests --examples -- -D clippy::all -D warnings
+
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/README.md
+++ b/README.md
@@ -19,32 +19,47 @@ The command line interface (CLI) allows users to submit their project package de
 
 ## Quickstart for Linux or macOS
 
-1. Download and unzip the latest [release package](https://github.com/phylum-dev/cli/releases/latest/download/phylum-cli-release.zip)
-2. Run the installer script
+1. Download and unzip the latest release package for your target:
+
+   | Target | Package |
+   | --- | --- |
+   | x86_64-unknown-linux-musl | [phylum-linux-x86_64.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-linux-x86_64.zip) |
+   | x86_64-apple-darwin | [phylum-macos-x86_64.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-macos-x86_64.zip) |
+   | aarch64-apple-darwin | [phylum-macos-aarch64.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-macos-aarch64.zip) |
+
+2. Confirm the signature of the `phylum` binary located within the archive with [minisign](https://jedisct1.github.io/minisign/) and the public key for Phylum
+
+   ```sh
+   $ minisign -Vm phylum -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
+   Signature and comment signature verified
+   Trusted comment: Phylum - the future of software supply chain security
+   ```
+
+3. Run the installer script
 
    ```sh
    ./install.sh
    ```
 
-3. [Register](https://docs.phylum.io/docs/authentication) for an account (if you don't already have one)
+4. [Register](https://docs.phylum.io/docs/authentication) for an account (if you don't already have one)
 
    ```sh
    phylum auth register
    ```
 
-4. [Authenticate](https://docs.phylum.io/docs/authentication) with Phylum (requires [activation](https://github.com/phylum-dev/cli/tree/development#activation) by Phylum)
+5. [Authenticate](https://docs.phylum.io/docs/authentication) with Phylum (requires [activation](https://github.com/phylum-dev/cli/tree/development#activation) by Phylum)
 
    ```sh
    phylum auth login
    ```
 
-5. [Create a new Phylum project](https://docs.phylum.io/docs/projects#creating-a-new-project) in your project directory
+6. [Create a new Phylum project](https://docs.phylum.io/docs/projects#creating-a-new-project) in your project directory
 
    ```sh
    phylum projects create <project-name>
    ```
 
-6. [Submit your package lock file](https://docs.phylum.io/docs/analyzing-dependencies)
+7. [Submit your package lock file](https://docs.phylum.io/docs/analyzing-dependencies)
 
    ```sh
    phylum analyze <package-lock-file.ext>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+<!-- markdownlint-disable-file MD033 - inline HTML is allowed here -->
+<!-- markdownlint-disable-next-line MD041 - okay to NOT start file with top-level heading -->
 <p align="center">
   <img height="100" src="https://phylum.io/logo/dark-bckg.svg">
 </p>
 
 ---
 
-## Command Line Utility for [Phylum.io](https://phylum.io) 
+# Command Line Utility for [Phylum.io](https://phylum.io)
   
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/phylum-dev/cli)
 [![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/tterb/atomic-design-ui/blob/master/LICENSEs)
@@ -15,32 +17,44 @@ The command line interface (CLI) allows users to submit their project package de
 
 [![asciicast](https://asciinema.org/a/431262.svg)](https://asciinema.org/a/431262)
 
-# Quickstart for Linux or macOS
+## Quickstart for Linux or macOS
+
 1. Download and unzip the latest [release package](https://github.com/phylum-dev/cli/releases/latest/download/phylum-cli-release.zip)
 2. Run the installer script
-```
-./install.sh
-```
+
+   ```sh
+   ./install.sh
+   ```
+
 3. [Register](https://docs.phylum.io/docs/authentication) for an account (if you don't already have one)
-```
-phylum auth register
-```
+
+   ```sh
+   phylum auth register
+   ```
+
 4. [Authenticate](https://docs.phylum.io/docs/authentication) with Phylum (requires [activation](https://github.com/phylum-dev/cli/tree/development#activation) by Phylum)
-```
-phylum auth login
-```
+
+   ```sh
+   phylum auth login
+   ```
+
 5. [Create a new Phylum project](https://docs.phylum.io/docs/projects#creating-a-new-project) in your project directory
-```
-phylum projects create <project-name>
-```
+
+   ```sh
+   phylum projects create <project-name>
+   ```
+
 6. [Submit your package lock file](https://docs.phylum.io/docs/analyzing-dependencies)
-```
-phylum analyze <package-lock-file.ext>
-```
+
+   ```sh
+   phylum analyze <package-lock-file.ext>
+   ```
+
 ---
 
 ## Overview
-```
+
+```sh
 ❯ phylum
 phylum 1.0.1
 Phylum, Inc.
@@ -70,39 +84,48 @@ SUBCOMMANDS:
 ```
 
 ## Installation
+
 Releases of phylum are built for Linux and macOS x64. If you need another architecture, see the section below on Building.
 
-Running the install script provided with the release package will install phylum, i.e. 
+Running the install script provided with the release package will install phylum, i.e.
 
-```
+```sh
 ./install.sh
 ```
 
 This will create a new directory in `$HOME/.phylum` to house the configuration, and will place the binary in the appropriate location. The script will also add the `$HOME/.phylum` directory to the user's `PATH`.
 
 ## Building
+
 <details>
   <summary>Expand to learn more about building from source</summary>
   
 Phylum is written in Rust, so you'll need a recent Rust installation to build it (we tested with v1.58.0). [Install Rust](https://www.rust-lang.org/tools/install)
+
 1. Clone repository
-```sh
-git clone https://github.com/phylum-dev/cli
-```
+
+   ```sh
+   git clone https://github.com/phylum-dev/cli
+   ```
+
 2. Run build and install scripts in cli/lib
-```sh
-cd cli/lib
-bash build.sh
-bash install.sh
-```
+
+   ```sh
+   cd cli/lib
+   bash build.sh
+   bash install.sh
+   ```
+
 </details>
 
 ## Registration
+
 <details>
   <summary>Expand to learn more about Phylum account registration</summary>
 
 To register a user account, use the `auth register` subcommand to enter the user registration workflow where the Phylum tool will open a web browser to complete the process:
-```
+
+```sh
 ❯ phylum auth register
 
 Please use browser window to complete login process
@@ -110,29 +133,38 @@ If browser window does not open, you can use the link below:
  <URL>
 ✅ Successfully registered a new account!
 ```
+
 </details>
 
 ## Activation
+
 To have your Phylum user account enabled, please contact someone at Phylum.
   
 ## Configuration
+
 <details>
   <summary>Expand to learn more about the Phylum configuration file</summary>
 
 Phylum uses a configuration file located at `$HOME/.phylum/settings.yaml`  
 The `install.sh` script copies a default configuration file, but requires a token to communicate with the Phylum API. The `settings.yaml` file is automatically updated with the proper token value after a successful CLI login.  
 The `offline_access` parameter in the `settings.yaml` file contains the API token. The following command can be used to retrieve your token value:  
+
 ```sh
 grep "offline_access" $HOME/.phylum/settings.yaml | sed 's/  offline_access: //'
 ```
+
 </details>
 
 ## Example: First project submission
+
 Package submissions must be part of _projects_. Projects in Phylum correspond to software projects the users want to analyze. When a phylum project is created, the `.phylum_project` file is written to the current working directory and used correlate mulitple analysis jobs to a single software project.
+
 ```sh
 ❯ phylum projects create <project_name>
 ```
+
 Next, submit a package lock file:
+
 ```sh
 ❯ phylum analyze package-lock.json
 ✅ Job ID: ec95dbc1-bd13-41f5-88f2-18ac9bcab3b6
@@ -155,22 +187,25 @@ Next, submit a package lock file:
      70 - 80   [    1]
      80 - 90   [    0]
      90 - 100  [   60] ████████████████████████████████
-
 ```
+
 phylum sends the information from the package lockfile to the Phylum API and receives summary analysis results.
 
 Here we can see some summary information:
+
 * the project score of the analysis job - `Proj. Score: 52`
 * the number of dependencies - `Num Deps: 63`
 * a histogram on the lower left showing the distribution of package scores for each dependency in the analysis job
 
 To get more detailed information about the job, we can use the verbose flag `-V` on phylum.
+
 ```sh
 ❯ phylum analyze package-lock.json -V
 ... long output omitted ...
 ```
 
 To get the analysis results data in JSON format, we can use the `--json` option:
+
 ```sh
 ❯ phylum analyze package-lock.json -V --json
 ... long output omitted ...

--- a/release.sh
+++ b/release.sh
@@ -1,26 +1,21 @@
 #!/bin/bash
 
 printf "version: "
-read version
+read -r version
 
 printf "changelog: "
-read changelog
+read -r changelog
 
 sed -E -i "1 s#^#* $version - $changelog\n#" CHANGELOG
-sed -E -i "s/^version = \"([^\"]*)\"/version = \"$version\"/" lib/Cargo.toml
-sed -E -i "s/^version: \"([^\"]*)\"/version: \"$version\"/" lib/src/bin/.conf/cli.yaml
+sed -E -i "s/^version = \"([^\"]*)\"/version = \"$version\"/" cli/Cargo.toml
 git add CHANGELOG
-git add lib/Cargo.toml
-git add lib/src/bin/.conf/cli.yaml
+git add cli/Cargo.toml
 git commit -m "Bump version"
-
-#sed -E -i "0,/^$/s/^version = \"([^\"]*)\"/version = \"$version\"/" bindings/python/Cargo.toml
 
 TAG=v${version}
 
-echo Tagging / pushing ${TAG}, press any key to proceed...
-read
+echo Tagging / pushing "${TAG}", press any key to proceed...
+read -r
 git push
-git tag ${TAG}
+git tag "${TAG}"
 git push --tags
-


### PR DESCRIPTION
# Overview
The CLI release workflow was not producing any artifacts. The last big refactor changed the way the artifacts are produced and named. The workflow and documentation has been updated to match. Further, the `release.sh` script was updated to make it easier to push a release. Linting and formatting was done throughout.

# Checklist
- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~

# Issue
Closes #185
