### PR TITLE
Allow local build on M1 hosts

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,10 +1,2 @@
 [alias]
 xtask = "run --package xtask --"
-
-[target.aarch64-apple-darwin]
-linker = "/build/osxcross/target/bin/o64-clang"
-ar = "/usr/bin/ar"
-
-[target.x86_64-apple-darwin]
-linker = "x86_64-apple-darwin20.4-clang"
-ar = "x86_64-apple-darwin20.4-ar"

--- a/README.md
+++ b/README.md
@@ -123,13 +123,17 @@ Phylum is written in Rust, so you'll need a recent Rust installation to build it
    git clone https://github.com/phylum-dev/cli
    ```
 
-2. Run build and install scripts in cli/lib
+2. Build the project
 
-   ```sh
-   cd cli/lib
-   bash build.sh
-   bash install.sh
-   ```
+```sh
+cargo build
+```
+
+3. You can use the executable directly as `./target/debug/phylum` or install it like so:
+
+```sh
+cargo install --path cli
+```
 
 </details>
 

--- a/cli/.cargo/config
+++ b/cli/.cargo/config
@@ -1,8 +1,0 @@
-[target.aarch64-apple-darwin]
-linker = "/build/osxcross/target/bin/o64-clang"
-ar = "/usr/bin/ar"
-
-[target.x86_64-apple-darwin]
-linker = "x86_64-apple-darwin20.4-clang"
-ar = "x86_64-apple-darwin20.4-ar"
-

--- a/xtask/src/dockerfiles/Dockerfile.macos
+++ b/xtask/src/dockerfiles/Dockerfile.macos
@@ -5,6 +5,9 @@ ARG CC_aarch64_apple_darwin="aarch64-apple-darwin20.4-clang -arch arm64"
 WORKDIR /build/cli
 COPY . .
 
+ENV CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="/build/osxcross/target/bin/o64-clang"
+ENV CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="x86_64-apple-darwin20.4-clang"
+
 RUN rustup target add x86_64-apple-darwin aarch64-apple-darwin
 RUN cargo build --release --target x86_64-apple-darwin
 RUN cargo build --release --target aarch64-apple-darwin


### PR DESCRIPTION
# Overview

Specify the linker for cross-compiling as an environment variable rather than in a config file. This allows the docker container in the Github Action to continue working without breaking local builds.

## Checklist

- [x] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [x] Have you updated all affected documentation?

## Issue

closes #190 
