### PR TITLE
Update docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@
 name: Sync `docs` directory to ReadMe
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - development
   
 jobs:
   Update-Documentation:
@@ -18,13 +17,6 @@ jobs:
         uses: actions/checkout@v3
        
       - name: Update v1-latest using rdme
-        if: ${{ github.ref_name == 'master' }}
         uses: readmeio/rdme@7.0.0
         with:
           rdme: docs ./docs --key=${{ secrets.README_API }} --version=1-latest
-          
-      - name: Update v1-development using rdme
-        if: ${{ github.ref_name == 'development' }}
-        uses: readmeio/rdme@7.0.0
-        with:
-          rdme: docs ./docs --key=${{ secrets.README_API }} --version=1-development


### PR DESCRIPTION
# Overview

The categories are different between versions, so we will not be able to update a development version of the docs at this time. Removing development strategy from the action to keep it from failing on push to `development`.
