### PR TITLE
Add Windows builds to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           command: clippy
           args: --manifest-path Cargo.toml --all-features --all --tests --examples -- -D clippy::all -D warnings
 
-  test:
+  test-matrix:
     strategy:
       fail-fast: false
       matrix:
@@ -60,3 +60,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  # This job reports the results of the test matrix above
+  test:
+    if: always()
+    needs: test-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.test-matrix.result != 'success'
+        name: Fail the build
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
       - development
-  # Run weekly on the development branch to make sure it always builds with the latest rust release
+  # Run weekly on the default branch to make sure it always builds with the latest rust release
   schedule:
     - cron: '30 5 * * 1'
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
       - development
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Install host dependencies
@@ -39,11 +39,23 @@ jobs:
           command: clippy
           args: --manifest-path Cargo.toml --all-features --all --tests --examples -- -D clippy::all -D warnings
 
-      - name: Build
-        run: cargo build --release
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@master
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --manifest-path Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,15 @@ on:
     branches:
       - master
       - development
+  # Run weekly on the development branch to make sure it always builds with the latest rust release
+  schedule:
+    - cron: '30 5 * * 1'
 
 jobs:
   lint:
+    # It is possible for lints to break after merge (e.g., new clippy checks), but it's not worth
+    # breaking the build if that happens. So we'll skip this job for scheduled runs.
+    if: github.event_name != "schedule"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install host dependencies
-        run: |
-          sudo apt update
-          sudo apt install -yq build-essential
-
       - name: Checkout the repo
         uses: actions/checkout@master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     # It is possible for lints to break after merge (e.g., new clippy checks), but it's not worth
     # breaking the build if that happens. So we'll skip this job for scheduled runs.
-    if: github.event_name != "schedule"
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,7 +20,4 @@ pub mod utils;
 // Enable logging for ALL doc & local tests
 use test::logging;
 
-#[macro_use]
-extern crate log;
-
 pub use reqwest::Error;

--- a/cli/src/update/mod.rs
+++ b/cli/src/update/mod.rs
@@ -1,0 +1,14 @@
+//! Self-update functions
+//!
+//! Self-update is currently only supported on macos and Linux. All other platforms are unsupported
+//! and will display an error when `phylum update` is run.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use self::unix::*;
+
+#[cfg(not(unix))]
+mod unsupported;
+#[cfg(not(unix))]
+pub use self::unsupported::*;

--- a/cli/src/update/mod.rs
+++ b/cli/src/update/mod.rs
@@ -1,7 +1,7 @@
 //! Self-update functions
 //!
-//! Self-update is currently only supported on macos and Linux. All other platforms are unsupported
-//! and will display an error when `phylum update` is run.
+//! Self-update is currently supported on macos and Linux. All other platforms are unsupported and
+//! will display an error when `phylum update` is run. For Windows support, see issue #221
 
 #[cfg(unix)]
 mod unix;

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -20,8 +20,30 @@ const PUBKEY: &str = "RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf";
 
 const GITHUB_URI: &str = "https://api.github.com";
 
+/// Check if a newer version of the client is available
+pub async fn needs_update(current_version: &str, prerelease: bool) -> bool {
+    let updater = ApplicationUpdater::default();
+    match updater.get_latest_version(prerelease).await {
+        Some(latest) => updater.needs_update(current_version, &latest),
+        None => {
+            log::debug!("Failed to get the latest version for update check");
+            false
+        }
+    }
+}
+
+/// Perform a self-update to the latest version
+pub async fn do_update(prerelease: bool) -> anyhow::Result<String> {
+    let updater = ApplicationUpdater::default();
+    let ver = updater
+        .get_latest_version(prerelease)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Failed to get version metadata"))?;
+    updater.do_update(ver).await.map_err(|e| e.into())
+}
+
 #[derive(Debug)]
-pub struct ApplicationUpdater {
+struct ApplicationUpdater {
     pubkey: PublicKey,
     github_uri: String,
 }
@@ -99,7 +121,7 @@ impl ApplicationUpdater {
     }
 
     /// Check for an update by querying the Github releases page.
-    pub async fn get_latest_version(&self, prerelease: bool) -> Option<GithubRelease> {
+    async fn get_latest_version(&self, prerelease: bool) -> Option<GithubRelease> {
         let ver = if prerelease {
             let url = format!("{}/repos/phylum-dev/cli/releases", self.github_uri);
 
@@ -176,7 +198,7 @@ impl ApplicationUpdater {
     /// published on Github. We do the naive thing here: If the latest version on
     /// Github does not match the Clap version, we indicate that we need to
     /// update. We do not compare semvers to determine if an update is required.
-    pub fn needs_update(&self, current_version: &str, latest_version: &GithubRelease) -> bool {
+    fn needs_update(&self, current_version: &str, latest_version: &GithubRelease) -> bool {
         let latest = latest_version
             .name
             .replace("phylum ", "")
@@ -188,7 +210,7 @@ impl ApplicationUpdater {
     }
 
     /// Locate the specified asset in the Github response structure.
-    pub fn find_github_asset<'a>(
+    fn find_github_asset<'a>(
         &self,
         latest: &'a GithubRelease,
         name: &str,
@@ -207,7 +229,7 @@ impl ApplicationUpdater {
     /// only compiling for these OSes and architectures.
     ///
     /// Until we update the releases, this should suffice.
-    pub async fn do_update(&self, latest: GithubRelease) -> Result<String, std::io::Error> {
+    async fn do_update(&self, latest: GithubRelease) -> Result<String, std::io::Error> {
         debug!("Performing the update process");
         let latest_version = &latest.name;
 
@@ -300,7 +322,7 @@ impl ApplicationUpdater {
 
     /// Verify that the downloaded binary matches the expected signature. Returns
     /// `true` for a valid signature, `false` otherwise.
-    pub fn has_valid_signature(&self, file: &str, sig_path: &str) -> bool {
+    fn has_valid_signature(&self, file: &str, sig_path: &str) -> bool {
         let sig = fs::read_to_string(sig_path).expect("Unable to read signature file");
         let bin = fs::read(file).expect("Unable to read binary data from disk");
 
@@ -315,7 +337,7 @@ impl ApplicationUpdater {
 
 #[cfg(test)]
 mod tests {
-    use crate::update::ApplicationUpdater;
+    use super::ApplicationUpdater;
     use minisign_verify::PublicKey;
     use std::fs;
     use std::fs::File;

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use futures::Future;
+use log::debug;
 use minisign_verify::{PublicKey, Signature};
 use reqwest::{Client, Response};
 

--- a/cli/src/update/unsupported.rs
+++ b/cli/src/update/unsupported.rs
@@ -1,11 +1,11 @@
 //! Dummy functions for platforms where self-update is unsupported
 
 /// Check if a newer version of the client is available
-pub async fn needs_update(current_version: &str, prerelease: bool) -> bool {
+pub async fn needs_update(_current_version: &str, _prerelease: bool) -> bool {
     false
 }
 
 /// Perform a self-update to the latest version
-pub async fn do_update(prerelease: bool) -> anyhow::Result<String> {
+pub async fn do_update(_prerelease: bool) -> anyhow::Result<String> {
     anyhow::bail!("Self-update not supported on this platform")
 }

--- a/cli/src/update/unsupported.rs
+++ b/cli/src/update/unsupported.rs
@@ -1,0 +1,11 @@
+//! Dummy functions for platforms where self-update is unsupported
+
+/// Check if a newer version of the client is available
+pub async fn needs_update(current_version: &str, prerelease: bool) -> bool {
+    false
+}
+
+/// Perform a self-update to the latest version
+pub async fn do_update(prerelease: bool) -> anyhow::Result<String> {
+    anyhow::bail!("Self-update not supported on this platform")
+}


### PR DESCRIPTION
# Overview

Use a matrix in the `test.yml` workflow to ensure that the CLI builds and all tests pass Linux, macos, and Windows. This also adds a scheduled run of the workflow to ensure that we are notified if the build begins to fail for external reasons (e.g., a new rust release). And this splits the self-update functions by platform in order to fix the build on Windows and close #200

## Checklist

- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
