### PR TITLE
Follow development branch of phylum-types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path Cargo.toml --all-features --all --tests --examples -- -D clippy::all -D warnings
+          args: --locked --all-features -- -D warnings
 
   test-matrix:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=master#582271f37bbceac2304b9839af5bc16449bf0062"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#241e855bf13a83fb6d046ee691266d6406847dbd"
 dependencies = [
  "log",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ maplit = "1.0.2"
 minisign-verify = "0.1.8"
 nom = "6.1.2"
 open = "2.0.1"
-phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "master" }
+phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 prettytable-rs = "0.8.0"
 rand = "0.8.4"
 reqwest = { version = "0.11.3", features = ["blocking", "json", "rustls-tls"], default-features = false }


### PR DESCRIPTION
Tracking the `master` branch of `phylum-types` creates an over-complicated workflow. We are already using `Cargo.lock` to lock the dependency to a specific revision until `cargo update` is run.

It is much more useful for us to develop against the `development` branch so that we can quickly find and fix any problems that might arise. This PR makes that switch.