### PR TITLE
Add uninstall subcommand to phylum

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 
 [features]
+default = ["selfmanage"]
 phylum-online = []
+selfmanage = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -18,7 +18,8 @@ and 'engineering' domains
 "#;
 
 pub fn app<'a>() -> clap::Command<'a> {
-    Command::new("phylum")
+    #[allow(unused_mut)]
+    let mut app = Command::new("phylum")
         .bin_name("phylum")
         .version(VERSION)
         .author("Phylum, Inc.")
@@ -131,5 +132,18 @@ pub fn app<'a>() -> clap::Command<'a> {
         .subcommand(
             Command::new("version")
                 .about("Display application version")
-        )
+        );
+
+    #[cfg(feature = "selfmanage")]
+    {
+        app = app.subcommand(
+            Command::new("uninstall")
+                .about("Uninstall the Phylum CLI")
+                .arg(arg!(
+                    -p --purge "Remove all files, including configuration files (default: false)"
+                )),
+        );
+    }
+
+    app
 }

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -13,6 +13,8 @@ use phylum_cli::commands::auth::*;
 use phylum_cli::commands::jobs::*;
 use phylum_cli::commands::packages::*;
 use phylum_cli::commands::project::handle_project;
+#[cfg(feature = "selfmanage")]
+use phylum_cli::commands::uninstall::*;
 use phylum_cli::commands::{CommandResult, CommandValue, ExitCode};
 use phylum_cli::config::*;
 use phylum_cli::print::*;
@@ -54,6 +56,11 @@ async fn handle_commands() -> CommandResult {
     let app_helper = &mut app.clone();
 
     let matches = app.get_matches();
+
+    #[cfg(feature = "selfmanage")]
+    if let Some(matches) = matches.subcommand_matches("uninstall") {
+        return handle_uninstall(matches);
+    }
 
     let settings_path = get_home_settings_path()?;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,8 @@ pub mod jobs;
 pub mod lock_files;
 pub mod packages;
 pub mod project;
+#[cfg(feature = "selfmanage")]
+pub mod uninstall;
 
 /// The possible result values of commands
 pub enum CommandValue {

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,0 +1,140 @@
+//! Phylum CLI removal.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use anyhow::{anyhow, Result};
+use clap::ArgMatches;
+use tempfile::NamedTempFile;
+
+use crate::commands::{CommandResult, ExitCode};
+use crate::{config, print_user_success, print_user_warning};
+
+/// Handle the `uninstall` subcommand.
+pub fn handle_uninstall(matches: &ArgMatches) -> CommandResult {
+    let home_dir = home_dir()?;
+
+    if matches.is_present("purge") {
+        purge(&home_dir);
+    }
+
+    remove_installed_files(&home_dir);
+
+    if let Err(err) = Shell::Bash.cleanup(&home_dir) {
+        print_user_warning!("BASH config error: {}", err);
+    }
+
+    if let Err(err) = Shell::Zsh.cleanup(&home_dir) {
+        print_user_warning!("ZSH config error: {}", err);
+    }
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Remove the entire `~/.config/phylum` directory.
+fn purge(home_dir: &Path) {
+    let config_dir = config::config_dir(home_dir).join("phylum");
+
+    match fs::remove_dir_all(&config_dir) {
+        Ok(()) => print_user_success!("Successfully removed {:?}", config_dir),
+        Err(err) => {
+            print_user_warning!("Could not remove phylum config directory: {}", err);
+        }
+    }
+}
+
+/// Remove files created by `install.sh`.
+fn remove_installed_files(home_dir: &Path) {
+    let data_dir = data_dir(home_dir).join("phylum");
+    let bin_path = bin_dir(home_dir).join("phylum");
+
+    let data_result = fs::remove_dir_all(data_dir);
+    let bin_result = fs::remove_file(bin_path);
+
+    if let Err(err) = &data_result {
+        print_user_warning!("Could not remove data directory: {}", err);
+    }
+
+    if let Err(err) = &bin_result {
+        print_user_warning!("Could not remove phylum executable: {}", err);
+    }
+
+    if data_result.is_ok() && bin_result.is_ok() {
+        print_user_success!("Successfully removed installer files");
+    }
+}
+
+/// XDG data directory.
+fn data_dir(home_dir: &Path) -> PathBuf {
+    env::var("XDG_DATA_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir.join(".local/share"))
+}
+
+/// XDG binary directory.
+fn bin_dir(home_dir: &Path) -> PathBuf {
+    home_dir.join(".local/bin")
+}
+
+/// Supported shells.
+#[derive(Debug)]
+enum Shell {
+    Bash,
+    Zsh,
+}
+
+impl Shell {
+    /// Get the shell's config path.
+    fn rc_path(&self, home_dir: &Path) -> PathBuf {
+        match self {
+            Self::Bash => home_dir.join(".bashrc"),
+            Self::Zsh => home_dir.join(".zshrc"),
+        }
+    }
+
+    /// Get the shell's phylum config path
+    fn phylum_path(&self, home_dir: &Path) -> PathBuf {
+        let data_dir = data_dir(home_dir).join("phylum");
+        match self {
+            Self::Bash => data_dir.join("bashrc"),
+            Self::Zsh => data_dir.join("zshrc"),
+        }
+    }
+
+    /// Remove all lines from the shell config which were added by the installer.
+    fn cleanup(&self, home_dir: &Path) -> Result<()> {
+        let rc_path = self.rc_path(home_dir);
+        let mut rc_content = fs::read_to_string(&rc_path)?;
+
+        let phylum_path = self.phylum_path(home_dir);
+        let config_line = format!("source {}\n", phylum_path.to_string_lossy());
+
+        // If the installer's config is present, remove it.
+        if !rc_content.contains(&config_line) {
+            return Ok(());
+        }
+        rc_content = rc_content.replace(&config_line, "");
+
+        // Write to tempfile on same mountpoint to avoid accidental corruption.
+        let rc_dir = rc_path
+            .parent()
+            .ok_or_else(|| anyhow!("Shell file has no parent directory"))?;
+        let mut tmpfile = NamedTempFile::new_in(rc_dir)?;
+        tmpfile.write_all(rc_content.as_bytes())?;
+
+        // Swap the tempfile into place.
+        tmpfile.persist(rc_path)?;
+
+        print_user_success!("Removed entries from {:?} config.", self);
+
+        Ok(())
+    }
+}
+
+/// Get the user's home directory.
+fn home_dir() -> Result<PathBuf> {
+    home::home_dir().ok_or(anyhow!("Unable to find home directory"))
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -168,13 +168,7 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
     let home_path =
         home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))?;
 
-    // Resolve XDG config directory.
-    let config_dir = env::var("XDG_CONFIG_HOME")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home_path.join(".config"));
-
+    let config_dir = config_dir(&home_path);
     let config_path = config_dir.join("phylum").join("settings.yaml");
     let old_config_path = home_path.join(".phylum").join("settings.yaml");
 
@@ -198,6 +192,15 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
     }
 
     Ok(config_path)
+}
+
+/// Resolve XDG config directory.
+pub fn config_dir(home_path: &Path) -> PathBuf {
+    env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_path.join(".config"))
 }
 
 #[cfg(test)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -169,7 +169,7 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
         home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))?;
 
     // Resolve XDG config directory.
-    let config_dir = env::var("XDG_CONFIG_DIR")
+    let config_dir = env::var("XDG_CONFIG_HOME")
         .ok()
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)


### PR DESCRIPTION
In #236 a shell script was proposed to allow for uninstallation of the
Phylum CLI, however the usage of that command turned out to be a bit
awkward.

This patch instead introduces the new `phylum uninstall` CLI option
which will automatically remove the CLI without having to go through the
hassle of acquiring a separate uninstallation script.

To ensure uninstallation never removes something it shouldn't, the shell
configs are only edited when the full text added by the installer can be
found. To ensure this works as often as possible, the `install.sh`
script had to be modified to always include the completion
initialization, since this is commonly present already.

Closes #206.