### PR TITLE
Use git_version for version numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1295,7 @@ dependencies = [
  "dialoguer",
  "env_logger",
  "futures",
+ "git-version",
  "histogram",
  "home",
  "hyper",
@@ -1383,6 +1406,12 @@ dependencies = [
  "term 0.5.2",
  "unicode-width",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.0.14" }
 dialoguer = "0.8.0"
 env_logger = "0.7.1"
 futures = "^0.3"
+git-version = "0.3.5"
 histogram = "0.6.9"
 home = "0.5.3"
 hyper = "0.14.16"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,4 +1,10 @@
 use clap::{arg, Command};
+use git_version::git_version;
+
+const VERSION: &str = git_version!(
+    args = ["--dirty=-modified", "--tags"],
+    cargo_prefix = "cargo:"
+);
 
 const FILTER_ABOUT: &str = r#"Provide a filter used to limit the issues displayed
 
@@ -14,7 +20,7 @@ and 'engineering' domains
 pub fn app<'a>() -> clap::Command<'a> {
     Command::new("phylum")
         .bin_name("phylum")
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(VERSION)
         .author("Phylum, Inc.")
         .about("Client interface to the Phylum system")
         .args(&[

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -116,7 +116,7 @@ async fn handle_commands() -> CommandResult {
         }
     }
 
-    if check_for_updates && update::needs_update(ver, false).await {
+    if check_for_updates && update::needs_update(false).await {
         print_update_message();
     }
 

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -18,11 +18,14 @@ const PUBKEY: &str = "RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf";
 
 const GITHUB_URI: &str = "https://api.github.com";
 
+// For updates, we use the cargo version instead of git_version
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Check if a newer version of the client is available
-pub async fn needs_update(current_version: &str, prerelease: bool) -> bool {
+pub async fn needs_update(prerelease: bool) -> bool {
     let updater = ApplicationUpdater::default();
     match updater.get_latest_version(prerelease).await {
-        Ok(latest) => updater.needs_update(current_version, &latest),
+        Ok(latest) => updater.needs_update(CURRENT_VERSION, &latest),
         Err(e) => {
             log::debug!("Failed to get the latest version for update check: {:?}", e);
             false

--- a/cli/src/update/unsupported.rs
+++ b/cli/src/update/unsupported.rs
@@ -1,7 +1,7 @@
 //! Dummy functions for platforms where self-update is unsupported
 
 /// Check if a newer version of the client is available
-pub async fn needs_update(_current_version: &str, _prerelease: bool) -> bool {
+pub async fn needs_update(_prerelease: bool) -> bool {
     false
 }
 


### PR DESCRIPTION
# Overview

Use [`git_version`](https://docs.rs/git-version/latest/git_version/) to provide the version number for the CLI.

If the CLI is built from a tagged commit, it will display the tag. Otherwise, it displays the most recent tag, followed by the number of commits difference and the hash of the current commit. If changes have been made to the working directory, a `-modified` suffix is added. Here is an example from this branch:

```
❯ ./target/debug/phylum version
✅ phylum (Version v2.0.0-4-gd43325e)
```

## Checklist

- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?

## Issue

Fixes #124 
