### PR TITLE
ci: Run doc workflow on tag instead of master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,14 @@ name: Sync `docs` directory to ReadMe
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '*'
   
 jobs:
   Update-Documentation:
     name: Update the documentation
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref, 'rc') }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,13 @@
 name: Sync `docs` directory to ReadMe
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [released]
   
 jobs:
   Update-Documentation:
     name: Update the documentation
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, 'rc') }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - development
     tags:
       - '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - development
   # Run weekly on the default branch to make sure it always builds with the latest rust release
   schedule:


### PR DESCRIPTION
Publish the docs when a new release is tagged rather than when a merge to `master` occurs. This is required now that we no longer have a `master` branch.