### PR TITLE
Follow XDG directories spec

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -167,15 +167,16 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
         .map(PathBuf::from)
         .unwrap_or_else(|| home_path.join(".config"));
 
-    let config = config_dir.join("phylum").join("settings.yaml");
-    let fallback_config = home_path.join(".phylum").join("settings.yaml");
+    let config_path = config_dir.join("phylum").join("settings.yaml");
+    let old_config_path = home_path.join(".phylum").join("settings.yaml");
 
-    // Pick ~/.phylum/settings.yaml only when it exists and the XDG directory does not.
-    if !config.exists() && fallback_config.exists() {
-        Ok(fallback_config)
-    } else {
-        Ok(config)
+    // Migrate the config from the old location.
+    if !config_path.exists() && old_config_path.exists() {
+        fs::create_dir_all(config_path.parent().unwrap())?;
+        fs::rename(old_config_path, &config_path).unwrap();
     }
+
+    Ok(config_path)
 }
 
 #[cfg(test)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,7 +1,8 @@
 use std::env;
-use std::fs;
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::fs::{self, Permissions};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
@@ -172,6 +173,7 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
 
     // Migrate the config from the old location.
     if !config_path.exists() && old_config_path.exists() {
+        fs::set_permissions(&old_config_path, Permissions::from_mode(0o600))?;
         fs::create_dir_all(config_path.parent().unwrap())?;
         fs::rename(old_config_path, &config_path).unwrap();
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,7 @@
 use std::env;
-use std::fs::{self, Permissions};
+use std::fs;
+#[cfg(unix)]
+use std::fs::Permissions;
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -111,11 +111,6 @@ copy_files() {
         xattr -c "${bin_dir}/${bin_name}"
     fi
 
-    # Correct inaccurate settings.yaml permissions set by previous installers.
-    if [ -f "${config_dir}/settings.yaml" ]; then
-        chmod 600 "${config_dir}/settings.yaml"
-    fi
-
     # Copy completions over
     mkdir -p "${data_dir}"
     cp -a "completions" "${data_dir}/"


### PR DESCRIPTION
Previously phylum's installer would put all files into `~/.phylum` and
retrieve the configuration file from there. This leads to a rather
cluttered home directory which is why the XDG directories spec is
usually preferred.

The CLI will now check the XDG config directory first
(`${XDG_CONFIG_HOME:-${HOME}/.config}/phylum/settings.yaml`), then fall
back to the old config path if that isn't present.

The installer will put the completions in the XDG data directory
(`${XDG_DATA_HOME:-${HOME}/.local/share}/phylum`) and the binary in
`${HOME}/.local/bin/`.

Since the `${HOME}/.local/bin` path is sometimes included in the path
already, without being present in the shell config itself, we check the
current `$PATH` first to try and detect if we need to add it or not.

Closes #224.
