### PR TITLE
Sign release tags and be descriptive

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+LATEST=$(git describe --tags --abbrev=0)
+
+printf "Latest release: %s\n\nGit log:\n" "${LATEST}"
+git log --oneline HEAD "^${LATEST}"
+printf "\n"
 
 printf "version: "
 read -r version
@@ -10,12 +16,12 @@ sed -E -i "1 s#^#* ${version} - ${changelog}\n#" CHANGELOG
 sed -E -i "s/^version = \"([^\"]*)\"/version = \"${version}\"/" cli/Cargo.toml
 git add CHANGELOG
 git add cli/Cargo.toml
-git commit -m "Bump version"
+git commit -m "v${version} - ${changelog}"
 
 TAG=v${version}
 
 echo Tagging / pushing "${TAG}", press any key to proceed...
 read -r
 git push
-git tag "${TAG}"
-git push --tags
+git tag --sign -m "${TAG} - ${changelog}" "${TAG}"
+git push "${TAG}"


### PR DESCRIPTION
This PR aims to improve `release.sh` so that our releases use signed tags and more descriptive commit messages.

It also gives the user more information to work with by listing a log of commits since the latest release.
