### PR TITLE
Set appropriate exit codes on failure

### DIFF
--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -126,7 +126,7 @@ pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         }
     }
 
-    CommandValue::Action(action).into()
+    Ok(CommandValue::Action(action))
 }
 
 /// Handles submission of packages to the system for analysis and
@@ -239,5 +239,5 @@ pub async fn handle_submission(
         log::debug!("Requesting status...");
         action = get_job_status(api, &job_id, verbose, pretty_print, display_filter).await;
     }
-    CommandValue::Action(action).into()
+    Ok(CommandValue::Action(action))
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,31 +8,26 @@ pub mod projects;
 
 /// The possible result values of commands
 pub enum CommandValue {
-    /// Do nothing
-    Void,
-    /// A response to print to the user
-    String(String),
+    /// Exit with a specific code.
+    Code(ExitCode),
     /// An action to be undertaken wrt the build
     Action(Action),
 }
 
-impl From<Action> for CommandValue {
-    fn from(action: Action) -> Self {
-        Self::Action(action)
-    }
-}
-
-impl From<&'static str> for CommandValue {
-    fn from(str: &'static str) -> Self {
-        Self::String(str.to_owned())
+impl From<ExitCode> for CommandValue {
+    fn from(code: ExitCode) -> Self {
+        Self::Code(code)
     }
 }
 
 /// Shorthand type for Result whose ok value is CommandValue
 pub type CommandResult = anyhow::Result<CommandValue>;
 
-impl From<CommandValue> for CommandResult {
-    fn from(value: CommandValue) -> Self {
-        Ok(value)
-    }
+/// Unique exit code values.
+pub enum ExitCode {
+    Ok = 0,
+    NotAuthenticated = 10,
+    AuthenticationFailure = 11,
+    PackageNotFound = 12,
+    SetThresholdsFailure = 13,
 }

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -7,7 +7,7 @@ use phylum_types::types::package::*;
 use reqwest::StatusCode;
 
 use crate::api::PhylumApi;
-use crate::commands::{CommandResult, CommandValue};
+use crate::commands::{CommandResult, ExitCode};
 use crate::print::print_response;
 use crate::print_user_warning;
 
@@ -53,8 +53,9 @@ pub async fn handle_get_package(
             "No matching packages found. Submit a lockfile for processing:\n\n\t{}\n",
             Blue.paint("phylum analyze <lock_file>")
         );
+        Ok(ExitCode::PackageNotFound.into())
     } else {
         print_response(&resp, pretty_print, None);
+        Ok(ExitCode::Ok.into())
     }
-    CommandValue::Void.into()
 }

--- a/cli/src/commands/projects.rs
+++ b/cli/src/commands/projects.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use chrono::Local;
 use uuid::Uuid;
 
-use super::{CommandResult, CommandValue};
+use super::{CommandResult, ExitCode};
 use crate::api::PhylumApi;
 use crate::config::{get_current_project, save_config, ProjectConfig, PROJ_CONF_FILE};
 use crate::print::*;
@@ -47,7 +47,6 @@ pub async fn handle_projects(api: &mut PhylumApi, matches: &clap::ArgMatches) ->
         });
 
         print_user_success!("Successfully created new project, {}", project_name);
-        return CommandValue::Void.into();
     } else if let Some(matches) = matches.subcommand_matches("list") {
         let pretty_print = pretty_print && !matches.is_present("json");
         get_project_list(api, pretty_print).await;
@@ -176,11 +175,12 @@ pub async fn handle_projects(api: &mut PhylumApi, matches: &clap::ArgMatches) ->
                     "Failed to set thresholds for the {} project",
                     White.paint(project_name)
                 );
+                return Ok(ExitCode::SetThresholdsFailure.into());
             }
         }
     } else {
         get_project_list(api, pretty_print).await;
     }
 
-    CommandValue::Void.into()
+    Ok(ExitCode::Ok.into())
 }


### PR DESCRIPTION
Several paths of the Phylum CLI would print warnings/errors to the user,
but still set and exit code of `0`. This makes it difficult for for
automated tools to verify success and can confuse users.

As a solution, the `CommandValue` enum has been changed, replacing the
`CommandValue::Void` variant with `CommandValue::Code`. This code is
then used on exit instead of the fixed `0` which was used for
`CommandValue::Void`.

This also introduces a few simplifications to the error/CommandValue
handling, removing unnecessary code and inlining unnecessary
abstractions. This hopefully improves transparency of the process and
makes the usage consistent.

Some functions relying on `CommandValue::Void` as a replacement to `()`
without ever propagating it have been switched to `anyhow::Result<()>`.
Generally there's little reason to use `CommandValue` unless the goal
is for it to end up directly as the command's exit code.

Some functions also had to be adjusted to ensure the code is properly
propagated. This should capture all instances where the result of a
function returning `CommandResult` was ignored.

Closes #229.
