### PR TITLE
Remove checkmark from `auth token` command

### DIFF
--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -66,7 +66,7 @@ pub async fn handle_auth_status(
 pub fn handle_auth_token(config: &Config) {
     match config.auth_info.offline_access.clone() {
         Some(token) => {
-            print_user_success!("{}", token);
+            println!("{}", token);
         }
         None => {
             print_user_warning!(


### PR DESCRIPTION
To ensure the `phylum auth token` command's output isn't confusing, the
checkmark in front of the token has been removed.

The token is now also written to `stdout` instead of `stderr`, which
should allow for much better interaction between `auth token` and shell
pipes.

Closes #252.
