### PR TITLE
Truncate excessive project names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "unicode-width",
  "url",
  "uuid",
  "wiremock",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 yaml-rust = "*"
 zeroize = "1.4.0"
 zip = "0.6.2"
+unicode-width = "0.1.9"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,9 +1,10 @@
-use std::io;
-use std::io::Write;
+use std::borrow::Cow;
+use std::io::{self, Write};
 
 use ansi_term::Color::{Blue, Cyan};
 use clap::Command;
 use serde::Serialize;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::api::PhylumApiError;
 use crate::filter::Filter;
@@ -89,4 +90,22 @@ pub fn print_sc_help(app: &mut Command, subcommand: &str) {
         }
     }
     println!();
+}
+
+/// Limit a string to a specific length, using an ellipsis to indicate truncation.
+pub fn truncate(text: &str, max_length: usize) -> Cow<str> {
+    if text.width() > max_length {
+        let mut len = 0;
+        let truncated = text
+            .chars()
+            .take_while(|c| {
+                len += c.width().unwrap_or(0);
+                len < max_length
+            })
+            .collect::<String>()
+            + "…";
+        Cow::Owned(truncated)
+    } else {
+        Cow::Borrowed(text)
+    }
 }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -5,6 +5,7 @@ use phylum_types::types::package::*;
 use phylum_types::types::project::*;
 use prettytable::*;
 
+use crate::print;
 use crate::types::PingResponse;
 use crate::utils::table_format;
 
@@ -38,8 +39,8 @@ impl Renderable for String {
 
 impl Renderable for ProjectSummaryResponse {
     fn render(&self) -> String {
-        let name = format!("{}", White.paint(self.name.clone()));
-        format!("{:<38}{}", name, self.id)
+        let name = print::truncate(&self.name, 28);
+        format!("{:<37} {}", White.paint(name).to_string(), self.id)
     }
 }
 
@@ -165,10 +166,11 @@ impl Renderable for AllJobsStatusResponse {
         );
 
         for (i, job) in self.jobs.iter().enumerate() {
-            let mut state = format!("{}", Green.paint("PASS"));
+            let mut state = Green.paint("PASS").to_string();
             let score = format!("{}", (job.score * 100.0) as u32);
-            let mut colored_score = format!("{}", Green.paint(&score));
-            let project_name = format!("{}", White.bold().paint(job.project.clone()));
+            let mut colored_score = Green.paint(&score).to_string();
+            let project_name = print::truncate(&job.project, 39);
+            let colored_project_name = White.bold().paint(project_name).to_string();
 
             if job.num_incomplete > 0 {
                 colored_score = format!("{}", Yellow.paint(&score));
@@ -185,7 +187,7 @@ impl Renderable for AllJobsStatusResponse {
                     (i + 1),
                     colored_score,
                     state,
-                    project_name,
+                    colored_project_name,
                     job.label,
                     job.job_id,
                     job.date

--- a/cli/src/summarize.rs
+++ b/cli/src/summarize.rs
@@ -11,6 +11,7 @@ use phylum_types::types::project::*;
 use prettytable::*;
 
 use crate::filter::Filter;
+use crate::print;
 use crate::render::Renderable;
 use crate::utils::table_format;
 
@@ -138,7 +139,7 @@ where
     let details = [
         (
             "Project",
-            resp.project_name.to_string(),
+            print::truncate(&resp.project_name, 36).to_string(),
             "Label",
             resp.label.as_ref().unwrap_or(&"".to_string()).to_owned(),
         ),


### PR DESCRIPTION
Since a lot of output in the Phylum CLI relies on tables, it's important
that text does not exceed the maximum cell length. The most likely
culprit for this is the `project`, which can be freely defined by the
user.

All instances of the project name output are now truncated to the
respective cell length and a truncation is indicated using the ellipsis
symbol.

To ensure this works for project names in any language, the length of
the cells is calculated using the `unicode-width` crate.

Closes #127.
