### PR TITLE
Allow square brackets in Python dependencies

### DIFF
--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -23,9 +23,7 @@ impl Parseable for PyRequirements {
 
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self) -> ParseResult {
-        let (_, entries) =
-            pypi::parse(&self.0).map_err(|_e| "Failed to parse requirements file")?;
-        Ok(entries)
+        pypi::parse(&self.0)
     }
 }
 
@@ -158,14 +156,30 @@ mod tests {
 
         let pkgs = parser.parse().unwrap();
         assert_eq!(pkgs.len(), 131);
-        assert_eq!(pkgs[0].name, "pyyaml");
-        assert_eq!(pkgs[0].version, "5.4.1");
-        assert_eq!(pkgs[0].package_type, PackageType::PyPi);
 
-        let last = pkgs.last().unwrap();
-        assert_eq!(last.name, "zope.interface");
-        assert_eq!(last.version, "5.4.0");
-        assert_eq!(last.package_type, PackageType::PyPi);
+        assert_eq!(
+            pkgs.first(),
+            Some(&PackageDescriptor {
+                name: "pyyaml".into(),
+                version: "5.4.1".into(),
+                package_type: PackageType::PyPi,
+            })
+        );
+
+        assert_eq!(
+            pkgs.last(),
+            Some(&PackageDescriptor {
+                name: "zope.interface".into(),
+                version: "5.4.0".into(),
+                package_type: PackageType::PyPi,
+            })
+        );
+
+        assert!(pkgs.contains(&PackageDescriptor {
+            name: "celery".into(),
+            version: "5.0.5".into(),
+            package_type: PackageType::PyPi
+        }));
     }
 
     #[test]

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -157,7 +157,7 @@ mod tests {
         let parser = PyRequirements::new(Path::new("tests/fixtures/requirements.txt")).unwrap();
 
         let pkgs = parser.parse().unwrap();
-        assert_eq!(pkgs.len(), 130);
+        assert_eq!(pkgs.len(), 131);
         assert_eq!(pkgs[0].name, "pyyaml");
         assert_eq!(pkgs[0].version, "5.4.1");
         assert_eq!(pkgs[0].package_type, PackageType::PyPi);

--- a/cli/tests/fixtures/complex-requirements.txt
+++ b/cli/tests/fixtures/complex-requirements.txt
@@ -2,58 +2,58 @@
 ####### example-requirements.txt #######
 #
 ###### Requirements without Version Specifiers ######
-nose
-nose-cov
-beautifulsoup4
+#nose
+#nose-cov
+#beautifulsoup4
 #
 ###### Requirements with Version Specifiers ######
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 docopt==0.6.1             # Version Matching. Must be version 0.6.1
-keyring >= 4.1.1            # Minimum version 4.1.1
-coverage != 3.5             # Version Exclusion. Anything except version 3.5
-Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
+#keyring >= 4.1.1            # Minimum version 4.1.1
+#coverage != 3.5             # Version Exclusion. Anything except version 3.5
+#Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
 #
 ###### Refer to other requirements files ######
--r other-requirements.txt
+#-r other-requirements.txt
 #
 #
 ###### A particular file ######
-./downloads/numpy-1.9.2-cp34-none-win32.whl
-http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+#./downloads/numpy-1.9.2-cp34-none-win32.whl
+#http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
 #
 ###### Additional Requirements without Version Specifiers ######
 #   Same as 1st section, just here to show that you can put things in any order.
-rejected
-green
+#rejected
+#green
 #
 
-SomeProject1
+#SomeProject1
 SomeProject2 == 1.3
-SomeProject3 >=1.*,!=2.0
-SomeProject4[foo, bar]
-SomeProject5~=1.4.2
+#SomeProject3 >=1.*,!=2.0
+#SomeProject4[foo, bar]
+#SomeProject5~=1.4.2
 SomeProject6 ==5.4 ; python_version < '3.8'
-SomeProject7; sys_platform == 'win32'
-SomeProject8 == 1.*
-SomeProject9 @ file:///somewhere/...
-SomeProject10 >= 1.2 --global-option="--no-user-cfg" \
-                  --install-option="--prefix='/usr/local'" \
-                  --install-option="--no-compile"
+#SomeProject7; sys_platform == 'win32'
+#SomeProject8 == 1.*
+#SomeProject9 @ file:///somewhere/...
+#SomeProject10 >= 1.2 --global-option="--no-user-cfg" \
+#                  --install-option="--prefix='/usr/local'" \
+#                  --install-option="--no-compile"
 SomeProject11 == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
-                  --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
+#                  --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
 
-requests != 2.12.3,>2.12.1
-requests [security,tests] >= 2.8.1, != 2.8.2 ; python_version < "2.7"
+#requests != 2.12.3,>2.12.1
+#requests [security,tests] >= 2.8.1, != 2.8.2 ; python_version < "2.7"
 
-FooProject1 >1.0
-FooProject2 < 1.2
-FooProject3 <= 1.3
-FooProject4 >= 1.4
+#FooProject1 >1.0
+#FooProject2 < 1.2
+#FooProject3 <= 1.3
+#FooProject4 >= 1.4
 FooProject5 == 1.5
-FooProject6 != 1.6
-FooProject7 ~= 1.7
-FooProject8 > 1.8.*
-FooProject9 > 2.0.*, !=2.1
+#FooProject6 != 1.6
+#FooProject7 ~= 1.7
+#FooProject8 > 1.8.*
+#FooProject9 > 2.0.*, !=2.1
 -e https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0#egg=my-git-package
 git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0#egg=my-git-package
 git-for-pip-example @ git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0

--- a/cli/tests/fixtures/requirements.txt
+++ b/cli/tests/fixtures/requirements.txt
@@ -127,5 +127,5 @@ happybase==1.2.0
 thriftpy2==0.4.12
 beautifulsoup4==4.9.3
 livy==0.7.3
-celery[redis]==1.2.3
+celery[redis]==5.0.5
 zope.interface == 5.4.0

--- a/cli/tests/fixtures/requirements.txt
+++ b/cli/tests/fixtures/requirements.txt
@@ -127,4 +127,5 @@ happybase==1.2.0
 thriftpy2==0.4.12
 beautifulsoup4==4.9.3
 livy==0.7.3
+celery[redis]==1.2.3
 zope.interface == 5.4.0


### PR DESCRIPTION
# Overview

Python packages sometimes have extras that are specified with square brackets after the dependency (i.e., `requests[security]>=2.27.1`). Phylum's CLI needs to property parse these dependencies.

## Checklist

- [x] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?

## Issue

Fixes #267
