### PR TITLE
fix: Parse package extras in Python requirements.txt files

### DIFF
--- a/cli/src/lockfiles/parsers/mod.rs
+++ b/cli/src/lockfiles/parsers/mod.rs
@@ -2,13 +2,13 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take, take_until},
     character::{
-        complete::{alphanumeric1, line_ending, none_of, not_line_ending, space0},
+        complete::{line_ending, none_of, not_line_ending, space0},
         streaming::multispace0,
     },
-    combinator::{eof, opt, recognize, rest, verify},
-    error::{context, VerboseError},
-    multi::{count, many0, many1, many_till},
-    sequence::{delimited, pair, tuple},
+    combinator::{eof, opt, recognize},
+    error::{context, ParseError, VerboseError},
+    multi::{count, many1, many_till},
+    sequence::{delimited, tuple},
     AsChar, IResult,
 };
 
@@ -28,6 +28,17 @@ fn take_till_line_end(input: &str) -> Result<&str, &str> {
 
 fn take_till_blank_line(input: &str) -> Result<&str, &str> {
     recognize(alt((take_until("\n\n"), take_until("\r\n\r\n"))))(input)
+}
+
+/// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and
+/// trailing whitespace, returning the output of `inner`.
+fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(
+    inner: F,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    F: Fn(&'a str) -> IResult<&'a str, O, E>,
+{
+    delimited(space0, inner, space0)
 }
 
 type Result<T, U> = IResult<T, U, VerboseError<T>>;

--- a/cli/src/lockfiles/parsers/pypi.rs
+++ b/cli/src/lockfiles/parsers/pypi.rs
@@ -83,7 +83,8 @@ fn package(input: &str) -> Option<PackageDescriptor> {
                 v.trim_start_matches("-e").to_string(),
             ),
             None => {
-                let (version, name) = filter_pip_name(s).ok()?;
+                let (version, pkg) = filter_pip_name(s).ok()?;
+                let (_, name) = filter_package_name(pkg).ok()?;
                 (
                     name.to_string(),
                     version.trim_start_matches('@').to_string(),
@@ -135,6 +136,15 @@ mod test {
             Some(PackageDescriptor {
                 name: "requests".into(),
                 version: "2.27.1".into(),
+                package_type: PackageType::PyPi,
+            })
+        );
+
+        assert_eq!(
+            package("git-for-pip-example[PDF] @ git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0"),
+            Some(PackageDescriptor {
+                name: "git-for-pip-example".into(),
+                version: "git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0".into(),
                 package_type: PackageType::PyPi,
             })
         );

--- a/cli/src/lockfiles/parsers/pypi.rs
+++ b/cli/src/lockfiles/parsers/pypi.rs
@@ -3,7 +3,7 @@ use nom::{
     bytes::complete::{tag, take_until},
     character::complete::{alphanumeric1, char, not_line_ending},
     combinator::{opt, recognize, rest, verify},
-    multi::{many0, many1},
+    multi::{many0, many1, separated_list0},
     sequence::{delimited, pair, terminated},
 };
 use phylum_types::types::package::{PackageDescriptor, PackageType};
@@ -26,8 +26,12 @@ fn identifier(input: &str) -> Result<&str, &str> {
     ))(input)
 }
 
+fn identifier_list(input: &str) -> Result<&str, &str> {
+    recognize(separated_list0(char(','), ws(identifier)))(input)
+}
+
 fn package_extras(input: &str) -> Result<&str, &str> {
-    delimited(char('['), ws(identifier), char(']'))(input)
+    delimited(char('['), identifier_list, char(']'))(input)
 }
 
 fn filter_git_repo(input: &str) -> Result<&str, &str> {
@@ -122,6 +126,15 @@ mod test {
             Some(PackageDescriptor {
                 name: "celery".into(),
                 version: "5.0.5".into(),
+                package_type: PackageType::PyPi,
+            })
+        );
+
+        assert_eq!(
+            package("requests[security,socks]==2.27.1"),
+            Some(PackageDescriptor {
+                name: "requests".into(),
+                version: "2.27.1".into(),
                 package_type: PackageType::PyPi,
             })
         );

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -157,7 +157,7 @@ mod tests {
         let parser = PyRequirements::new(Path::new("tests/fixtures/requirements.txt")).unwrap();
 
         let pkgs = parser.parse().unwrap();
-        assert_eq!(pkgs.len(), 130);
+        assert_eq!(pkgs.len(), 131);
         assert_eq!(pkgs[0].name, "pyyaml");
         assert_eq!(pkgs[0].version, "5.4.1");
         assert_eq!(pkgs[0].package_type, PackageType::PyPi);

--- a/cli/tests/fixtures/requirements.txt
+++ b/cli/tests/fixtures/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML== 5.4.1
+Django[bcrypt]==4.0.4
 aihems == 0.0
 aiohttp == 3.7.4.post0
 airflow == 0.6


### PR DESCRIPTION
# Overview

This PR adjusts our parsing for `requirements.txt` files so that we ignore package extras (i.e., stuff in square brackets after the package name).

I've also added a new `ws` utility to the `parsers` module that makes eating whitepspace a bit easier. This utility was taken basically verbatim from `nom::recipes`, but I use `space0` instead of `multispace0` so that it doesn't eat newlines.

## Checklist

- [x] Does this PR have an associated issue?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?

## Issue

Fixes #267 
