### PR TITLE
Indicate version type in update notification

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -17,19 +17,20 @@ use phylum_cli::commands::{CommandResult, CommandValue, ExitCode};
 use phylum_cli::config::*;
 use phylum_cli::print::*;
 use phylum_cli::update;
+use phylum_cli::CURRENT_VERSION;
 use phylum_cli::{print_user_failure, print_user_success, print_user_warning};
 use phylum_types::types::common::JobId;
 use phylum_types::types::job::Action;
 
 /// Print a warning message to the user before exiting with exit code 0.
-pub fn exit_warn(message: impl AsRef<str>) -> ! {
+fn exit_warn(message: impl AsRef<str>) -> ! {
     warn!("{}", message.as_ref());
     print_user_warning!("Warning: {}", message.as_ref());
     process::exit(0)
 }
 
 /// Print an error to the user before exiting with exit code 1.
-pub fn exit_fail(message: impl AsRef<str>) -> ! {
+fn exit_fail(message: impl AsRef<str>) -> ! {
     error!("{}", message.as_ref());
     print_user_failure!("Error: {}", message.as_ref());
     process::exit(1)
@@ -37,7 +38,7 @@ pub fn exit_fail(message: impl AsRef<str>) -> ! {
 
 /// Exit with status code 1, and optionally print a message to the user and
 /// print error information.
-pub fn exit_error(error: Box<dyn std::error::Error>, message: impl AsRef<str>) -> ! {
+fn exit_error(error: Box<dyn std::error::Error>, message: impl AsRef<str>) -> ! {
     error!("{}: {:?}", message.as_ref(), error);
     print_user_failure!("Error: {} caused by: {}", message.as_ref(), error);
     process::exit(1)
@@ -99,8 +100,9 @@ async fn handle_commands() -> CommandResult {
         }
     }
 
-    if check_for_updates && update::needs_update(false).await {
-        print_update_message();
+    let prerelease = CURRENT_VERSION.contains('-');
+    if check_for_updates && update::needs_update(prerelease).await {
+        print_update_message(prerelease);
     }
 
     // For these commands, we want to just provide verbose help and exit if no

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,3 +20,6 @@ pub mod update;
 use test::logging;
 
 pub use reqwest::Error;
+
+/// Cargo crate version.
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -70,14 +70,21 @@ pub fn print_response<T>(
 }
 
 /// Prints a verbose message informing the user that an update is available.
-pub fn print_update_message() {
+pub fn print_update_message(prerelease: bool) {
+    // Indicate update granularity.
+    let version_text = if prerelease {
+        "version"
+    } else {
+        "stable version"
+    };
+
     eprintln!(
         "---------------- {} ----------------\n",
         Cyan.paint("Update Available")
     );
-    eprintln!("A new version of the Phylum CLI is available. Run");
+    eprintln!("A new {version_text} of the Phylum CLI is available. Run");
     eprintln!(
-        "\n\t{}\n\nto update to the latest version!\n",
+        "\n\t{}\n\nto update to the latest {version_text}!\n",
         Blue.paint("phylum update")
     );
     eprintln!("{:-^50}\n\n", "");

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -12,14 +12,12 @@ use zip::ZipArchive;
 use wiremock::MockServer;
 
 use crate::types::{GithubRelease, GithubReleaseAsset};
+use crate::CURRENT_VERSION;
 
 // Phylum's public key for Minisign.
 const PUBKEY: &str = "RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf";
 
 const GITHUB_URI: &str = "https://api.github.com";
-
-// For updates, we use the cargo version instead of git_version
-const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Check if a newer version of the client is available
 pub async fn needs_update(prerelease: bool) -> bool {


### PR DESCRIPTION
This patch clarifies the message about a new Phylum CLI version by
explicitly pointing out that a new *stable* version is available when
the user is currently running from an existing stable version.

Closes #125.
