### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - development
+      - main
     tags:
       - '*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-      - development
+      - main
   # Run weekly on the default branch to make sure it always builds with the latest rust release
   schedule:
     - cron: '30 5 * * 1'


### PR DESCRIPTION
This PR contains the few code changes that need to happen in order to change the default branch to `main`

Nothing depends on us, so it's pretty simple. If/when this is merged, I'll swap the default branch, update all other PRs to target `main`, and delete the `development` branch.