### PR TITLE
Create directory with mode 700 by default

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -179,7 +179,9 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
         {
             fs::set_permissions(&old_config_path, Permissions::from_mode(0o600))?;
         }
-        fs::create_dir_all(config_path.parent().unwrap())?;
+        let config_dir = config_path.parent().unwrap();
+        fs::create_dir_all(&config_dir)?;
+        fs::set_permissions(&config_dir, Permissions::from_mode(0o700))?;
         fs::rename(old_config_path, &config_path).unwrap();
     }
 

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -7,7 +7,6 @@ NC='\033[0m'
 # Don't continue after failure:
 set -eu
 
-config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/phylum"
 data_dir="${XDG_DATA_HOME:-${HOME}/.local/share}/phylum"
 completions_dir="${data_dir}/completions"
 bin_dir="${HOME}/.local/bin"
@@ -124,7 +123,7 @@ cleanup_pre_xdg() {
     sed -i'' "/^export PATH=\"\$HOME\/.phylum:\$PATH\"$/d" "${HOME}/.bashrc"
     sed -i'' "/^alias ph='phylum'$/d" "${HOME}/.bashrc"
 
-    # Remove old entries from bashrc.
+    # Remove old entries from zshrc.
     sed -i'' "/^fpath+=(\"\$HOME\/.phylum\/completions\")$/d" "${HOME}/.zshrc"
     sed -i'' "/^export PATH=\"\$HOME\/.phylum:\$PATH\"$/d" "${HOME}/.zshrc"
     sed -i'' "/^alias ph='phylum'$/d" "${HOME}/.zshrc"

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -102,7 +102,7 @@ copy_files() {
     bin_name="phylum"
 
     # Ensure binary directory exists.
-    mkdir -p "${bin_dir}"
+    mkdir -pm 700 "${bin_dir}"
 
     install -m 0755 "${bin_name}" "${bin_dir}/${bin_name}"
     if [ "${platform}" = "macos" ]; then
@@ -112,7 +112,7 @@ copy_files() {
     fi
 
     # Copy completions over
-    mkdir -p "${data_dir}"
+    mkdir -pm 700 "${data_dir}"
     cp -a "completions" "${data_dir}/"
     success "Copied completions to ${completions_dir}"
 }


### PR DESCRIPTION
Following the XDG spec, new directories will now be created with the
mode 700 set instead of 755.

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

> If, when attempting to write a file, the destination directory is
> non-existent an attempt should be made to create it with permission
> 0700. If the destination directory exists already the permissions
> should not be changed. The application should be prepared to handle
> the case where the file could not be written, either because the
> directory was non-existent and could not be created, or for any other
> reason. In such case it may choose to present an error message to the
> user.

Closes #285.
