### PR TITLE
Add `--project` option to `phylum history`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -43,6 +43,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                     arg!(-v --verbose "Increase verbosity of api response."),
                     arg!(--filter <filter>).required(false).help(FILTER_ABOUT),
                     arg!(-j --json "Produce output in json format (default: false)"),
+                    arg!(-p --project <project_name> "Project name used to filter jobs").required(false),
                 ])
                 .subcommand(
                     Command::new("project")
@@ -51,6 +52,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                             arg!(<project_name>).required(false),
                             arg!(<job_id>).required(false),
                         ])
+                        .hide(true)
                 )
         )
         .subcommand(

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -139,7 +139,10 @@ pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
                 Blue.paint("phylum analyze <lock_file>")
             );
         } else {
-            println!("Projects and most recent runs\n",);
+            if pretty_print {
+                println!("Projects and most recent runs\n",);
+            }
+
             print_response(&resp, pretty_print, None);
         }
     }

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -99,22 +99,40 @@ pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         if let Some(project_name) = project_name {
             if project_job_id.is_none() {
+                print_user_warning!(
+                    "`phylum history project <PROJECT>` is deprecated, \
+                    use `phylum history --project <PROJECT>` instead"
+                );
+
                 let resp = api.get_project_details(project_name).await;
                 print_response(&resp, pretty_print, None);
             } else {
+                print_user_warning!(
+                    "`phylum history project <PROJECT> <JOB_ID>` is deprecated, \
+                    use `phylum history <JOB_ID>` instead"
+                );
+
                 // TODO The original code had unwrap in it above. This needs to
                 // be refactored in general for better flow
                 let job_id = resolve_job_id(project_job_id.expect("No job id found"))?;
                 action = get_job_status(api, &job_id, verbose, pretty_print, display_filter).await
             }
         } else {
+            print_user_warning!(
+                "`phylum history project` is deprecated, use `phylum project` instead"
+            );
+
             get_project_list(api, pretty_print).await;
         }
     } else if matches.is_present("JOB_ID") {
         let job_id = resolve_job_id(matches.value_of("JOB_ID").expect("No job id found"))?;
         action = get_job_status(api, &job_id, verbose, pretty_print, display_filter).await;
+    } else if let Some(project) = matches.value_of("project") {
+        let resp = api.get_project_details(project).await.map(|r| r.jobs);
+        print_response(&resp, pretty_print, None);
     } else {
         let resp = api.get_status().await;
+
         if let Err(Some(StatusCode::NOT_FOUND)) = resp.as_ref().map_err(|e| e.status()) {
             print_user_warning!(
                 "No results found. Submit a lockfile for processing:\n\n\t{}\n",

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -159,12 +159,19 @@ impl Renderable for ProjectDetailsResponse {
 
 impl Renderable for AllJobsStatusResponse {
     fn render(&self) -> String {
-        let mut runs = format!(
-            "Last {} runs of {} submitted\n\n",
-            self.count, self.total_jobs
-        );
+        format!(
+            "Last {} runs of {} submitted\n\n{}",
+            self.count,
+            self.total_jobs,
+            self.jobs.render()
+        )
+    }
+}
 
-        for (i, job) in self.jobs.iter().enumerate() {
+impl Renderable for Vec<JobDescriptor> {
+    fn render(&self) -> String {
+        let mut jobs = String::new();
+        for (i, job) in self.iter().enumerate() {
             let mut state = Green.paint("PASS").to_string();
             let score = format!("{:>3}", (job.score * 100.0) as u32);
             let mut colored_score = Green.paint(&score).to_string();
@@ -197,27 +204,12 @@ impl Renderable for AllJobsStatusResponse {
                 "             {}{:>62}{:>29} dependencies",
                 job.ecosystem, "Crit:-/High:-/Med:-/Low:-", job.num_dependencies
             );
-            runs.push_str(first_line.as_str());
-            runs.push_str(second_line.as_str());
-            runs.push_str(third_line.as_str());
-            runs.push_str("\n\n");
+            jobs.push_str(first_line.as_str());
+            jobs.push_str(second_line.as_str());
+            jobs.push_str(third_line.as_str());
+            jobs.push_str("\n\n");
         }
-
-        runs
-    }
-}
-
-impl Renderable for JobDescriptor {
-    fn render(&self) -> String {
-        let mut res = format!(
-            "Job id: {}\n====================================\n",
-            self.job_id
-        );
-
-        for p in &self.packages {
-            res.push_str(&p.render());
-        }
-        res
+        jobs.trim_end().into()
     }
 }
 

--- a/cli/src/summarize.rs
+++ b/cli/src/summarize.rs
@@ -4,8 +4,9 @@ use std::str::FromStr;
 use ansi_term::Color::*;
 use chrono::NaiveDateTime;
 use color::Color;
-use phylum_types::types::job::JobStatusResponse;
-use phylum_types::types::job::{AllJobsStatusResponse, CancelJobResponse};
+use phylum_types::types::job::{
+    AllJobsStatusResponse, CancelJobResponse, JobDescriptor, JobStatusResponse,
+};
 use phylum_types::types::package::*;
 use phylum_types::types::project::*;
 use prettytable::*;
@@ -331,6 +332,12 @@ impl Summarize for PackageStatusExtended {
             println!("\n Issues:");
             issues_table.printstd();
         }
+    }
+}
+
+impl Summarize for Vec<JobDescriptor> {
+    fn summarize(&self, _filter: Option<Filter>) {
+        println!("Last {} runs\n\n{}", self.len(), self.render());
     }
 }
 


### PR DESCRIPTION
This removes the `phylum history project` subcommand from the
documentation and prints a warninng when running it without the `--json`
flag.

Users are instructed to instead use the `phylum project` command.

Closes #277.