### PR TITLE
Hide the --prerelease arg in `phylum update`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -33,7 +33,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                 .about("Check for a new release of the Phylum CLI tool and update if one exists")
                 .arg(arg!(
                     -p --prerelease "Update to the latest prerelease (vs. stable, default: false)"
-                ))
+                ).hide(true))
         )
         .subcommand(
             Command::new("history")


### PR DESCRIPTION
This PR hides the `--prerelease` argument of `phylum update`.

I did not remove the help doc for argument because it is still available with tab completion (in zsh and fish):

```
❯ phylum update -<TAB>     
--help        -h  -- Print help information                                                                                                                                                                                                                                                              
--prerelease  -p  -- Update to the latest prerelease (vs. stable, default: false)                                                                                                                                                                                                                        
```

Fixes #301