### PR TITLE
fix(install): Use printf instead of echo

### DIFF
--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -68,7 +68,7 @@ autoload -U compinit && compinit" \
     > "${phylum_rc}"
 
     if ! grep -q "source ${phylum_rc}" "${rc_path}"; then
-        echo "\nsource ${phylum_rc}" >> "${rc_path}"
+        printf "\nsource %s\n" "${phylum_rc}" >> "${rc_path}"
     fi
 
     success "Completions are enabled for zsh."
@@ -89,7 +89,7 @@ source ${completions_dir}/phylum.bash" \
     > "${phylum_rc}"
 
     if ! grep -q "source ${phylum_rc}" "${rc_path}"; then
-        echo "\nsource ${phylum_rc}" >> "${rc_path}"
+        printf "\nsource %s\n" "${phylum_rc}" >> "${rc_path}"
     fi
 
     success "Completions are enabled for bash."


### PR DESCRIPTION
Using escape sequences in echo relies on XSI-conformance in addition to
POSIX conformance. Using printf is more portable.

Ref: https://github.com/koalaman/shellcheck/wiki/SC2028
Ref: https://www.man7.org/linux/man-pages/man1/echo.1p.html