### PR TITLE
Add `--bearer` parameter to `phylum auth token`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -98,7 +98,11 @@ pub fn app<'a>() -> clap::Command<'a> {
                 .subcommand(Command::new("register").about("Register a new account"))
                 .subcommand(Command::new("login").about("Login to an existing account"))
                 .subcommand(Command::new("status").about("Return the current authentication status"))
-                .subcommand(Command::new("token").about("Return the current authentication token"))
+                .subcommand(
+                    Command::new("token")
+                    .about("Return the current authentication token")
+                    .arg(arg!(-b --bearer "Output the short-lived bearer token for the Phylum API"))
+                )
         )
         .subcommand(
             Command::new("ping").about("Ping the remote system to verify it is available")


### PR DESCRIPTION
This patch adds the new `--bearer` parameter which will print the
short-lived API access token rather than the long-lived refresh token.

Using this new command it should be much easier to make `curl` requests
to the phylum API, without having to handle login manually.

Closes #319.
