### PR TITLE
Simplify the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,7 @@
-# Overview
-
-Provide information on what this PR does and any context necessary to understand its implementation.
 
 ## Checklist
 
-- [ ] Does this PR have an associated issue?
+- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
 - [ ] Have you ensured that you have met the expected acceptance criteria?
 - [ ] Have you created sufficient tests?
 - [ ] Have you updated all affected documentation?
-
-## Issue
-
-What issue(s) does this PR close? Use the `closes #<issueNum>` here.


### PR DESCRIPTION
This patch removes the boilerplate from our pull request template. What
is left is only the checklist, which is important to ensure that nothing
is missed before a PR is merged.

If developers are using detailed commit messages (like this one), PRs
will automatically be created with the detailed commit message followed
by the checklist, which is exactly how we want them.

Fix #321.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?