### PR TITLE
chore: refresh the release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-# Releasing a new version of the CLI is initiated with a tag and completed with
-# the Release workflow in CI. Run this script from the `main` branch and follow
-# the prompts to initiate a new release. There are a few manual steps that are
-# provided at the end. This is to ensure a chance to review the automated work
-# and not accidentally release a new version.
+# Releasing a new version of the CLI is initiated with a tag and completed with the
+# Release workflow in CI. Run this script from the `main` branch and follow the prompts
+# to initiate a new release. There is a manual step required at the end. This is to
+# ensure a chance to review the automated work and not accidentally release a new version.
+
+set -eu
 
 LATEST=$(git describe --tags --abbrev=0 --exclude="*-rc*")
 printf "Latest release: %s\n\n" "${LATEST}"
@@ -30,19 +31,22 @@ git add CHANGELOG
 git add cli/Cargo.toml
 
 commit_message="Bump to ${TAG} - ${changelog}"
-printf "\nFiles to be added and committed with message: \"%s\"\n" "${commit_message}"
+printf "\nFiles to be added and committed with message: \"%s\"\n\n" "${commit_message}"
 git status
 
-printf "Press enter to proceed with the commit ..."
+printf "Press enter to proceed with the commit and tag ..."
 read -r
 git commit -m "${commit_message}"
+git tag --sign -m "${TAG} - ${changelog}" "${TAG}"
+
+printf "\nOutput of the command: git show %s\n" "${TAG}"
+git show "${TAG}"
 
 cat << __instructions__
 
-The automation is done. Run the following commands manually,
-in sequence, to tag the release and push the changes:
+The automation is done.
+Run the following command manually to push the changes:
 
-    git tag --sign -m "${TAG} - ${changelog}" ${TAG}
     git push origin main ${TAG}
 
 __instructions__


### PR DESCRIPTION
While releasing the last handful of CLI versions it became clear that
the release script used to do so could use a refresh. For one, it
automated _everything_, which felt risky and most of the time the script
would be aborted before it could tag and push the changes. Another
minor annoyance was not remembering the format of the version or
changelog entry. Additionally, the git log summary would only show from
the last tag, not taking into account that the last tag could be from a
pre-release.

These issues have been addressed, along with some minor
refactoring and formatting. It is still just a basic shell script and
there could certainly be better ways yet.