### PR TITLE
Automatically run `cargo update` in a workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -1,0 +1,27 @@
+---
+name: Test
+
+on:
+  workflow_dispatch:
+  # Run every Monday
+  schedule:
+    - cron: '30 5 * * 1'
+
+jobs:
+  cargo-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Cargo update
+        run: cargo update
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: Bump dependencies"
+          body: |
+            Bump dependencies in Cargo.lock for all SemVer-compatible updates.
+          branch: auto-cargo-update

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -1,5 +1,5 @@
 ---
-name: Test
+name: Update Deps
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: Bump dependencies"
+          commit-message: "build: Bump dependencies"
           body: |
             Bump dependencies in Cargo.lock for all SemVer-compatible updates.
           branch: auto-cargo-update


### PR DESCRIPTION
This runs a basic `cargo update` in a Github Action and creates a PR
with any changes. Combined with limiting Dependabot to major version
updates, this should resolve concerns about too many PRs and being too
strict in our Cargo.toml files.

Ref: Discussion on #325