### PR TITLE
fix: Resolve project create errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#c9960ef94be75e5829d62eb3e2937e7e77dbc141"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#653f5f642b19542b07d57114ef2e1b688e9692b1"
 dependencies = [
  "chrono",
  "log",

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -5,6 +5,8 @@ use anyhow::anyhow;
 use chrono::Local;
 use uuid::Uuid;
 
+use phylum_types::types::user_settings::Threshold;
+
 use super::{CommandResult, ExitCode};
 use crate::api::PhylumApi;
 use crate::config::{get_current_project, save_config, ProjectConfig, PROJ_CONF_FILE};
@@ -159,12 +161,13 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
                 x => x.to_string(),
             };
 
-            user_settings.set_threshold(
-                project_details.id.clone(),
-                name,
-                threshold,
-                action.to_string(),
-            );
+            let threshold = Threshold {
+                threshold: threshold as f32 / 100.,
+                active: threshold != 0,
+                action: action.into(),
+            };
+
+            user_settings.set_threshold(project_details.id.clone(), name, threshold);
         }
 
         let resp = api.put_user_settings(&user_settings).await;


### PR DESCRIPTION
This is the quickest way to fix #331. Even in staging, the API is not
currently accepting the `group_name` parameter for project creation and
this is causing an error (which is getting misrepresented as being about
the characters in the project name).
