### PR TITLE
Fix yarn lockfile parsing with patched deps

### DIFF
--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -91,16 +91,24 @@ impl Parseable for YarnLock {
             let resolution = package
                 .get(&"resolution".into())
                 .and_then(YamlValue::as_str)
+                .filter(|s| !s.is_empty())
                 .ok_or_else(|| "Failed to parse resolution field in yarn lock file".to_owned())?;
 
             // Ignore workspace-local dependencies like project itself ("project@workspace:.").
-            if resolution.contains("@workspace:") {
+            if resolution[1..].contains("@workspace:") {
                 continue;
             }
 
-            let (name, _version) = resolution
-                .rsplit_once("@npm:")
-                .ok_or_else(|| "Failed to parse name in yarn lock file".to_owned())?;
+            let (name, _version) = if let Some(index) = resolution[1..].find("@patch:") {
+                // Extract npm version from patched dependencies.
+                resolution[index + "@patch:".len() + 1..]
+                    .rsplit_once("@npm")
+                    .ok_or_else(|| "Failed to parse patch in yarn lock file".to_owned())?
+            } else {
+                resolution
+                    .rsplit_once("@npm")
+                    .ok_or_else(|| "Failed to parse name in yarn lock file".to_owned())?
+            };
 
             let version = package
                 .get(&"version".into())
@@ -198,7 +206,7 @@ mod tests {
 
         let pkgs = parser.parse().unwrap();
 
-        assert_eq!(pkgs.len(), 50);
+        assert_eq!(pkgs.len(), 51);
 
         let expected_pkgs = [
             PackageDescriptor {
@@ -214,6 +222,11 @@ mod tests {
             PackageDescriptor {
                 name: "statuses".into(),
                 version: "1.5.0".into(),
+                package_type: PackageType::Npm,
+            },
+            PackageDescriptor {
+                name: "@fake/package".into(),
+                version: "1.2.3".into(),
                 package_type: PackageType::Npm,
             },
         ];

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -99,15 +99,14 @@ impl Parseable for YarnLock {
                 continue;
             }
 
-            let (name, _version) = if let Some(index) = resolution[1..].find("@patch:") {
+            let (name, _version) = match resolution[1..].split_once("@patch:") {
                 // Extract npm version from patched dependencies.
-                resolution[index + "@patch:".len() + 1..]
+                Some((_, patch)) => patch
                     .rsplit_once("@npm")
-                    .ok_or_else(|| "Failed to parse patch in yarn lock file".to_owned())?
-            } else {
-                resolution
+                    .ok_or_else(|| "Failed to parse patch in yarn lock file".to_owned())?,
+                None => resolution
                     .rsplit_once("@npm")
-                    .ok_or_else(|| "Failed to parse name in yarn lock file".to_owned())?
+                    .ok_or_else(|| "Failed to parse name in yarn lock file".to_owned())?,
             };
 
             let version = package

--- a/cli/tests/fixtures/yarn.lock
+++ b/cli/tests/fixtures/yarn.lock
@@ -463,3 +463,10 @@ __metadata:
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
   languageName: node
   linkType: hard
+
+"@fake/package@patch:@fake/package@npm:1.2.3#.yarn/patches/@fake-package-npm-1.2.3-0deadbeef0::locator=root%40workspace%3A.":
+  version: 1.2.3
+  resolution: "@fake/package@patch:@fake/package@npm%3A1.2.3#.yarn/patches/@fake-package-npm-1.2.3-0deadbeef0::version=1.2.3&hash=ff00ff&locator=root%40workspace%3A."
+  checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
+  languageName: node
+  linkType: hard


### PR DESCRIPTION
Yarn allows patching dependencies, which produces a local patch file
applied on top of a dependency. Before this patch, this would cause an
error in the lockfile parser.

To provide the most value possible, this patch adds support for parsing
these patched dependencies and extracts the original package, while
discarding the local patch information. This allows analyzing the
unpatched dependency for vulnerabilities.

Closes #342.
