### PR TITLE
Use anyhow instead of boxed errors for parsers

### DIFF
--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::path::Path;
 
+use anyhow::anyhow;
 use phylum_types::ecosystems::maven::{Dependency, Plugin, Project};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
@@ -20,8 +21,8 @@ impl Parseable for GradleDeps {
 
     /// Parses `gradle-dependencies.txt` files into a vec of packages
     fn parse(&self) -> ParseResult {
-        let (_, entries) =
-            gradle_dep::parse(&self.0).map_err(|_e| "Failed to parse requirements file")?;
+        let (_, entries) = gradle_dep::parse(&self.0)
+            .map_err(|_e| anyhow!("Failed to parse requirements file"))?;
         Ok(entries)
     }
 }

--- a/cli/src/lockfiles/mod.rs
+++ b/cli/src/lockfiles/mod.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::io;
 use std::marker::Sized;
 use std::path::Path;
@@ -18,7 +17,7 @@ pub use javascript::{PackageLock, YarnLock};
 pub use python::{PipFile, Poetry, PyRequirements};
 pub use ruby::GemLock;
 
-pub type ParseResult = Result<Vec<PackageDescriptor>, Box<dyn Error>>;
+pub type ParseResult = anyhow::Result<Vec<PackageDescriptor>>;
 
 pub trait Parseable {
     fn new(filename: &Path) -> Result<Self, io::Error>

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::{fs, io};
 
+use anyhow::anyhow;
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 use serde::Deserialize;
 use serde_json::Value;
@@ -24,7 +25,7 @@ impl Parseable for PyRequirements {
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self) -> ParseResult {
         let (_, entries) =
-            pypi::parse(&self.0).map_err(|_e| "Failed to parse requirements file")?;
+            pypi::parse(&self.0).map_err(|_e| anyhow!("Failed to parse requirements file"))?;
         Ok(entries)
     }
 }

--- a/cli/src/lockfiles/ruby.rs
+++ b/cli/src/lockfiles/ruby.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::path::Path;
 
+use anyhow::anyhow;
+
 use super::parsers::gem;
 use crate::lockfiles::{ParseResult, Parseable};
 
@@ -16,7 +18,8 @@ impl Parseable for GemLock {
 
     /// Parses `Gemfile.lock` files into a vec of packages
     fn parse(&self) -> ParseResult {
-        let (_, entries) = gem::parse(&self.0).map_err(|_e| "Failed to parse gem lock file")?;
+        let (_, entries) =
+            gem::parse(&self.0).map_err(|_e| anyhow!("Failed to parse gem lock file"))?;
         Ok(entries)
     }
 }

--- a/cli/src/lockfiles/ruby.rs
+++ b/cli/src/lockfiles/ruby.rs
@@ -1,7 +1,9 @@
 use std::io;
 use std::path::Path;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
+use nom::error::convert_error;
+use nom::Finish;
 
 use super::parsers::gem;
 use crate::lockfiles::{ParseResult, Parseable};
@@ -18,8 +20,11 @@ impl Parseable for GemLock {
 
     /// Parses `Gemfile.lock` files into a vec of packages
     fn parse(&self) -> ParseResult {
-        let (_, entries) =
-            gem::parse(&self.0).map_err(|_e| anyhow!("Failed to parse gem lock file"))?;
+        let data = self.0.as_str();
+        let (_, entries) = gem::parse(data)
+            .finish()
+            .map_err(|e| anyhow!(convert_error(data, e)))
+            .context("Failed to parse gem lock file")?;
         Ok(entries)
     }
 }


### PR DESCRIPTION
We make heavy use of the anyhow crate everywhere else and it makes sense
to use it in the parsers as well.

This is just the first of a series of refactors to the parsers that I
hope to make in order to improve their ergonomics and assist in
implementing a `parse` subcommand (Ref: #346)