### PR TITLE
Add better error for missing lockfiles

### DIFF
--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -176,7 +176,7 @@ pub async fn handle_submission(
             .value_of("LOCKFILE")
             .ok_or_else(|| anyhow!("Lockfile not found"))?;
         let res = get_packages_from_lockfile(lockfile)
-            .ok_or_else(|| anyhow!("Unable to locate any valid package in package lockfile"))?;
+            .context("Unable to locate any valid package in package lockfile")?;
 
         packages = res.0;
         request_type = res.1;


### PR DESCRIPTION
The existing error for missing lockfiles was somewhat opaque, making it
difficult for users to figure out how to resolve this issue.

Before:

```
[2022-05-04T21:04:44Z WARN  phylum_cli::commands::lock_files] Attempting to obtain packages from unrecognized lockfile type: reqiurements.txt
[2022-05-04T21:04:44Z ERROR phylum] Execution failed: Unable to locate any valid package in package lockfile
❗ Error: Execution failed caused by: Unable to locate any valid package in package lockfile
```

After:

```
[2022-05-05T19:44:04Z ERROR phylum] Execution failed: Lockfile "/tmp/xxx" does not exist
❗ Error: Execution failed caused by: Lockfile "/tmp/xxx" does not exist
```

Closes #347.