### PR TITLE
Remove redundancy from lock_files.rs

### DIFF
--- a/cli/src/commands/lock_files.rs
+++ b/cli/src/commands/lock_files.rs
@@ -12,11 +12,23 @@ pub fn try_get_packages(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageT
         path.to_string_lossy()
     );
 
-    let packages = YarnLock::new(path)?.parse();
-    if let Some(packages) = packages.ok().filter(|pkgs| !pkgs.is_empty()) {
-        log::debug!("Submitting file as type yarn lock");
-        return Ok((packages, PackageType::Npm));
+    fn xxx<T: Parseable>(path: &Path) -> Option<(Vec<PackageDescriptor>, PackageType)> {
+        let packages = T::new(path).ok()?.parse();
+        packages
+            .ok()
+            .filter(|pkgs| !pkgs.is_empty())
+            .map(|pkgs| (pkgs, PackageType::Npm))
     }
+
+    if let Some(packages) = xxx::<YarnLock>(path) {
+        log::debug!("Submitting file as type yarn lock");
+        return Ok(packages);
+    }
+    // let packages = YarnLock::new(path)?.parse();
+    // if let Some(packages) = packages.ok().filter(|pkgs| !pkgs.is_empty()) {
+    //     log::debug!("Submitting file as type yarn lock");
+    //     return Ok((packages, PackageType::Npm));
+    // }
 
     let packages = PackageLock::new(path)?.parse();
     if let Some(packages) = packages.ok().filter(|pkgs| !pkgs.is_empty()) {

--- a/cli/src/lockfiles/csharp.rs
+++ b/cli/src/lockfiles/csharp.rs
@@ -80,6 +80,10 @@ impl Parseable for CSProj {
         let parsed = Project::deserialize(&mut de)?;
         Ok(parsed.into())
     }
+
+    fn package_type() -> PackageType {
+        PackageType::Nuget
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -30,6 +30,10 @@ impl Parseable for GradleDeps {
             .context("Failed to parse requirements file")?;
         Ok(entries)
     }
+
+    fn package_type() -> PackageType {
+        PackageType::Maven
+    }
 }
 
 impl Parseable for Pom {
@@ -136,11 +140,15 @@ impl Parseable for Pom {
                             &dep.artifact_id.clone().unwrap_or_default()
                         ),
                         version: s.into(),
-                        package_type: PackageType::Maven,
+                        package_type: Self::package_type(),
                     })
                 })
             })
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::Maven
     }
 }
 

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -36,7 +36,7 @@ impl Parseable for PackageLock {
             let pkg = PackageDescriptor {
                 name,
                 version,
-                package_type: PackageType::Npm,
+                package_type: Self::package_type(),
             };
             Ok(pkg)
         };
@@ -60,6 +60,10 @@ impl Parseable for PackageLock {
         } else {
             Err(anyhow!("Failed to find dependencies"))
         }
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::Npm
     }
 }
 
@@ -156,13 +160,17 @@ impl Parseable for YarnLock {
             };
 
             packages.push(PackageDescriptor {
-                package_type: PackageType::Npm,
+                package_type: Self::package_type(),
                 name: name.to_owned(),
                 version,
             });
         }
 
         Ok(packages)
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::Npm
     }
 }
 

--- a/cli/src/lockfiles/mod.rs
+++ b/cli/src/lockfiles/mod.rs
@@ -3,6 +3,7 @@ use std::marker::Sized;
 use std::path::Path;
 
 use phylum_types::types::package::PackageDescriptor;
+use phylum_types::types::package::PackageType;
 
 mod csharp;
 mod java;
@@ -23,5 +24,8 @@ pub trait Parseable {
     fn new(filename: &Path) -> Result<Self, io::Error>
     where
         Self: Sized;
+
     fn parse(&self) -> ParseResult;
+
+    fn package_type() -> PackageType;
 }

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -33,6 +33,10 @@ impl Parseable for PyRequirements {
             .context("Failed to parse requirements file")?;
         Ok(entries)
     }
+
+    fn package_type() -> PackageType {
+        PackageType::PyPi
+    }
 }
 
 impl Parseable for PipFile {
@@ -83,7 +87,7 @@ impl Parseable for PipFile {
                         Ok(PackageDescriptor {
                             name: k.as_str().to_string().to_lowercase(),
                             version: v.replace("==", "").trim().to_string(),
-                            package_type: PackageType::PyPi,
+                            package_type: Self::package_type(),
                         })
                     }),
                     None => {
@@ -93,6 +97,10 @@ impl Parseable for PipFile {
                 }
             })
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::PyPi
     }
 }
 
@@ -128,6 +136,10 @@ impl Parseable for Poetry {
             })
             .map(PackageDescriptor::from)
             .collect())
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::PyPi
     }
 }
 

--- a/cli/src/lockfiles/ruby.rs
+++ b/cli/src/lockfiles/ruby.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::{anyhow, Context};
 use nom::error::convert_error;
 use nom::Finish;
+use phylum_types::types::package::PackageType;
 
 use super::parsers::gem;
 use crate::lockfiles::{ParseResult, Parseable};
@@ -26,6 +27,10 @@ impl Parseable for GemLock {
             .map_err(|e| anyhow!(convert_error(data, e)))
             .context("Failed to parse gem lock file")?;
         Ok(entries)
+    }
+
+    fn package_type() -> PackageType {
+        PackageType::RubyGems
     }
 }
 


### PR DESCRIPTION
This patch attempts to reduce the maintenance overhead of changing the
`lock_files.rs` by providing macros and helper functions to generate the
necessary output rather than relying on repeating the same code over and
over.