### PR TITLE
Improve handling of HTTP JSON error responses

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -201,6 +201,7 @@ impl PhylumApi {
 
     /// Put updated user settings
     pub async fn put_user_settings(&mut self, settings: &UserSettings) -> Result<bool> {
+        // TODO
         self.client
             .put(endpoints::put_user_settings(&self.api_uri))
             .json(&settings)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -201,13 +201,7 @@ impl PhylumApi {
 
     /// Put updated user settings
     pub async fn put_user_settings(&mut self, settings: &UserSettings) -> Result<bool> {
-        // TODO
-        self.client
-            .put(endpoints::put_user_settings(&self.api_uri))
-            .json(&settings)
-            .send()
-            .await?
-            .json::<UserSettings>()
+        self.put::<UserSettings, _>(endpoints::put_user_settings(&self.api_uri), &settings)
             .await?;
         Ok(true)
     }

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -285,5 +285,4 @@ pub struct UserInfo {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponseError {
     error: String,
-    error_description: String,
 }

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -155,10 +155,13 @@ pub async fn fetch_oidc_server_settings(auth_info: &AuthInfo) -> Result<OidcServ
         .header("Accept", "application/json")
         .timeout(Duration::from_secs(5))
         .send()
-        .await?
-        .json::<OidcServerSettings>()
         .await?;
-    Ok(response)
+
+    if let Err(error) = response.error_for_status_ref() {
+        Err(anyhow!(response.text().await?)).context(error)
+    } else {
+        Ok(response.json::<OidcServerSettings>().await?)
+    }
 }
 
 fn build_grant_type_auth_code_post_body(
@@ -210,10 +213,26 @@ pub async fn acquire_tokens(
         .timeout(Duration::from_secs(5))
         .form(&body)
         .send()
-        .await?
-        .json::<TokenResponse>()
         .await?;
-    Ok(response)
+
+    if let Err(error) = response.error_for_status_ref() {
+        let body = response.text().await?;
+        let mut err = Err(anyhow!(body.clone())).context(error);
+
+        // Provide additional detail when user requires activation.
+        if serde_json::from_str::<ResponseError>(&body)
+            .map_or(false, |response| response.error == "not_allowed")
+        {
+            err = err.context(
+                "Your account is not authorized to perform this action. \
+                Please contact Phylum support.",
+            );
+        }
+
+        err
+    } else {
+        Ok(response.json::<TokenResponse>().await?)
+    }
 }
 
 pub async fn refresh_tokens(
@@ -260,4 +279,11 @@ pub struct UserInfo {
     pub family_name: Option<String>,
     pub preferred_username: Option<String>,
     pub email_verified: Option<bool>,
+}
+
+/// Keycloak error response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResponseError {
+    error: String,
+    error_description: String,
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -102,10 +102,7 @@ pub async fn handle_auth(
                 print_user_success!("{}", "User successfuly regsistered");
                 Ok(ExitCode::Ok.into())
             }
-            Err(error) => Err(anyhow!(
-                "User registration failed: {}",
-                error.root_cause().to_string()
-            )),
+            Err(error) => Err(error).context("User registration failed"),
         }
     } else if matches.subcommand_matches("login").is_some() {
         match handle_auth_login(config, config_path).await {
@@ -113,10 +110,7 @@ pub async fn handle_auth(
                 print_user_success!("{}", "User login successful");
                 Ok(ExitCode::Ok.into())
             }
-            Err(error) => Err(anyhow!(
-                "User login failed: {}",
-                error.root_cause().to_string()
-            )),
+            Err(error) => Err(error).context("User login failed"),
         }
     } else if matches.subcommand_matches("status").is_some() {
         handle_auth_status(config, timeout, ignore_certs).await

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -77,7 +77,7 @@ async fn http_get_json<T: DeserializeOwned>(url: &str) -> anyhow::Result<T> {
     if let Err(error) = response.error_for_status_ref() {
         Err(anyhow!(response.text().await?)).context(error)
     } else {
-        Ok(response.json::<T>().await?)
+        Ok(response.json().await?)
     }
 }
 

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -2,10 +2,11 @@ use std::io::{self, Cursor};
 use std::process::Command;
 use std::str;
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use log::debug;
 use minisign_verify::{PublicKey, Signature};
 use reqwest::Client;
+use serde::de::DeserializeOwned;
 use zip::ZipArchive;
 
 #[cfg(test)]
@@ -69,6 +70,17 @@ async fn http_get(url: &str) -> anyhow::Result<reqwest::Response> {
     Ok(response)
 }
 
+/// Generic function for fetching JSON structs via HTTP GET.
+async fn http_get_json<T: DeserializeOwned>(url: &str) -> anyhow::Result<T> {
+    let response = http_get(url).await?;
+
+    if let Err(error) = response.error_for_status_ref() {
+        Err(anyhow!(response.text().await?)).context(error)
+    } else {
+        Ok(response.json::<T>().await?)
+    }
+}
+
 /// Download the specified Github asset. Returns a bytes object containing the contents of the asset.
 async fn download_github_asset(latest: &GithubReleaseAsset) -> anyhow::Result<bytes::Bytes> {
     let r = http_get(&latest.browser_download_url).await?;
@@ -126,8 +138,7 @@ impl ApplicationUpdater {
     async fn get_latest_version(&self, prerelease: bool) -> anyhow::Result<GithubRelease> {
         let ver = if prerelease {
             let url = format!("{}/repos/phylum-dev/cli/releases", self.github_uri);
-            let r = http_get(&url).await?;
-            let releases = r.json::<Vec<GithubRelease>>().await?;
+            let releases = http_get_json::<Vec<GithubRelease>>(&url).await?;
             // Use the first one in the list, which should be the most recent
             releases
                 .first()
@@ -135,8 +146,7 @@ impl ApplicationUpdater {
                 .ok_or_else(|| anyhow::anyhow!("no releases found"))?
         } else {
             let url = format!("{}/repos/phylum-dev/cli/releases/latest", self.github_uri);
-            let r = http_get(&url).await?;
-            r.json::<GithubRelease>().await?
+            http_get_json::<GithubRelease>(&url).await?
         };
 
         log::debug!("Found latest version: {:?}", ver);


### PR DESCRIPTION
This resolves an issue where an HTTP JSON error response would lead to
cryptic serde deserialization error instead of a helpful error message.

To provide better user feedback in these kind of scenarios, all
instances of json HTTP deserialization have now been changed to check
the response status before attempting deserialization. In case of an
error response, the body is logged instead of deserialized.

Closes #361.
