### PR TITLE
Use the action from completed jobs only

### DIFF
--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use ansi_term::Color::Blue;
 use anyhow::{anyhow, Context, Result};
+use phylum_types::types::common::Status;
 use reqwest::StatusCode;
 use serde::Serialize;
 use uuid::Uuid;
@@ -42,7 +43,7 @@ where
         );
     } else {
         if let Ok(ref resp) = resp {
-            if !resp.pass {
+            if resp.status == Status::Complete && !resp.pass {
                 action = resp.action.to_owned();
             }
         }


### PR DESCRIPTION
Failing to check the completion status of the job leads to error messages like this even when the job is not yet completed.

```
❗ Error: Project failed threshold requirements, failing the build!
```

With this change, the code uses `Action::None` if the job is incomplete.