### PR TITLE
 Use new endpoint for ping 

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -8,9 +8,9 @@ pub fn put_submit_package(api_uri: &str) -> String {
     format!("{api_uri}/{API_PATH}/job")
 }
 
-/// GET /job/heartbeat
+/// GET /health
 pub fn get_ping(api_uri: &str) -> String {
-    format!("{api_uri}/{API_PATH}/job/heartbeat")
+    format!("{api_uri}/{API_PATH}/health")
 }
 
 /// GET /job/

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -165,7 +165,7 @@ impl PhylumApi {
         Ok(self
             .get::<PingResponse>(endpoints::get_ping(&self.api_uri))
             .await?
-            .msg)
+            .response)
     }
 
     /// Get information about the authenticated user

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -6,7 +6,6 @@ use phylum_types::types::project::*;
 use prettytable::*;
 
 use crate::print::{self, table_format};
-use crate::types::PingResponse;
 
 pub trait Renderable {
     fn render(&self) -> String;
@@ -283,12 +282,6 @@ impl Renderable for PackageStatusExtended {
 impl Renderable for CancelJobResponse {
     fn render(&self) -> String {
         format!("Request canceled: {}", self.msg)
-    }
-}
-
-impl Renderable for PingResponse {
-    fn render(&self) -> String {
-        format!("Ping response: {}", self.msg)
     }
 }
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PingResponse {
-    pub msg: String,
+    pub response: String,
 }
 
 // TODO Deprecate


### PR DESCRIPTION
The `/api/v0/health` endpoint has existed for a while, but we have
continued to use the old endpoint. This patch closes #370 