### PR TITLE
Remove uuid dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,6 @@ dependencies = [
  "toml",
  "unicode-width",
  "url",
- "uuid",
  "wiremock",
  "yaml-rust",
  "zeroize",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,6 @@ thiserror = "1.0.29"
 tokio = { version = "^1.0", features = ["full"] }
 toml = "0.5.8"
 url = { version = "2", features = ["serde"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
 yaml-rust = "*"
 zeroize = "1.4.0"
 zip = "0.6.2"

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -283,7 +283,6 @@ mod tests {
 
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
-    use uuid::Uuid;
     use wiremock::http::HeaderName;
     use wiremock::matchers::{method, path, path_regex, query_param};
     use wiremock::{Mock, ResponseTemplate};
@@ -344,7 +343,7 @@ mod tests {
             version: "16.13.1".to_string(),
             package_type: PackageType::Npm,
         };
-        let project_id = Uuid::new_v4();
+        let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
         client
             .submit_request(&PackageType::Npm, &[pkg], true, project_id, label)
@@ -376,7 +375,7 @@ mod tests {
             version: "16.13.1".to_string(),
             package_type: PackageType::Npm,
         };
-        let project_id = Uuid::new_v4();
+        let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
         client
             .submit_request(&PackageType::Npm, &[pkg], true, project_id, label)

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 
 use ansi_term::Color::Blue;
 use anyhow::{anyhow, Context, Result};
+use phylum_types::types::common::ProjectId;
 use reqwest::StatusCode;
 use serde::Serialize;
-use uuid::Uuid;
 
 use phylum_types::types::common::JobId;
 use phylum_types::types::job::*;
@@ -71,7 +71,7 @@ pub async fn get_job_status(
 
 /// Resolve a potential job_id, which could be a UUID string or the value
 /// 'current' which means the UUID of the current running job.
-fn resolve_job_id(job_id: &str) -> Result<Uuid> {
+fn resolve_job_id(job_id: &str) -> Result<JobId> {
     let maybe_job_id = if job_id == "current" {
         get_current_project().map(|p: ProjectConfig| p.id)
     } else {
@@ -266,12 +266,12 @@ pub async fn handle_submission(
 /// Get the current project's UUID.
 ///
 /// Assumes that the clap `matches` has a `project` arguments option.
-async fn project_uuid(api: &mut PhylumApi, matches: &clap::ArgMatches) -> Result<Uuid> {
+async fn project_uuid(api: &mut PhylumApi, matches: &clap::ArgMatches) -> Result<ProjectId> {
     // Prefer `--project` if it was specified.
     if let Some(project_name) = matches.value_of("project") {
         let response = api.get_project_details(project_name).await;
         let project_id = response.context("Project details request failure")?.id;
-        return Uuid::parse_str(&project_id).context("Invalid project UUID");
+        return ProjectId::parse_str(&project_id).context("Invalid project UUID");
     }
 
     // Retrieve the project from the `.phylum_project` file.

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use ansi_term::Color::{Blue, White};
 use anyhow::anyhow;
 use chrono::Local;
-use uuid::Uuid;
+use phylum_types::types::common::ProjectId;
 
 use super::{CommandResult, ExitCode};
 use crate::api::PhylumApi;
@@ -61,7 +61,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         match resp {
             Ok(proj) => {
-                let proj_uuid = Uuid::parse_str(proj.id.as_str()).unwrap(); // TODO: Handle this.
+                let proj_uuid = ProjectId::parse_str(proj.id.as_str()).unwrap(); // TODO: Handle this.
                 let proj_conf = ProjectConfig {
                     id: proj_uuid,
                     name: proj.name,


### PR DESCRIPTION
It turns out that we don't actually need this as a direct dependency
because `phylum_types` has type aliases for all of this.

Doing it this way has pros and cons. Maybe someday we'll decide that the
aliases in `phylum_types` don't actually make sense or that they should
actually use the newtype pattern. But for now, they exist, so we might
as well use them.

As an nice bonus, this means we won't have to worry about coordinating
our version bump of the uuid crate with phylum-dev/phylum-types#27. Once
that is merged, we will automatically be upgraded (after the next cargo
update)

Closes #349