### PR TITLE
Split get_project_id into its own method

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::anyhow;
+use anyhow::Context;
 use phylum_types::types::auth::*;
 use phylum_types::types::common::*;
 use phylum_types::types::job::*;
@@ -260,6 +261,15 @@ impl PhylumApi {
     ) -> Result<ProjectDetailsResponse> {
         self.get(endpoints::get_project_details(&self.api_uri, project_name))
             .await
+    }
+
+    /// Resolve a Project Name to a Project ID
+    pub async fn get_project_id(&mut self, project_name: &str) -> Result<ProjectId> {
+        self.get(endpoints::get_project_details(&self.api_uri, project_name))
+            .await
+            .context("Project details request failure")
+            .and_then(|p: ProjectDetailsResponse| p.id.parse().context("Invalid Project ID"))
+            .map_err(PhylumApiError::Other)
     }
 
     /// Get package details

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -269,9 +269,7 @@ pub async fn handle_submission(
 async fn project_uuid(api: &mut PhylumApi, matches: &clap::ArgMatches) -> Result<ProjectId> {
     // Prefer `--project` if it was specified.
     if let Some(project_name) = matches.value_of("project") {
-        let response = api.get_project_details(project_name).await;
-        let project_id = response.context("Project details request failure")?.id;
-        return ProjectId::parse_str(&project_id).context("Invalid project UUID");
+        return Ok(api.get_project_id(project_name).await?);
     }
 
     // Retrieve the project from the `.phylum_project` file.


### PR DESCRIPTION
Many of the uses of `get_project_details()` were only using that method to
get the Project ID. This split will simplify future updates to the
endpoints.

## Additional context

There are plans to deprecate and remove the endpoint used here. Splitting the functionality like this will help us decide what endpoints to switch to when that happens.

See [this comment](https://github.com/phylum-dev/api/blob/d362b0d4fc8d423e1abc0067c854f56f44f53d49/src/endpoints/projects/endpoints.rs#L186-L191) on the API endpoint.