### PR TITLE
Add group support

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -62,3 +62,18 @@ pub(crate) fn get_user_settings(api_uri: &str) -> String {
 pub(crate) fn put_user_settings(api_uri: &str) -> String {
     format!("{api_uri}/{API_PATH}/settings/current-user")
 }
+
+/// GET /groups/list
+pub(crate) fn group_list(api_uri: &str) -> String {
+    format!("{api_uri}/{API_PATH}/groups")
+}
+
+/// POST /groups/create
+pub(crate) fn group_create(api_uri: &str) -> String {
+    format!("{api_uri}/{API_PATH}/groups")
+}
+
+/// GET /groups/<groupName>/projects
+pub fn group_project_summary(api_uri: &str, group: &str) -> String {
+    format!("{api_uri}/{API_PATH}/groups/{}/projects", group)
+}

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -75,5 +75,5 @@ pub(crate) fn group_create(api_uri: &str) -> String {
 
 /// GET /groups/<groupName>/projects
 pub fn group_project_summary(api_uri: &str, group: &str) -> String {
-    format!("{api_uri}/{API_PATH}/groups/{}/projects", group)
+    format!("{api_uri}/{API_PATH}/groups/{group}/projects")
 }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -201,7 +201,7 @@ impl PhylumApi {
     /// Get a list of projects
     pub async fn get_projects(
         &mut self,
-        group: &Option<String>,
+        group: Option<&str>,
     ) -> Result<Vec<ProjectSummaryResponse>> {
         let uri = match group {
             Some(group) => endpoints::group_project_summary(&self.api_uri, group),
@@ -285,7 +285,7 @@ impl PhylumApi {
     pub async fn get_project_id(
         &mut self,
         project_name: &str,
-        group_name: &Option<String>,
+        group_name: Option<&str>,
     ) -> Result<ProjectId> {
         let projects = self.get_projects(group_name).await?;
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use phylum_types::types::auth::*;
 use phylum_types::types::common::*;
+use phylum_types::types::group::{CreateGroupRequest, CreateGroupResponse, ListUserGroupsResponse};
 use phylum_types::types::job::*;
 use phylum_types::types::package::*;
 use phylum_types::types::project::CreateProjectRequest;
@@ -68,6 +69,14 @@ impl PhylumApi {
 
     async fn put<T: DeserializeOwned, S: serde::Serialize>(&self, path: String, s: S) -> Result<T> {
         self.send_request(Method::PUT, path, Some(s)).await
+    }
+
+    async fn post<T: serde::de::DeserializeOwned, S: serde::Serialize>(
+        &self,
+        path: String,
+        s: S,
+    ) -> Result<T> {
+        self.send_request(Method::POST, path, Some(s)).await
     }
 
     async fn send_request<T: DeserializeOwned, B: Serialize>(
@@ -176,13 +185,13 @@ impl PhylumApi {
     }
 
     /// Create a new project
-    pub async fn create_project(&mut self, name: &str) -> Result<ProjectId> {
+    pub async fn create_project(&mut self, name: &str, group: Option<&str>) -> Result<ProjectId> {
         Ok(self
             .put::<CreateProjectResponse, _>(
                 endpoints::put_create_project(&self.api_uri),
                 CreateProjectRequest {
-                    name: name.to_string(),
-                    group_name: None,
+                    name: name.to_owned(),
+                    group_name: group.map(String::from),
                 },
             )
             .await?
@@ -190,9 +199,16 @@ impl PhylumApi {
     }
 
     /// Get a list of projects
-    pub async fn get_projects(&mut self) -> Result<Vec<ProjectSummaryResponse>> {
-        self.get(endpoints::get_project_summary(&self.api_uri))
-            .await
+    pub async fn get_projects(
+        &mut self,
+        group: Option<String>,
+    ) -> Result<Vec<ProjectSummaryResponse>> {
+        let uri = match group {
+            Some(group) => endpoints::group_project_summary(&self.api_uri, &group),
+            None => endpoints::get_project_summary(&self.api_uri),
+        };
+
+        self.get(uri).await
     }
 
     /// Get user settings
@@ -215,14 +231,15 @@ impl PhylumApi {
         is_user: bool,
         project: ProjectId,
         label: Option<String>,
+        group_name: Option<String>,
     ) -> Result<JobId> {
         let req = SubmitPackageRequest {
             package_type: req_type.to_owned(),
             packages: package_list.to_vec(),
             is_user,
             project,
-            group_name: None,
             label: label.unwrap_or_else(|| "uncategorized".to_string()),
+            group_name,
         };
         log::debug!("==> Sending package submission: {:?}", req);
         let resp: SubmitPackageResponse = self
@@ -279,6 +296,20 @@ impl PhylumApi {
         pkg: &PackageDescriptor,
     ) -> Result<PackageStatusExtended> {
         self.get(endpoints::get_package_status(&self.api_uri, pkg))
+            .await
+    }
+
+    /// Get all groups the user is part of.
+    pub async fn get_groups_list(&mut self) -> Result<ListUserGroupsResponse> {
+        self.get(endpoints::group_list(&self.api_uri)).await
+    }
+
+    /// Get all groups the user is part of.
+    pub async fn create_group(&mut self, group_name: &str) -> Result<CreateGroupResponse> {
+        let group = CreateGroupRequest {
+            group_name: group_name.into(),
+        };
+        self.post(endpoints::group_create(&self.api_uri), group)
             .await
     }
 }
@@ -352,7 +383,7 @@ mod tests {
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
         client
-            .submit_request(&PackageType::Npm, &[pkg], true, project_id, label)
+            .submit_request(&PackageType::Npm, &[pkg], true, project_id, label, None)
             .await?;
 
         // Request should have been submitted with a bearer token
@@ -384,7 +415,7 @@ mod tests {
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
         client
-            .submit_request(&PackageType::Npm, &[pkg], true, project_id, label)
+            .submit_request(&PackageType::Npm, &[pkg], true, project_id, label, None)
             .await?;
         Ok(())
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -93,7 +93,10 @@ pub fn app<'a>() -> clap::Command<'a> {
                 .subcommand(
                     Command::new("set-thresholds")
                         .about("Interactively set risk domain thresholds for a project")
-                        .arg(arg!(<name> "Name of the project"))
+                        .args(&[
+                            arg!(<name> "Name of the project"),
+                            arg!(-g --group <group_name> "Group owning the project").required(false),
+                        ])
                 )
         )
         .subcommand(

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -71,7 +71,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                         .about("Create a new project")
                         .args(&[
                             arg!(<name> "Name of the project"),
-                            arg!(-g --group <group_name> "Group which will be the owner of the project"),
+                            arg!(-g --group <group_name> "Group which will be the owner of the project").required(false),
                         ])
                 )
                 .subcommand(
@@ -87,7 +87,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                         .about("Link a repository to a project")
                         .args(&[
                             arg!(<name> "Name of the project"),
-                            arg!(-g --group <group_name> "Group owning the project"),
+                            arg!(-g --group <group_name> "Group owning the project").required(false),
                         ])
                 )
                 .subcommand(

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -61,22 +61,34 @@ pub fn app<'a>() -> clap::Command<'a> {
         .subcommand(
             Command::new("project")
                 .about("Create, list, link and set thresholds for projects")
-                .arg(arg!(-j --json "Produce output in json format (default: false)"))
+                .args(&[
+                    arg!(-j --json "Produce output in json format (default: false)"),
+                    arg!(-g --group <group_name> "Group to list projects for").required(false),
+                ])
                 .aliases(&["projects"])
                 .subcommand(
                     Command::new("create")
                         .about("Create a new project")
-                        .arg(arg!(<name> "Name of the project"))
+                        .args(&[
+                            arg!(<name> "Name of the project"),
+                            arg!(-g --group <group_name> "Group which will be the owner of the project"),
+                        ])
                 )
                 .subcommand(
                     Command::new("list")
                         .about("List all existing projects")
-                        .arg(arg!(-j --json "Produce output in json format (default: false)"))
+                        .args(&[
+                            arg!(-j --json "Produce output in json format (default: false)"),
+                            arg!(-g --group <group_name> "Group to list projects for").required(false),
+                        ])
                 )
                 .subcommand(
                     Command::new("link")
                         .about("Link a repository to a project")
-                        .arg(arg!(<name> "Name of the project"))
+                        .args(&[
+                            arg!(<name> "Name of the project"),
+                            arg!(-g --group <group_name> "Group owning the project"),
+                        ])
                 )
                 .subcommand(
                     Command::new("set-thresholds")
@@ -128,6 +140,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                     arg!(--filter <filter>).required(false).help(FILTER_ABOUT),
                     arg!(-j --json "Produce output in json format (default: false)"),
                     arg!(-p --project <project_name> "Project to use for analysis").required(false),
+                    arg!(-g --group <group_name> "Group to use for analysis").required(false).requires("project"),
                 ])
         )
         .subcommand(
@@ -141,11 +154,27 @@ pub fn app<'a>() -> clap::Command<'a> {
                     arg!(-L --"low-priority"),
                     arg!(-l --label),
                     arg!(-p --project <project_name> "Project to use for analysis").required(false),
+                    arg!(-g --group <group_name> "Group to use for analysis").required(false).requires("project"),
                 ])
         )
         .subcommand(
             Command::new("version")
                 .about("Display application version")
+        )
+        .subcommand(
+            Command::new("group")
+                .about("Interact with user groups")
+                .arg(arg!(-j --json "Produce group list in json format (default: false)"))
+                .subcommand(
+                    Command::new("list")
+                        .about("List all groups the user is part of")
+                        .arg(arg!(-j --json "Produce output in json format (default: false)"))
+                )
+                .subcommand(
+                    Command::new("create")
+                        .about("Create a new group")
+                        .arg(arg!(<group_name> "Name for the new group"))
+                )
         );
 
     #[cfg(feature = "selfmanage")]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -10,6 +10,7 @@ use spinners::{Spinner, Spinners};
 
 use phylum_cli::api::PhylumApi;
 use phylum_cli::commands::auth::*;
+use phylum_cli::commands::group::handle_group;
 use phylum_cli::commands::jobs::*;
 use phylum_cli::commands::packages::*;
 use phylum_cli::commands::project::handle_project;
@@ -201,6 +202,8 @@ async fn handle_commands() -> CommandResult {
         return handle_submission(&mut api, config, &matches).await;
     } else if let Some(matches) = matches.subcommand_matches("history") {
         return handle_history(&mut api, matches).await;
+    } else if let Some(matches) = matches.subcommand_matches("group") {
+        return handle_group(&mut api, matches).await;
     }
 
     Ok(ExitCode::Ok.into())

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -1,0 +1,25 @@
+//! Subcommand `phylum group`.
+
+use clap::ArgMatches;
+
+use crate::api::PhylumApi;
+use crate::commands::{CommandResult, ExitCode};
+use crate::print;
+use crate::print_user_success;
+
+/// Handle `phylum group` subcommand.
+pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+    if let Some(matches) = matches.subcommand_matches("create") {
+        let group_name = matches.value_of("group_name").unwrap();
+        let response = api.create_group(group_name).await?;
+        print_user_success!("Successfully created group {}", response.group_name);
+        Ok(ExitCode::Ok.into())
+    } else {
+        let response = api.get_groups_list().await;
+
+        let pretty_print = !matches.is_present("json");
+        print::print_response(&response, pretty_print, None);
+
+        Ok(ExitCode::Ok.into())
+    }
+}

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -275,7 +275,7 @@ async fn cli_project(
     // Prefer `--project` and `--group` if they were specified.
     if let Some(project_name) = matches.value_of("project") {
         let group = matches.value_of("group").map(String::from);
-        let project = api.get_project_id(project_name).await?;
+        let project = api.get_project_id(project_name, &group).await?;
         return Ok((project, group));
     }
 

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -274,9 +274,9 @@ async fn cli_project(
 ) -> Result<(ProjectId, Option<String>)> {
     // Prefer `--project` and `--group` if they were specified.
     if let Some(project_name) = matches.value_of("project") {
-        let group = matches.value_of("group").map(String::from);
-        let project = api.get_project_id(project_name, &group).await?;
-        return Ok((project, group));
+        let group = matches.value_of("group");
+        let project = api.get_project_id(project_name, group).await?;
+        return Ok((project, group.map(String::from)));
     }
 
     // Retrieve the project from the `.phylum_project` file.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use phylum_types::types::job::Action;
 
 pub mod auth;
+pub mod group;
 pub mod jobs;
 pub mod packages;
 pub mod parse;

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -14,7 +14,7 @@ use crate::prompt::prompt_threshold;
 
 /// List the projects in this account.
 pub async fn get_project_list(api: &mut PhylumApi, pretty_print: bool, group: Option<String>) {
-    let resp = api.get_projects(group).await;
+    let resp = api.get_projects(&group).await;
 
     // Print table header when we're not outputting in JSON format.
     if pretty_print {
@@ -59,10 +59,10 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         get_project_list(api, pretty_print, group).await;
     } else if let Some(matches) = matches.subcommand_matches("link") {
         let project_name = matches.value_of("name").unwrap();
-        let group_name = matches.value_of("group");
+        let group_name = matches.value_of("group").map(String::from);
 
         let proj_uuid = api
-            .get_project_id(project_name)
+            .get_project_id(project_name, &group_name)
             .await
             .context("A project with that name does not exist")?;
 
@@ -70,7 +70,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             id: proj_uuid,
             name: project_name.into(),
             created_at: Local::now(),
-            group_name: group_name.map(String::from),
+            group_name,
         };
         save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
             log::error!("Failed to save user credentials to config: {}", err)
@@ -82,6 +82,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         );
     } else if let Some(matches) = matches.subcommand_matches("set-thresholds") {
         let mut project_name = matches.value_of("name").unwrap_or("current");
+        let group_name = matches.value_of("group").map(String::from);
 
         let proj = if project_name == "current" {
             get_current_project().map(|p| p.name)
@@ -128,7 +129,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         println!();
 
         let project_id = api
-            .get_project_id(project_name)
+            .get_project_id(project_name, &group_name)
             .await
             .context("Could not get project ID")?;
 

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -13,8 +13,8 @@ use crate::print_user_success;
 use crate::prompt::prompt_threshold;
 
 /// List the projects in this account.
-pub async fn get_project_list(api: &mut PhylumApi, pretty_print: bool, group: Option<String>) {
-    let resp = api.get_projects(&group).await;
+pub async fn get_project_list(api: &mut PhylumApi, pretty_print: bool, group: Option<&str>) {
+    let resp = api.get_projects(group).await;
 
     // Print table header when we're not outputting in JSON format.
     if pretty_print {
@@ -54,15 +54,15 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         print_user_success!("Successfully created new project, {}", name);
     } else if let Some(matches) = matches.subcommand_matches("list") {
-        let group = matches.value_of("group").map(String::from);
+        let group = matches.value_of("group");
         let pretty_print = pretty_print && !matches.is_present("json");
         get_project_list(api, pretty_print, group).await;
     } else if let Some(matches) = matches.subcommand_matches("link") {
         let project_name = matches.value_of("name").unwrap();
-        let group_name = matches.value_of("group").map(String::from);
+        let group_name = matches.value_of("group");
 
         let proj_uuid = api
-            .get_project_id(project_name, &group_name)
+            .get_project_id(project_name, group_name)
             .await
             .context("A project with that name does not exist")?;
 
@@ -70,7 +70,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             id: proj_uuid,
             name: project_name.into(),
             created_at: Local::now(),
-            group_name,
+            group_name: group_name.map(String::from),
         };
         save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
             log::error!("Failed to save user credentials to config: {}", err)
@@ -82,7 +82,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         );
     } else if let Some(matches) = matches.subcommand_matches("set-thresholds") {
         let mut project_name = matches.value_of("name").unwrap_or("current");
-        let group_name = matches.value_of("group").map(String::from);
+        let group_name = matches.value_of("group");
 
         let proj = if project_name == "current" {
             get_current_project().map(|p| p.name)
@@ -129,7 +129,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         println!();
 
         let project_id = api
-            .get_project_id(project_name, &group_name)
+            .get_project_id(project_name, group_name)
             .await
             .context("Could not get project ID")?;
 
@@ -184,7 +184,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             }
         }
     } else {
-        let group = matches.value_of("group").map(String::from);
+        let group = matches.value_of("group");
         get_project_list(api, pretty_print, group).await;
     }
 

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -13,8 +13,8 @@ use crate::print_user_success;
 use crate::prompt::prompt_threshold;
 
 /// List the projects in this account.
-pub async fn get_project_list(api: &mut PhylumApi, pretty_print: bool) {
-    let resp = api.get_projects().await;
+pub async fn get_project_list(api: &mut PhylumApi, pretty_print: bool, group: Option<String>) {
+    let resp = api.get_projects(group).await;
 
     // Print table header when we're not outputting in JSON format.
     if pretty_print {
@@ -34,28 +34,33 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
     let pretty_print = !matches.is_present("json");
 
     if let Some(matches) = matches.subcommand_matches("create") {
-        let project_name = matches.value_of("name").unwrap();
+        let name = matches.value_of("name").unwrap();
+        let group = matches.value_of("group");
 
-        log::info!("Initializing new project: `{}`", project_name);
+        log::info!("Initializing new project: `{}`", name);
 
-        let project_id = api.create_project(project_name).await?;
+        let project_id = api.create_project(name, group).await?;
 
         let proj_conf = ProjectConfig {
             id: project_id.to_owned(),
-            name: project_name.to_owned(),
             created_at: Local::now(),
+            group_name: group.map(String::from),
+            name: name.to_owned(),
         };
 
         save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
             print_user_failure!("Failed to save project file: {}", err);
         });
 
-        print_user_success!("Successfully created new project, {}", project_name);
+        print_user_success!("Successfully created new project, {}", name);
     } else if let Some(matches) = matches.subcommand_matches("list") {
+        let group = matches.value_of("group").map(String::from);
         let pretty_print = pretty_print && !matches.is_present("json");
-        get_project_list(api, pretty_print).await;
+        get_project_list(api, pretty_print, group).await;
     } else if let Some(matches) = matches.subcommand_matches("link") {
         let project_name = matches.value_of("name").unwrap();
+        let group_name = matches.value_of("group");
+
         let proj_uuid = api
             .get_project_id(project_name)
             .await
@@ -65,6 +70,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             id: proj_uuid,
             name: project_name.into(),
             created_at: Local::now(),
+            group_name: group_name.map(String::from),
         };
         save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
             log::error!("Failed to save user credentials to config: {}", err)
@@ -177,7 +183,8 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             }
         }
     } else {
-        get_project_list(api, pretty_print).await;
+        let group = matches.value_of("group").map(String::from);
+        get_project_list(api, pretty_print, group).await;
     }
 
     Ok(ExitCode::Ok.into())

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -46,6 +46,7 @@ pub struct ProjectConfig {
     pub id: ProjectId,
     pub name: String,
     pub created_at: DateTime<Local>,
+    pub group_name: Option<String>,
 }
 
 impl Default for Config {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -104,6 +104,8 @@ pub fn truncate(text: &str, max_length: usize) -> Cow<str> {
                 len < max_length
             })
             .collect::<String>()
+            .trim_end()
+            .to_owned()
             + "…";
         Cow::Owned(truncated)
     } else {

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -1,5 +1,8 @@
+use std::fmt::Write;
+
 use ansi_term::Color::{Blue, Green, Red, White, Yellow};
 use chrono::{Local, TimeZone};
+use phylum_types::types::group::ListUserGroupsResponse;
 use phylum_types::types::job::*;
 use phylum_types::types::package::*;
 use phylum_types::types::project::*;
@@ -299,5 +302,22 @@ impl Renderable for ProjectThresholds {
         );
         table.set_format(table_format(0, 0));
         table.to_string()
+    }
+}
+
+impl Renderable for ListUserGroupsResponse {
+    fn render(&self) -> String {
+        let mut table = Blue
+            .paint(
+                "Group Name                 Owner                                Creation Time\n",
+            )
+            .to_string();
+        for group in &self.groups {
+            let _ = write!(table, "{:<25}  ", print::truncate(&group.group_name, 25));
+            let _ = write!(table, "{:<35}  ", print::truncate(&group.owner_email, 35));
+            let _ = write!(table, "{}", group.created_at.format("%FT%RZ"));
+            table.push('\n');
+        }
+        table.trim_end().to_owned()
     }
 }

--- a/cli/src/summarize.rs
+++ b/cli/src/summarize.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use ansi_term::Color::*;
 use chrono::NaiveDateTime;
 use color::Color;
+use phylum_types::types::group::ListUserGroupsResponse;
 use phylum_types::types::job::{
     AllJobsStatusResponse, CancelJobResponse, JobDescriptor, JobStatusResponse,
 };
@@ -348,6 +349,7 @@ impl Summarize for PackageStatus {}
 impl Summarize for ProjectDetailsResponse {}
 impl Summarize for AllJobsStatusResponse {}
 impl Summarize for CancelJobResponse {}
+impl Summarize for ListUserGroupsResponse {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This adds support for user groups, which allow multiple people to have
access to the same projects.

A group can now be specified for the following commands:
    - `phylum project`
    - `phylum project create`
    - `phylum project list`
    - `phylum project link`
    - `phylum project set-thresholds`
    - `phylum analyze`
    - `phylum batch`

Additionally two commands have been added which allow interacting with
groups:
    - `phylum group list`
    - `phylum group create`

Closes #276.
Closes #275.
Closes #274.
