### PR TITLE
Fix json flag with `phylum group list`

### DIFF
--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -8,13 +8,15 @@ use crate::print;
 use crate::print_user_success;
 
 /// Handle `phylum group` subcommand.
-pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+pub async fn handle_group(api: &mut PhylumApi, mut matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         let group_name = matches.value_of("group_name").unwrap();
         let response = api.create_group(group_name).await?;
         print_user_success!("Successfully created group {}", response.group_name);
         Ok(ExitCode::Ok.into())
     } else {
+        matches = matches.subcommand_matches("list").unwrap_or(matches);
+
         let response = api.get_groups_list().await;
 
         let pretty_print = !matches.is_present("json");


### PR DESCRIPTION
Previously instead of reading the flags from the `list` subcommand,
`phylum group list` would instead read all flags from the `group`
subcommand. Thus `phylum group --json list` worked, while `phylum group
list --json` produced pretty-printed output.

To fix this, flags from the `group` subcommand are now ignored, so
`phylum group --json list` will pretty-print, while `phylum group list
--json` will output json.
