### PR TITLE
Ignore certs everywhere when requested

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -32,6 +32,7 @@ type Result<T> = std::result::Result<T, PhylumApiError>;
 pub struct PhylumApi {
     client: Client,
     api_uri: String,
+    ignore_certs: bool,
 }
 
 /// Phylum Api Error type
@@ -120,8 +121,10 @@ impl PhylumApi {
     ) -> Result<Self> {
         // Do we have a refresh token?
         let tokens: TokenResponse = match &auth_info.offline_access {
-            Some(refresh_token) => handle_refresh_tokens(auth_info, refresh_token).await?,
-            None => handle_auth_flow(&AuthAction::Login, auth_info).await?,
+            Some(refresh_token) => {
+                handle_refresh_tokens(auth_info, refresh_token, ignore_certs).await?
+            }
+            None => handle_auth_flow(&AuthAction::Login, auth_info, ignore_certs).await?,
         };
 
         auth_info.offline_access = Some(tokens.refresh_token.clone());
@@ -149,14 +152,15 @@ impl PhylumApi {
         Ok(Self {
             client,
             api_uri: api_uri.to_string(),
+            ignore_certs,
         })
     }
 
     /// update auth info by forcing the login flow, using the given Auth
     /// configuration. The auth_info struct will be updated with the new
     /// credentials. It is the duty of the calling code to save any changes
-    pub async fn login(mut auth_info: AuthInfo) -> Result<AuthInfo> {
-        let tokens = handle_auth_flow(&AuthAction::Login, &auth_info).await?;
+    pub async fn login(mut auth_info: AuthInfo, ignore_certs: bool) -> Result<AuthInfo> {
+        let tokens = handle_auth_flow(&AuthAction::Login, &auth_info, ignore_certs).await?;
         auth_info.offline_access = Some(tokens.refresh_token);
         Ok(auth_info)
     }
@@ -164,8 +168,8 @@ impl PhylumApi {
     /// update auth info by forcing the registration flow, using the given Auth
     /// configuration. The auth_info struct will be updated with the new
     /// credentials. It is the duty of the calling code to save any changes
-    pub async fn register(mut auth_info: AuthInfo) -> Result<AuthInfo> {
-        let tokens = handle_auth_flow(&AuthAction::Register, &auth_info).await?;
+    pub async fn register(mut auth_info: AuthInfo, ignore_certs: bool) -> Result<AuthInfo> {
+        let tokens = handle_auth_flow(&AuthAction::Register, &auth_info, ignore_certs).await?;
         auth_info.offline_access = Some(tokens.refresh_token);
         Ok(auth_info)
     }
@@ -180,7 +184,7 @@ impl PhylumApi {
 
     /// Get information about the authenticated user
     pub async fn user_info(&self, auth_info: &AuthInfo) -> Result<UserInfo> {
-        let oidc_settings = fetch_oidc_server_settings(auth_info).await?;
+        let oidc_settings = fetch_oidc_server_settings(auth_info, self.ignore_certs).await?;
         self.get(oidc_settings.userinfo_endpoint.into()).await
     }
 


### PR DESCRIPTION
This should fix #388 by correctly setting `danger_accept_invalid_certs`
on all `request::Client` objects and not just the one used for API
requests.