### PR TITLE
Bump to v3.4.0 - Group account support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.4.0 - Group account support
 * 3.3.0 - Introduce parse command
 * 3.2.0 - Support yarn patched dependencies
 * 3.1.0 - Resolve project create error and add `--bearer` option to `phylum auth token`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# Releasing a new version of the CLI is initiated with a tag and completed with the
-# Release workflow in CI. Run this script from the `main` branch and follow the prompts
-# to initiate a new release. There is a manual step required at the end. This is to
-# ensure a chance to review the automated work and not accidentally release a new version.
+# To release a new version of the CLI:
+#
+# * Run this script on a branch to bump the version
+# * Submit a PR for the version bump and, after approval, merge it to the default branch
+# * Run tag.sh from the default branch
 
 set -eu
 
@@ -34,19 +35,20 @@ commit_message="Bump to ${TAG} - ${changelog}"
 printf "\nFiles to be added and committed with message: \"%s\"\n\n" "${commit_message}"
 git status
 
-printf "Press enter to proceed with the commit and tag ..."
+printf "Press enter to proceed with the commit..."
 read -r
-git commit -m "${commit_message}"
-git tag --sign -m "${TAG} - ${changelog}" "${TAG}"
 
-printf "\nOutput of the command: git show %s\n" "${TAG}"
-git show "${TAG}"
+git commit -F - <<EOF
+${commit_message}
+
+Release-Version: ${TAG}
+Release-Summary: ${changelog}
+EOF
+
+git log --pretty=fuller -1
 
 cat << __instructions__
 
-The automation is done.
-Run the following command manually to push the changes:
-
-    git push origin main ${TAG}
+Version bump successful!
 
 __instructions__

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# usage: ./tag.sh [BRANCH]
+# Tag the latest release commit (i.e., a commit with a "Release-Version" trailer)
+#
+# This script should be run on the default branch after a version bump (using bump_version.sh) has
+# been merged to the default branch. It will find and tag the latest release commit. If no branch
+# argument is provided, the search will begin from HEAD.
+#
+# Note: After the commit is found, a check is performed to ensure that the commit is reachable from
+# the default branch on the remote (origin/HEAD). To skip this check, set SKIP_ORIGIN_HEAD_CHECK=1
+
+set -eu
+
+SOURCE_BRANCH=HEAD
+if [ -n "${1:-}" ]; then
+    SOURCE_BRANCH="$1"
+fi
+
+echo "Searching for latest release commit from ${SOURCE_BRANCH}"
+
+TAG_COMMIT=$(git rev-list -i --grep='^release-version:' -1 "${SOURCE_BRANCH}")
+if [ -z "${TAG_COMMIT}" ]; then
+    echo "No release commit found!" >&2
+    exit 1
+fi
+
+TAG=$(git log --pretty="format:%(trailers:key=release-version,valueonly)" -1 "${TAG_COMMIT}")
+SUMMARY=$(git log --pretty="format:%(trailers:key=release-summary,valueonly)" -1 "${TAG_COMMIT}")
+
+if git rev-list "${TAG}" >/dev/null 2>&1; then
+    echo "Tag ${TAG} already exists!" >&2
+    exit 1
+fi
+
+echo "Tagging this commit:"
+git log --oneline -1 "${TAG_COMMIT}"
+
+if [ -z "${SKIP_ORIGIN_HEAD_CHECK:-}" ]; then
+    # Check that the tag is being created on the default branch
+    git fetch origin >/dev/null
+    if ! git merge-base --is-ancestor "${TAG_COMMIT}" origin/HEAD; then
+        echo "WARNING! You are about to tag a commit that is not on the default branch!"
+        echo "Unless you are patching an old version, this is probably not what you want!"
+
+        printf "Are you sure? [y/N] "
+        read -r yn
+        if [ "${yn}" != "y" ] && [ "${yn}" != "Y" ]; then
+            echo "Aborting tag"
+            exit 1
+        fi
+    fi
+fi
+
+git tag --sign -m "${TAG} - ${SUMMARY}" "${TAG}" "${TAG_COMMIT}"
+
+printf "\nOutput of the command: git show %s\n" "${TAG}"
+git show "${TAG}"
+
+cat << __instructions__
+
+Successfully created tag!
+Run the following command manually to push the new tag:
+
+    git push origin ${TAG}
+
+__instructions__


### PR DESCRIPTION
This patch includes a change to split release.sh into two scripts:
bump_version.sh and tag.sh

Making this split allows us to avoid pushing directly to the default
branch, while still ensuring that the tag is created on the default
branch. With this update, we can enable stricter branch protection
rules on the repository.

Release-Version: v3.4.0
Release-Summary: Group account support