### PR TITLE
Remove unused deps in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,12 +755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "histogram"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1201,6 @@ dependencies = [
  "env_logger",
  "futures",
  "git-version",
- "histogram",
  "home",
  "hyper",
  "lazy_static",
@@ -1223,7 +1216,6 @@ dependencies = [
  "routerify",
  "serde",
  "serde-xml-rs",
- "serde_derive",
  "serde_json",
  "serde_yaml",
  "sha2",
@@ -1237,8 +1229,6 @@ dependencies = [
  "unicode-width",
  "url",
  "wiremock",
- "yaml-rust",
- "zeroize",
  "zip",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,6 @@ dialoguer = "0.10.0"
 env_logger = "0.9.0"
 futures = "^0.3"
 git-version = "0.3.5"
-histogram = "0.6.9"
 home = "0.5.3"
 hyper = "0.14.16"
 lazy_static = "1.4.0"
@@ -38,10 +37,9 @@ rand = "0.8.4"
 reqwest = { version = "0.11.3", features = ["blocking", "json", "rustls-tls"], default-features = false }
 routerify = { version = "3.0.0", features =["all"] }
 serde = { version = "^1.0", features = ["derive"] }
-serde_derive = "1.0"
 serde_json = "^1.0"
-serde-xml-rs = "0.5.1"
 serde_yaml = "0.8.14"
+serde-xml-rs = "0.5.1"
 sha2 = "0.10.2"
 shellexpand = "2.0.0"
 spinners = "4.0.0"
@@ -50,11 +48,9 @@ textwrap = "0.15.0"
 thiserror = "1.0.29"
 tokio = { version = "^1.0", features = ["full"] }
 toml = "0.5.8"
-url = { version = "2", features = ["serde"] }
-yaml-rust = "*"
-zeroize = "1.4.0"
-zip = "0.6.2"
 unicode-width = "0.1.9"
+url = { version = "2", features = ["serde"] }
+zip = "0.6.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"


### PR DESCRIPTION
There were some dependencies in `Cargo.toml` that we weren't using (or weren't using directly). This patch removes them.