### PR TITLE
Remove APIResult type

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -15,7 +15,7 @@ use phylum_types::types::user_settings::*;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client, Method, StatusCode};
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use thiserror::Error as ThisError;
 
 mod endpoints;
@@ -55,13 +55,6 @@ impl PhylumApiError {
     }
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum APIResult<T> {
-    Ok(T),
-    Err { msg: String },
-}
-
 impl PhylumApi {
     async fn get<T: DeserializeOwned>(&self, path: String) -> Result<T> {
         self.send_request::<_, ()>(Method::GET, path, None).await
@@ -98,12 +91,7 @@ impl PhylumApi {
             return Err(anyhow!(body).into());
         }
 
-        let api_obj = serde_json::from_str::<APIResult<T>>(&body)
-            .map_err(|e| PhylumApiError::Other(e.into()))?;
-        match api_obj {
-            APIResult::Ok(api_obj) => Ok(api_obj),
-            APIResult::Err { msg } => Err(PhylumApiError::Other(anyhow::anyhow!(msg))),
-        }
+        serde_json::from_str::<T>(&body).map_err(|e| PhylumApiError::Other(e.into()))
     }
 }
 


### PR DESCRIPTION
This type has been flawed for a few reasons:

* Deserialization for this type only happens when an HTTP 200 status
  code is returned. But the API correctly uses 4xx and 5xx HTTP status
  codes for errors.

* The error format does not match the format used by the API.

* Using this type results in an obscure error message when
  deserialization fails:

```
data did not match any variant of untagged enum APIResult
```

## Additional context

As noted by @samtay in [this comment](https://github.com/phylum-dev/cli/pull/365#discussion_r869637268), API errors do not match this format.