### PR TITLE
Use new API endpoint for OIDC redirect

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -77,3 +77,8 @@ pub(crate) fn group_create(api_uri: &str) -> String {
 pub fn group_project_summary(api_uri: &str, group: &str) -> String {
     format!("{api_uri}/{API_PATH}/groups/{group}/projects")
 }
+
+/// GET /.well-known/openid-configuration
+pub fn oidc_discovery(api_uri: &str) -> String {
+    format!("{api_uri}/{API_PATH}/.well-known/openid-configuration")
+}

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::ip_addr_ext::IpAddrExt;
-use crate::config::AuthInfo;
+use crate::api::endpoints;
 
 pub const OIDC_SCOPES: [&str; 4] = ["openid", "offline_access", "profile", "email"];
 
@@ -149,14 +149,14 @@ pub fn check_if_routable(hostname: impl AsRef<str>) -> Result<bool> {
 }
 
 pub async fn fetch_oidc_server_settings(
-    auth_info: &AuthInfo,
     ignore_certs: bool,
+    api_uri: &str,
 ) -> Result<OidcServerSettings> {
     let client = reqwest::Client::builder()
         .danger_accept_invalid_certs(ignore_certs)
         .build()?;
     let response = client
-        .get(auth_info.oidc_discovery_url.clone())
+        .get(endpoints::oidc_discovery(api_uri))
         .header("Accept", "application/json")
         .timeout(Duration::from_secs(5))
         .send()
@@ -273,11 +273,11 @@ pub async fn refresh_tokens(
 }
 
 pub async fn handle_refresh_tokens(
-    auth_info: &AuthInfo,
     refresh_token: &RefreshToken,
     ignore_certs: bool,
+    api_uri: &str,
 ) -> Result<TokenResponse> {
-    let oidc_settings = fetch_oidc_server_settings(auth_info, ignore_certs).await?;
+    let oidc_settings = fetch_oidc_server_settings(ignore_certs, api_uri).await?;
     refresh_tokens(&oidc_settings, refresh_token, ignore_certs).await
 }
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -18,7 +18,8 @@ async fn handle_auth_register(
     config_path: &Path,
     ignore_certs: bool,
 ) -> Result<()> {
-    config.auth_info = PhylumApi::register(config.auth_info, ignore_certs).await?;
+    let api_uri = &config.connection.uri;
+    config.auth_info = PhylumApi::register(config.auth_info, ignore_certs, api_uri).await?;
     save_config(config_path, &config).map_err(|error| anyhow!(error))?;
     Ok(())
 }
@@ -30,7 +31,8 @@ async fn handle_auth_login(
     config_path: &Path,
     ignore_certs: bool,
 ) -> Result<()> {
-    config.auth_info = PhylumApi::login(config.auth_info, ignore_certs).await?;
+    let api_uri = &config.connection.uri;
+    config.auth_info = PhylumApi::login(config.auth_info, ignore_certs, api_uri).await?;
     save_config(config_path, &config).map_err(|error| anyhow!(error))?;
     Ok(())
 }
@@ -56,7 +58,7 @@ pub async fn handle_auth_status(
     .await
     .context("Error creating client")?;
 
-    let user_info = api.user_info(&config.auth_info).await;
+    let user_info = api.user_info().await;
 
     match user_info {
         Ok(user) => {
@@ -90,8 +92,8 @@ pub async fn handle_auth_token(
     };
 
     if matches.is_present("bearer") {
-        let tokens =
-            auth::handle_refresh_tokens(&config.auth_info, refresh_token, ignore_certs).await?;
+        let api_uri = &config.connection.uri;
+        let tokens = auth::handle_refresh_tokens(refresh_token, ignore_certs, api_uri).await?;
         println!("{}", tokens.access_token);
         Ok(ExitCode::Ok.into())
     } else {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
 use phylum_types::types::auth::*;
@@ -25,7 +24,6 @@ pub struct ConnectionInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AuthInfo {
-    pub oidc_discovery_url: Url,
     pub offline_access: Option<RefreshToken>,
 }
 
@@ -56,10 +54,6 @@ impl Default for Config {
                 uri: "https://api.phylum.io".into(),
             },
             auth_info: AuthInfo {
-                oidc_discovery_url:
-                    "https://login.phylum.io/auth/realms/phylum/.well-known/openid-configuration"
-                        .parse()
-                        .unwrap(),
                 offline_access: None,
             },
             request_type: PackageType::Npm,
@@ -216,7 +210,6 @@ mod tests {
         };
 
         let auth = AuthInfo {
-            oidc_discovery_url: Url::parse("http://example.com").unwrap(),
             offline_access: Some(RefreshToken::new("FAKE TOKEN")),
         };
 

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -32,7 +32,7 @@ pub mod mockito {
     pub const DUMMY_ID_TOKEN: &str = "DUMMY_ID_TOKEN";
     pub const DUMMY_AUTH_CODE: &str = "DUMMY_AUTH_CODE";
 
-    pub const OIDC_URI: &str = "oidc";
+    pub const OIDC_URI: &str = "api/v0/.well-known/openid-configuration";
     pub const AUTH_URI: &str = "auth";
     pub const USER_URI: &str = "user";
     pub const TOKEN_URI: &str = "token";
@@ -126,25 +126,21 @@ pub mod mockito {
         mock_server
     }
 
-    pub fn build_authenticated_auth_info(mock_server: &MockServer) -> AuthInfo {
+    pub fn build_authenticated_auth_info() -> AuthInfo {
         AuthInfo {
             offline_access: Some(RefreshToken::new(DUMMY_REFRESH_TOKEN)),
-            oidc_discovery_url: Url::from_str(&format!("{}/{}", mock_server.uri(), OIDC_URI))
-                .expect("Failed to parse test url"),
         }
     }
 
-    pub fn build_unauthenticated_auth_info(mock_server: &MockServer) -> AuthInfo {
+    pub fn build_unauthenticated_auth_info() -> AuthInfo {
         AuthInfo {
             offline_access: None,
-            oidc_discovery_url: Url::from_str(&format!("{}/{}", mock_server.uri(), OIDC_URI))
-                .expect("Failed to parse test url"),
         }
     }
 
     pub async fn build_phylum_api(mock_server: &MockServer) -> Result<PhylumApi, PhylumApiError> {
         let phylum = PhylumApi::new(
-            &mut build_authenticated_auth_info(mock_server),
+            &mut build_authenticated_auth_info(),
             mock_server.uri().as_str(),
             None,
             false,


### PR DESCRIPTION
Previously the `oidc_discovery_url` had to be specified in the
configuration file to handle the user authentication.

This patch makes use of the new `/.well-known/openid-configuration`
endpoint of the API, which automatically redirects to the correct URL.

Closes #373.