### PR TITLE
Don't use streaming parsers

### DIFF
--- a/cli/src/lockfiles/parsers/mod.rs
+++ b/cli/src/lockfiles/parsers/mod.rs
@@ -1,10 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::{tag, take, take_until},
-    character::{
-        complete::{line_ending, none_of, not_line_ending, space0},
-        streaming::multispace0,
-    },
+    character::complete::{line_ending, multispace0, none_of, not_line_ending, space0},
     combinator::{eof, opt, recognize},
     error::{context, ParseError, VerboseError},
     multi::{count, many1, many_till},


### PR DESCRIPTION
The use of streaming parsers in combination with nom::Finish will
occasionally cause a panic...

Fixes #402