### PR TITLE
Emit unique exit code when failing thresholds

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -29,7 +29,7 @@ pub fn exit_warn(message: impl AsRef<str>) -> ! {
     ExitCode::Ok.exit()
 }
 
-/// Print an error to the user before exiting with exit code 1.
+/// Print an error to the user before exiting with the passed exit code.
 pub fn exit_fail(message: impl AsRef<str>, exit_code: ExitCode) -> ! {
     error!("{}", message.as_ref());
     print_user_failure!("Error: {}", message.as_ref());

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,5 @@
+use std::process;
+
 use phylum_types::types::job::Action;
 
 pub mod auth;
@@ -27,10 +29,20 @@ impl From<ExitCode> for CommandValue {
 pub type CommandResult = anyhow::Result<CommandValue>;
 
 /// Unique exit code values.
+#[derive(Copy, Clone)]
 pub enum ExitCode {
     Ok = 0,
+    Generic = 1,
     NotAuthenticated = 10,
     AuthenticationFailure = 11,
     PackageNotFound = 12,
     SetThresholdsFailure = 13,
+    FailedThresholds = 100,
+}
+
+impl ExitCode {
+    /// Terminate the application with this exit code.
+    pub fn exit(&self) -> ! {
+        process::exit(*self as i32);
+    }
 }

--- a/docs/analyzing-dependencies.md
+++ b/docs/analyzing-dependencies.md
@@ -67,3 +67,5 @@ If you prefer JSON formatted output, you can leverage the `--json` flag.
 ```sh
 phylum analyze --verbose --json <package-lock-file.ext> > output.json
 ```
+
+If the analysis failed to meet the project's thresholds, the command's exit code will be set to `100`.


### PR DESCRIPTION
Previously a failure to meet project thresholds would result in the
generic exit code of 1, making it difficult to identify the type of
error that occurred.

Instead of returning a generic exit code of 1, a special exit code of
100 has been introduced to identify failure to meet the project
thresholds.

Closes #403.
