### PR TITLE
Revert "Use new format for package analysis endpoint (#384)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#fb64032119e160a4b7719dd58ba1e10454d6af0a"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#3f596a1924f640b70b1fd8aa7611aff29bc2010b"
 dependencies = [
  "chrono",
  "log",

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -35,7 +35,7 @@ pub fn get_package_status(api_uri: &str, pkg: &PackageDescriptor) -> String {
         version,
         ..
     } = pkg;
-    format!("{api_uri}/{API_PATH}/data/packages/{package_type}/{name_escaped}/{version}")
+    format!("{api_uri}/{API_PATH}/job/packages/{package_type}/{name_escaped}/{version}")
 }
 
 /// GET /job/projects/name/<pkg_id>

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -295,7 +295,10 @@ impl PhylumApi {
     }
 
     /// Get package details
-    pub async fn get_package_details(&mut self, pkg: &PackageDescriptor) -> Result<Package> {
+    pub async fn get_package_details(
+        &mut self,
+        pkg: &PackageDescriptor,
+    ) -> Result<PackageStatusExtended> {
         self.get(endpoints::get_package_status(&self.api_uri, pkg))
             .await
     }
@@ -490,51 +493,43 @@ mod tests {
     async fn get_package_details() -> Result<()> {
         let body = r#"
         {
-          "id": "npm:@schematics~angular:9.1.9",
-          "name": "@schematics~angular",
-          "version": "9.1.9",
-          "registry": "npm",
-          "publishedDate": "1970-01-01T00:00:00+00:00",
-          "latestVersion": null,
-          "versions": [],
-          "description": null,
-          "license": null,
-          "depSpecs": [],
-          "dependencies": [],
-          "downloadCount": 0,
-          "riskScores": {
-            "total": 1,
-            "vulnerability": 1,
-            "malicious_code": 1,
-            "author": 1,
-            "engineering": 1,
-            "license": 1
-          },
-          "totalRiskScoreDynamics": null,
-          "issuesDetails": [],
-          "issues": [],
-          "authors": [],
-          "developerResponsiveness": {
-            "open_issue_count": 167,
-            "total_issue_count": 393,
-            "open_issue_avg_duration": 980,
-            "open_pull_request_count": 50,
-            "total_pull_request_count": 476,
-            "open_pull_request_avg_duration": 474
-          },
-          "issueImpacts": {
-            "low": 0,
-            "medium": 0,
-            "high": 0,
-            "critical": 0
-          },
-          "complete": false
-        }
+            "name": "@schematics/angular",
+            "version": "9.1.9",
+            "type": "npm",
+            "last_updated": 1611962723183,
+            "license": "MIT",
+            "package_score": 1.0,
+            "num_dependencies": 2,
+            "num_vulnerabilities": 4,
+            "msg": "Project met threshold requirements",
+            "pass": true,
+            "action": "warn",
+            "status": "complete",
+            "riskVectors": {
+                "author": 0.90,
+                "engineering": 0.42,
+                "license": 1.0,
+                "malicious_code": 1.0,
+                "vulnerability": 1.0
+            },
+            "issues": [
+                {
+                "title": "Commercial license risk in xmlrpc@0.3.0",
+                "description": "license is medium risk",
+                "risk_level": "medium",
+                "risk_domain": "license",
+                "pkg_name": "xmlrpc",
+                "pkg_version": "0.3.0",
+                "score": 0.7
+                }
+            ],
+            "dependencies": {}
+          }
         "#;
 
         let mock_server = build_mock_server().await;
         Mock::given(method("GET"))
-            .and(path("/api/v0/data/packages/npm/@schematics~angular/9.1.9"))
+            .and(path("/api/v0/job/packages/npm/@schematics~angular/9.1.9"))
             .respond_with_fn(move |_| ResponseTemplate::new(200).set_body_string(body))
             .mount(&mock_server)
             .await;

--- a/cli/src/filter.rs
+++ b/cli/src/filter.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::str::FromStr;
 
-use phylum_types::types::package::{RiskLevel, RiskType};
+use phylum_types::types::package::{RiskDomain, RiskLevel};
 
 pub struct Filter {
     pub level: Option<RiskLevel>,
-    pub domains: Option<Vec<RiskType>>,
+    pub domains: Option<Vec<RiskDomain>>,
 }
 
 impl FromStr for Filter {
@@ -37,27 +37,27 @@ impl FromStr for Filter {
         let domains = tokens
             .iter()
             .filter_map(|t| match *t {
-                "aut" => Some(RiskType::AuthorsRisk),
-                "AUT" => Some(RiskType::AuthorsRisk),
-                "auth" => Some(RiskType::AuthorsRisk),
-                "author" => Some(RiskType::AuthorsRisk),
-                "eng" => Some(RiskType::EngineeringRisk),
-                "ENG" => Some(RiskType::EngineeringRisk),
-                "engineering" => Some(RiskType::EngineeringRisk),
-                "code" => Some(RiskType::MaliciousCodeRisk),
-                "malicious_code" => Some(RiskType::MaliciousCodeRisk),
-                "mal" => Some(RiskType::MaliciousCodeRisk),
-                "MAL" => Some(RiskType::MaliciousCodeRisk),
-                "vuln" => Some(RiskType::Vulnerabilities),
-                "vulnerability" => Some(RiskType::Vulnerabilities),
-                "VLN" => Some(RiskType::Vulnerabilities),
-                "vln" => Some(RiskType::Vulnerabilities),
-                "license" => Some(RiskType::LicenseRisk),
-                "lic" => Some(RiskType::LicenseRisk),
-                "LIC" => Some(RiskType::LicenseRisk),
+                "aut" => Some(RiskDomain::AuthorRisk),
+                "AUT" => Some(RiskDomain::AuthorRisk),
+                "auth" => Some(RiskDomain::AuthorRisk),
+                "author" => Some(RiskDomain::AuthorRisk),
+                "eng" => Some(RiskDomain::EngineeringRisk),
+                "ENG" => Some(RiskDomain::EngineeringRisk),
+                "engineering" => Some(RiskDomain::EngineeringRisk),
+                "code" => Some(RiskDomain::MaliciousCode),
+                "malicious_code" => Some(RiskDomain::MaliciousCode),
+                "mal" => Some(RiskDomain::MaliciousCode),
+                "MAL" => Some(RiskDomain::MaliciousCode),
+                "vuln" => Some(RiskDomain::Vulnerabilities),
+                "vulnerability" => Some(RiskDomain::Vulnerabilities),
+                "VLN" => Some(RiskDomain::Vulnerabilities),
+                "vln" => Some(RiskDomain::Vulnerabilities),
+                "license" => Some(RiskDomain::LicenseRisk),
+                "lic" => Some(RiskDomain::LicenseRisk),
+                "LIC" => Some(RiskDomain::LicenseRisk),
                 _ => None,
             })
-            .collect::<HashSet<RiskType>>();
+            .collect::<HashSet<RiskDomain>>();
 
         let domains = if domains.is_empty() {
             None
@@ -103,8 +103,8 @@ mod tests {
             .expect("No risk domains parsed from filter string");
 
         assert_eq!(domains.len(), 2);
-        assert!(domains.contains(&RiskType::AuthorsRisk));
-        assert!(domains.contains(&RiskType::EngineeringRisk));
+        assert!(domains.contains(&RiskDomain::AuthorRisk));
+        assert!(domains.contains(&RiskDomain::EngineeringRisk));
 
         let filter_string = "crit,author,AUT,med,ENG,foo,engineering,VLN";
 
@@ -115,8 +115,8 @@ mod tests {
             .expect("No risk domains parsed from filter string");
 
         assert_eq!(domains.len(), 3);
-        assert!(domains.contains(&RiskType::AuthorsRisk));
-        assert!(domains.contains(&RiskType::EngineeringRisk));
-        assert!(domains.contains(&RiskType::Vulnerabilities));
+        assert!(domains.contains(&RiskDomain::AuthorRisk));
+        assert!(domains.contains(&RiskDomain::EngineeringRisk));
+        assert!(domains.contains(&RiskDomain::Vulnerabilities));
     }
 }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -282,22 +282,6 @@ impl Renderable for PackageStatusExtended {
     }
 }
 
-impl Renderable for Package {
-    fn render(&self) -> String {
-        let unknown = String::from("Unknown"); // TODO
-        let time = self.published_date.as_ref().unwrap_or(&unknown);
-
-        let mut overview_table = table!(
-            ["Package Name:", rB -> self.name, "Package Version:", r -> self.version],
-            ["License:", r -> self.license.as_ref().unwrap_or(&"Unknown".to_string()), "Last updated:", r -> time],
-            ["Num Deps:", r -> self.dependencies.as_ref().map(Vec::len).unwrap_or(0), "Num Vulns:", r -> self.issues.len()],
-            ["Ecosystem:", r -> self.registry.render()]
-        );
-        overview_table.set_format(table_format(0, 3));
-        overview_table.to_string()
-    }
-}
-
 impl Renderable for CancelJobResponse {
     fn render(&self) -> String {
         format!("Request canceled: {}", self.msg)

--- a/cli/src/summarize.rs
+++ b/cli/src/summarize.rs
@@ -216,12 +216,12 @@ impl Summarize for JobStatusResponse<PackageStatus> {
 fn check_filter_issue(filter: &Filter, issue: &Issue) -> bool {
     let mut include = true;
     if let Some(ref level) = filter.level {
-        if issue.severity < *level {
+        if issue.risk_level < *level {
             include = false;
         }
     }
     if let Some(ref domains) = filter.domains {
-        if !domains.contains(&issue.domain.into()) {
+        if !domains.contains(&issue.risk_domain) {
             include = false;
         }
     }
@@ -249,7 +249,7 @@ impl Summarize for JobStatusResponse<PackageStatusExtended> {
             }
         }
 
-        issues.sort_by(|a, b| a.severity.partial_cmp(&b.severity).unwrap());
+        issues.sort_by(|a, b| a.risk_level.partial_cmp(&b.risk_level).unwrap());
         issues.reverse();
 
         for issue in issues {
@@ -277,13 +277,13 @@ impl Summarize for PackageStatusExtended {
                     let mut include = true;
 
                     if let Some(ref level) = filter.level {
-                        if i.severity < *level {
+                        if i.risk_level < *level {
                             include = false;
                         }
                     }
 
                     if let Some(domains) = &filter.domains {
-                        if !domains.contains(&i.domain.into()) {
+                        if !domains.contains(&i.risk_domain) {
                             include = false;
                         }
                     }
@@ -335,72 +335,6 @@ impl Summarize for PackageStatusExtended {
     }
 }
 
-impl Summarize for Package {
-    fn summarize(&self, filter: Option<Filter>) {
-        let mut issues_table = Table::new();
-        issues_table.set_format(table_format(3, 0));
-
-        let issues = if let Some(ref filter) = filter {
-            self.issues
-                .iter()
-                .filter_map(|i| {
-                    let mut include = true;
-
-                    if let Some(ref level) = filter.level {
-                        if i.impact < *level {
-                            include = false;
-                        }
-                    }
-
-                    if let Some(domains) = &filter.domains {
-                        if !domains.contains(&i.risk_type) {
-                            include = false;
-                        }
-                    }
-                    if include {
-                        Some(i.to_owned())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<IssuesListItem>>()
-        } else {
-            self.issues.to_owned()
-        };
-
-        for issue in &issues {
-            let rows: Vec<Row> = issueslistitem_to_row(issue);
-            for mut row in rows {
-                row.remove_cell(2);
-                issues_table.add_row(row);
-            }
-            issues_table.add_empty_row();
-        }
-
-        let risk_to_string = |risk: f32| format!("{}", (100. * risk).round());
-
-        let mut risks_table = table![
-            ["Total Risk:", r -> risk_to_string(self.risk_scores.total)],
-            ["Author Risk:", r -> risk_to_string(self.risk_scores.author)],
-            ["Engineering Risk:", r -> risk_to_string(self.risk_scores.engineering)],
-            ["License Risk:", r -> risk_to_string(self.risk_scores.license)],
-            ["Malicious Code Risk:", r -> risk_to_string(self.risk_scores.malicious_code)],
-            ["Vulnerability Risk:", r -> risk_to_string(self.risk_scores.vulnerability)]
-        ];
-        risks_table.set_format(table_format(3, 1));
-
-        println!("{}", self.render());
-
-        println!(" Risk Vectors:");
-        risks_table.printstd();
-
-        if !issues_table.is_empty() {
-            println!("\n Issues:");
-            issues_table.printstd();
-        }
-    }
-}
-
 impl Summarize for Vec<JobDescriptor> {
     fn summarize(&self, _filter: Option<Filter>) {
         println!("Last {} runs\n\n{}", self.len(), self.render());
@@ -428,7 +362,7 @@ mod tests {
         let issue = r#"{
                     "title": "Commercial license risk in xmlrpc@0.3.0",
                     "description": "license is medium risk",
-                    "severity": "medium",
+                    "risk_level": "medium",
                     "domain": "license"
                     }"#;
         let issue: Issue = serde_json::from_str(issue).unwrap();
@@ -455,30 +389,11 @@ fn risk_level_to_color(level: &RiskLevel) -> Color {
 
 fn issue_to_row(issue: &Issue) -> Vec<Row> {
     let row_1 = Row::new(vec![
-        Cell::new_align(&issue.severity.to_string(), format::Alignment::LEFT)
-            .with_style(Attr::ForegroundColor(risk_level_to_color(&issue.severity))),
+        Cell::new_align(&issue.risk_level.to_string(), format::Alignment::LEFT).with_style(
+            Attr::ForegroundColor(risk_level_to_color(&issue.risk_level)),
+        ),
         Cell::new_align(
-            &format!("{} [{}]", &issue.title, issue.domain),
-            format::Alignment::LEFT,
-        )
-        .with_style(Attr::Bold),
-    ]);
-
-    let row_2 = Row::new(vec![
-        Cell::new(""),
-        Cell::new(&textwrap::fill(&issue.description, 80)),
-        Cell::new(""),
-    ]);
-
-    vec![row_1, row![], row_2]
-}
-
-fn issueslistitem_to_row(issue: &IssuesListItem) -> Vec<Row> {
-    let row_1 = Row::new(vec![
-        Cell::new_align(&issue.impact.to_string(), format::Alignment::LEFT)
-            .with_style(Attr::ForegroundColor(risk_level_to_color(&issue.impact))),
-        Cell::new_align(
-            &format!("{} [{}]", &issue.title, issue.risk_type),
+            &format!("{} [{}]", &issue.title, issue.risk_domain),
             format::Alignment::LEFT,
         )
         .with_style(Attr::Bold),


### PR DESCRIPTION
This reverts commit df2130b5c81e0e05958f380a8f715ae70b2c0c73.

The change in #384 fixed #376, but accidentally caused phylum-dev/api#254

Doing this revert is the quickest way to resolve this mistake. But it will require us to re-open #376 and find a solution that does not cause this breakage.