### PR TITLE
Bump to v3.5.0 - Automatically detect OIDC URL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.5.0 - Automatically detect OIDC URL
 * 3.4.0 - Group account support
 * 3.3.0 - Introduce parse command
 * 3.2.0 - Support yarn patched dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phylum-cli"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Eric Freitag <eric@phylum.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Bump to v3.5.0 - Automatically detect OIDC URL

Release-Version: v3.5.0
Release-Summary: Automatically detect OIDC URL