### PR TITLE
Use unit structs for parsers

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -9,11 +9,11 @@ use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use super::{CommandResult, ExitCode};
 use crate::lockfiles::{
-    parse_file, CSProj, GemLock, GradleLock, PackageLock, Parser, PipFile, Poetry, Pom,
+    parse_file, CSProj, GemLock, GradleLock, PackageLock, Parse, PipFile, Poetry, Pom,
     PyRequirements, YarnLock,
 };
 
-const LOCKFILE_PARSERS: &[(&str, &dyn Parser)] = &[
+const LOCKFILE_PARSERS: &[(&str, &dyn Parse)] = &[
     ("yarn", &YarnLock),
     ("npm", &PackageLock),
     ("gem", &GemLock),
@@ -110,7 +110,7 @@ pub fn get_packages_from_lockfile(path: &Path) -> Result<(Vec<PackageDescriptor>
 }
 
 /// Get all packages for a specific lockfile type.
-fn parse<P: Parser>(parser: P, path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
+fn parse<P: Parse>(parser: P, path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
     let pkg_type = parser.package_type();
     parse_file(parser, path).map(|pkgs| (pkgs, pkg_type))
 }

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -9,8 +9,7 @@ use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use super::{CommandResult, ExitCode};
 use crate::lockfiles::{
-    parse_file, CSProj, GemLock, GradleLock, PackageLock, Parse, PipFile, Poetry, Pom,
-    PyRequirements, YarnLock,
+    CSProj, GemLock, GradleLock, PackageLock, Parse, PipFile, Poetry, Pom, PyRequirements, YarnLock,
 };
 
 const LOCKFILE_PARSERS: &[(&str, &dyn Parse)] = &[
@@ -110,9 +109,12 @@ pub fn get_packages_from_lockfile(path: &Path) -> Result<(Vec<PackageDescriptor>
 }
 
 /// Get all packages for a specific lockfile type.
-fn parse<P: Parse>(parser: P, path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
+fn parse<P: Parse + Sized>(
+    parser: P,
+    path: &Path,
+) -> Result<(Vec<PackageDescriptor>, PackageType)> {
     let pkg_type = parser.package_type();
-    parse_file(parser, path).map(|pkgs| (pkgs, pkg_type))
+    parser.parse_file(path).map(|pkgs| (pkgs, pkg_type))
 }
 
 #[cfg(test)]

--- a/cli/src/lockfiles/csharp.rs
+++ b/cli/src/lockfiles/csharp.rs
@@ -77,11 +77,10 @@ impl Parse for CSProj {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_csproj() {
-        let pkgs = parse_file(CSProj, "tests/fixtures/sample.csproj").unwrap();
+        let pkgs = CSProj.parse_file("tests/fixtures/sample.csproj").unwrap();
 
         assert_eq!(pkgs.len(), 5);
         assert_eq!(pkgs[0].name, "Microsoft.NETFramework.ReferenceAssemblies");
@@ -96,7 +95,9 @@ mod tests {
 
     #[test]
     fn lock_parse_another_invalid_char() {
-        let pkgs = parse_file(CSProj, "tests/fixtures/Calculator.csproj").unwrap();
+        let pkgs = CSProj
+            .parse_file("tests/fixtures/Calculator.csproj")
+            .unwrap();
         assert!(!pkgs.is_empty());
     }
 }

--- a/cli/src/lockfiles/csharp.rs
+++ b/cli/src/lockfiles/csharp.rs
@@ -3,7 +3,7 @@ use serde_xml_rs::Deserializer;
 
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
-use crate::lockfiles::{ParseResult, Parser};
+use crate::lockfiles::{Parse, ParseResult};
 
 pub struct CSProj;
 
@@ -59,7 +59,7 @@ impl From<Project> for Vec<PackageDescriptor> {
     }
 }
 
-impl Parser for CSProj {
+impl Parse for CSProj {
     /// Parses `.csproj` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let data = data.trim_start_matches(INVALID_CHAR);

--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -5,12 +5,12 @@ use phylum_types::ecosystems::maven::{Dependency, Plugin, Project};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use super::parsers::gradle_dep;
-use crate::lockfiles::{ParseResult, Parser};
+use crate::lockfiles::{Parse, ParseResult};
 
 pub struct Pom;
 pub struct GradleLock;
 
-impl Parser for GradleLock {
+impl Parse for GradleLock {
     /// Parses `gradle.lockfile` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let (_, entries) = gradle_dep::parse(data)
@@ -25,7 +25,7 @@ impl Parser for GradleLock {
     }
 }
 
-impl Parser for Pom {
+impl Parse for Pom {
     /// Parses maven effecti-pom files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         // Get plugin dependencies

--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -1,6 +1,3 @@
-use std::io;
-use std::path::Path;
-
 use anyhow::{anyhow, Context};
 use nom::error::convert_error;
 use nom::Finish;
@@ -8,22 +5,14 @@ use phylum_types::ecosystems::maven::{Dependency, Plugin, Project};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use super::parsers::gradle_dep;
-use crate::lockfiles::{ParseResult, Parseable};
+use crate::lockfiles::{ParseResult, Parser};
 
-pub struct Pom(String);
-pub struct GradleLock(String);
+pub struct Pom;
+pub struct GradleLock;
 
-impl Parseable for GradleLock {
-    fn new(filename: &Path) -> Result<Self, io::Error>
-    where
-        Self: Sized,
-    {
-        Ok(GradleLock(std::fs::read_to_string(filename)?))
-    }
-
+impl Parser for GradleLock {
     /// Parses `gradle.lockfile` files into a vec of packages
-    fn parse(&self) -> ParseResult {
-        let data = self.0.as_str();
+    fn parse(&self, data: &str) -> ParseResult {
         let (_, entries) = gradle_dep::parse(data)
             .finish()
             .map_err(|e| anyhow!(convert_error(data, e)))
@@ -31,21 +20,14 @@ impl Parseable for GradleLock {
         Ok(entries)
     }
 
-    fn package_type() -> PackageType {
+    fn package_type(&self) -> PackageType {
         PackageType::Maven
     }
 }
 
-impl Parseable for Pom {
-    fn new(filename: &Path) -> Result<Self, io::Error>
-    where
-        Self: Sized,
-    {
-        Ok(Pom(std::fs::read_to_string(filename)?))
-    }
-
+impl Parser for Pom {
     /// Parses maven effecti-pom files into a vec of packages
-    fn parse(&self) -> ParseResult {
+    fn parse(&self, data: &str) -> ParseResult {
         // Get plugin dependencies
         fn get_plugin_deps(plugins: &[Plugin]) -> Vec<Dependency> {
             plugins
@@ -69,7 +51,7 @@ impl Parseable for Pom {
         }
 
         // Get project reference
-        let pom: Project = serde_xml_rs::from_str(&self.0)?;
+        let pom: Project = serde_xml_rs::from_str(data)?;
 
         // Get project dependencies
         let mut dependencies = pom.dependencies.unwrap_or_default().dependencies;
@@ -140,14 +122,14 @@ impl Parseable for Pom {
                             &dep.artifact_id.clone().unwrap_or_default()
                         ),
                         version: s.into(),
-                        package_type: Self::package_type(),
+                        package_type: self.package_type(),
                     })
                 })
             })
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn package_type() -> PackageType {
+    fn package_type(&self) -> PackageType {
         PackageType::Maven
     }
 }
@@ -155,12 +137,11 @@ impl Parseable for Pom {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_gradle() {
-        let parser = GradleLock::new(Path::new("tests/fixtures/gradle.lockfile")).unwrap();
-
-        let pkgs = parser.parse().unwrap();
+        let pkgs = parse_file(GradleLock, "tests/fixtures/gradle.lockfile").unwrap();
 
         assert_eq!(pkgs.len(), 5);
 
@@ -175,9 +156,8 @@ mod tests {
 
     #[test]
     fn lock_parse_effective_pom() {
-        let parser = Pom::new(Path::new("tests/fixtures/effective-pom.xml")).unwrap();
+        let mut pkgs = parse_file(Pom, "tests/fixtures/effective-pom.xml").unwrap();
 
-        let mut pkgs = parser.parse().unwrap();
         pkgs.sort_by(|a, b| a.version.cmp(&b.version));
         assert_eq!(pkgs.len(), 16);
         assert_eq!(pkgs[0].name, "com.bitalino:bitalino-java-sdk");

--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -137,11 +137,12 @@ impl Parse for Pom {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_gradle() {
-        let pkgs = parse_file(GradleLock, "tests/fixtures/gradle.lockfile").unwrap();
+        let pkgs = GradleLock
+            .parse_file("tests/fixtures/gradle.lockfile")
+            .unwrap();
 
         assert_eq!(pkgs.len(), 5);
 
@@ -156,7 +157,7 @@ mod tests {
 
     #[test]
     fn lock_parse_effective_pom() {
-        let mut pkgs = parse_file(Pom, "tests/fixtures/effective-pom.xml").unwrap();
+        let mut pkgs = Pom.parse_file("tests/fixtures/effective-pom.xml").unwrap();
 
         pkgs.sort_by(|a, b| a.version.cmp(&b.version));
         assert_eq!(pkgs.len(), 16);

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -6,12 +6,12 @@ use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 
 use super::parsers::yarn;
-use crate::lockfiles::{ParseResult, Parser};
+use crate::lockfiles::{Parse, ParseResult};
 
 pub struct PackageLock;
 pub struct YarnLock;
 
-impl Parser for PackageLock {
+impl Parse for PackageLock {
     /// Parses `package-lock.json` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let parsed: JsonValue = serde_json::from_str(data)?;
@@ -66,7 +66,7 @@ fn is_yarn_v2(yaml: &&serde_yaml::Mapping) -> bool {
         .any(|(k, _v)| k.as_str().unwrap_or_default() == "__metadata")
 }
 
-impl Parser for YarnLock {
+impl Parse for YarnLock {
     /// Parses `yarn.lock` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let yaml = serde_yaml::from_str::<YamlValue>(data).ok();

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -168,11 +168,12 @@ impl Parse for YarnLock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_package() {
-        let pkgs = parse_file(PackageLock, "tests/fixtures/package-lock-v6.json").unwrap();
+        let pkgs = PackageLock
+            .parse_file("tests/fixtures/package-lock-v6.json")
+            .unwrap();
 
         assert_eq!(pkgs.len(), 17);
         assert_eq!(pkgs[0].name, "@yarnpkg/lockfile");
@@ -187,7 +188,9 @@ mod tests {
 
     #[test]
     fn lock_parse_package_v7() {
-        let pkgs = parse_file(PackageLock, "tests/fixtures/package-lock.json").unwrap();
+        let pkgs = PackageLock
+            .parse_file("tests/fixtures/package-lock.json")
+            .unwrap();
 
         assert_eq!(pkgs.len(), 50);
 
@@ -215,7 +218,9 @@ mod tests {
         //
         // We need to make sure we don't take the v2 lockfile code path because this is not a v2
         // lockfile and parsing it as one will produce incorrect results.
-        let pkgs = parse_file(YarnLock, "tests/fixtures/yarn-v1.simple.lock").unwrap();
+        let pkgs = YarnLock
+            .parse_file("tests/fixtures/yarn-v1.simple.lock")
+            .unwrap();
 
         assert_eq!(
             pkgs,
@@ -233,7 +238,7 @@ mod tests {
             "tests/fixtures/yarn-v1.lock",
             "tests/fixtures/yarn-v1.trailing_newlines.lock",
         ] {
-            let pkgs = parse_file(YarnLock, p).unwrap();
+            let pkgs = YarnLock.parse_file(p).unwrap();
 
             assert_eq!(pkgs.len(), 17);
 
@@ -255,12 +260,14 @@ mod tests {
     #[should_panic]
     #[test]
     fn lock_parse_yarn_v1_malformed_fails() {
-        parse_file(YarnLock, "tests/fixtures/yarn-v1.lock.bad").unwrap();
+        YarnLock
+            .parse_file("tests/fixtures/yarn-v1.lock.bad")
+            .unwrap();
     }
 
     #[test]
     fn lock_parse_yarn() {
-        let pkgs = parse_file(YarnLock, "tests/fixtures/yarn.lock").unwrap();
+        let pkgs = YarnLock.parse_file("tests/fixtures/yarn.lock").unwrap();
 
         assert_eq!(pkgs.len(), 53);
 

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -1,6 +1,3 @@
-use std::io;
-use std::path::Path;
-
 use anyhow::{anyhow, Context};
 use nom::error::convert_error;
 use nom::Finish;
@@ -9,22 +6,15 @@ use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 
 use super::parsers::yarn;
-use crate::lockfiles::{ParseResult, Parseable};
+use crate::lockfiles::{ParseResult, Parser};
 
-pub struct PackageLock(String);
-pub struct YarnLock(String);
+pub struct PackageLock;
+pub struct YarnLock;
 
-impl Parseable for PackageLock {
-    fn new(filename: &Path) -> Result<Self, io::Error>
-    where
-        Self: Sized,
-    {
-        Ok(PackageLock(std::fs::read_to_string(filename)?))
-    }
-
+impl Parser for PackageLock {
     /// Parses `package-lock.json` files into a vec of packages
-    fn parse(&self) -> ParseResult {
-        let parsed: JsonValue = serde_json::from_str(&self.0)?;
+    fn parse(&self, data: &str) -> ParseResult {
+        let parsed: JsonValue = serde_json::from_str(data)?;
 
         let into_descriptor = |(name, v): (String, &JsonValue)| {
             let version = v
@@ -36,7 +26,7 @@ impl Parseable for PackageLock {
             let pkg = PackageDescriptor {
                 name,
                 version,
-                package_type: Self::package_type(),
+                package_type: self.package_type(),
             };
             Ok(pkg)
         };
@@ -62,7 +52,7 @@ impl Parseable for PackageLock {
         }
     }
 
-    fn package_type() -> PackageType {
+    fn package_type(&self) -> PackageType {
         PackageType::Npm
     }
 }
@@ -76,24 +66,16 @@ fn is_yarn_v2(yaml: &&serde_yaml::Mapping) -> bool {
         .any(|(k, _v)| k.as_str().unwrap_or_default() == "__metadata")
 }
 
-impl Parseable for YarnLock {
-    fn new(filename: &Path) -> Result<Self, io::Error>
-    where
-        Self: Sized,
-    {
-        Ok(YarnLock(std::fs::read_to_string(filename)?))
-    }
-
+impl Parser for YarnLock {
     /// Parses `yarn.lock` files into a vec of packages
-    fn parse(&self) -> ParseResult {
-        let yaml = serde_yaml::from_str::<YamlValue>(&self.0).ok();
+    fn parse(&self, data: &str) -> ParseResult {
+        let yaml = serde_yaml::from_str::<YamlValue>(data).ok();
         let yaml_mapping = yaml.as_ref().and_then(|yaml| yaml.as_mapping());
 
         // Check if we should use v1 or v2 yarn parser.
         let yaml_v2 = match yaml_mapping.filter(is_yarn_v2) {
             Some(yaml_v2) => yaml_v2,
             _ => {
-                let data = self.0.as_str();
                 let (_, entries) = yarn::parse(data)
                     .finish()
                     .map_err(|e| anyhow!(convert_error(data, e)))
@@ -169,7 +151,7 @@ impl Parseable for YarnLock {
             };
 
             packages.push(PackageDescriptor {
-                package_type: Self::package_type(),
+                package_type: self.package_type(),
                 name: name.to_owned(),
                 version,
             });
@@ -178,7 +160,7 @@ impl Parseable for YarnLock {
         Ok(packages)
     }
 
-    fn package_type() -> PackageType {
+    fn package_type(&self) -> PackageType {
         PackageType::Npm
     }
 }
@@ -186,12 +168,12 @@ impl Parseable for YarnLock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_package() {
-        let parser = PackageLock::new(Path::new("tests/fixtures/package-lock-v6.json")).unwrap();
+        let pkgs = parse_file(PackageLock, "tests/fixtures/package-lock-v6.json").unwrap();
 
-        let pkgs = parser.parse().unwrap();
         assert_eq!(pkgs.len(), 17);
         assert_eq!(pkgs[0].name, "@yarnpkg/lockfile");
         assert_eq!(pkgs[0].version, "1.1.0");
@@ -205,9 +187,7 @@ mod tests {
 
     #[test]
     fn lock_parse_package_v7() {
-        let parser = PackageLock::new(Path::new("tests/fixtures/package-lock.json")).unwrap();
-
-        let pkgs = parser.parse().unwrap();
+        let pkgs = parse_file(PackageLock, "tests/fixtures/package-lock.json").unwrap();
 
         assert_eq!(pkgs.len(), 50);
 
@@ -235,10 +215,10 @@ mod tests {
         //
         // We need to make sure we don't take the v2 lockfile code path because this is not a v2
         // lockfile and parsing it as one will produce incorrect results.
-        let parser = YarnLock::new(Path::new("tests/fixtures/yarn-v1.simple.lock")).unwrap();
+        let pkgs = parse_file(YarnLock, "tests/fixtures/yarn-v1.simple.lock").unwrap();
 
         assert_eq!(
-            parser.parse().unwrap(),
+            pkgs,
             vec![PackageDescriptor {
                 name: "@yarnpkg/lockfile".to_string(),
                 version: "1.1.0".to_string(),
@@ -253,9 +233,8 @@ mod tests {
             "tests/fixtures/yarn-v1.lock",
             "tests/fixtures/yarn-v1.trailing_newlines.lock",
         ] {
-            let parser = YarnLock::new(Path::new(p)).unwrap();
+            let pkgs = parse_file(YarnLock, p).unwrap();
 
-            let pkgs = parser.parse().unwrap();
             assert_eq!(pkgs.len(), 17);
 
             assert_eq!(pkgs[0].name, "@yarnpkg/lockfile");
@@ -276,16 +255,12 @@ mod tests {
     #[should_panic]
     #[test]
     fn lock_parse_yarn_v1_malformed_fails() {
-        let parser = YarnLock::new(Path::new("tests/fixtures/yarn-v1.lock.bad")).unwrap();
-
-        parser.parse().unwrap();
+        parse_file(YarnLock, "tests/fixtures/yarn-v1.lock.bad").unwrap();
     }
 
     #[test]
     fn lock_parse_yarn() {
-        let parser = YarnLock::new(Path::new("tests/fixtures/yarn.lock")).unwrap();
-
-        let pkgs = parser.parse().unwrap();
+        let pkgs = parse_file(YarnLock, "tests/fixtures/yarn.lock").unwrap();
 
         assert_eq!(pkgs.len(), 53);
 

--- a/cli/src/lockfiles/mod.rs
+++ b/cli/src/lockfiles/mod.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::marker::Sized;
+use std::fs::read_to_string;
 use std::path::Path;
 
 use phylum_types::types::package::PackageDescriptor;
@@ -20,12 +19,15 @@ pub use ruby::GemLock;
 
 pub type ParseResult = anyhow::Result<Vec<PackageDescriptor>>;
 
-pub trait Parseable {
-    fn new(filename: &Path) -> Result<Self, io::Error>
-    where
-        Self: Sized;
+pub trait Parser {
+    /// Parse from a string
+    fn parse(&self, data: &str) -> ParseResult;
+    /// Indicate the type of packages parsed by this parser
+    fn package_type(&self) -> PackageType;
+}
 
-    fn parse(&self) -> ParseResult;
-
-    fn package_type() -> PackageType;
+/// Parse a file with the given parser.
+pub fn parse_file<T: Parser, P: AsRef<Path>>(parser: T, path: P) -> ParseResult {
+    let data = read_to_string(path)?;
+    parser.parse(&data)
 }

--- a/cli/src/lockfiles/mod.rs
+++ b/cli/src/lockfiles/mod.rs
@@ -22,12 +22,16 @@ pub type ParseResult = anyhow::Result<Vec<PackageDescriptor>>;
 pub trait Parse {
     /// Parse from a string
     fn parse(&self, data: &str) -> ParseResult;
+
+    /// Parse from a file
+    fn parse_file<P: AsRef<Path>>(&self, path: P) -> ParseResult
+    where
+        Self: Sized,
+    {
+        let data = read_to_string(path)?;
+        self.parse(&data)
+    }
+
     /// Indicate the type of packages parsed by this parser
     fn package_type(&self) -> PackageType;
-}
-
-/// Parse a file with the given parser.
-pub fn parse_file<T: Parse, P: AsRef<Path>>(parser: T, path: P) -> ParseResult {
-    let data = read_to_string(path)?;
-    parser.parse(&data)
 }

--- a/cli/src/lockfiles/mod.rs
+++ b/cli/src/lockfiles/mod.rs
@@ -19,7 +19,7 @@ pub use ruby::GemLock;
 
 pub type ParseResult = anyhow::Result<Vec<PackageDescriptor>>;
 
-pub trait Parser {
+pub trait Parse {
     /// Parse from a string
     fn parse(&self, data: &str) -> ParseResult;
     /// Indicate the type of packages parsed by this parser
@@ -27,7 +27,7 @@ pub trait Parser {
 }
 
 /// Parse a file with the given parser.
-pub fn parse_file<T: Parser, P: AsRef<Path>>(parser: T, path: P) -> ParseResult {
+pub fn parse_file<T: Parse, P: AsRef<Path>>(parser: T, path: P) -> ParseResult {
     let data = read_to_string(path)?;
     parser.parse(&data)
 }

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -168,11 +168,12 @@ struct PoetryMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lockfiles::parse_file;
 
     #[test]
     fn parse_requirements() {
-        let pkgs = parse_file(PyRequirements, "tests/fixtures/requirements.txt").unwrap();
+        let pkgs = PyRequirements
+            .parse_file("tests/fixtures/requirements.txt")
+            .unwrap();
         assert_eq!(pkgs.len(), 131);
         assert_eq!(pkgs[0].name, "pyyaml");
         assert_eq!(pkgs[0].version, "5.4.1");
@@ -186,7 +187,9 @@ mod tests {
 
     #[test]
     fn parse_requirements_complex() {
-        let pkgs = parse_file(PyRequirements, "tests/fixtures/complex-requirements.txt").unwrap();
+        let pkgs = PyRequirements
+            .parse_file("tests/fixtures/complex-requirements.txt")
+            .unwrap();
         assert_eq!(pkgs.len(), 8);
         assert_eq!(pkgs[0].name, "docopt");
         assert_eq!(pkgs[0].version, "0.6.1");
@@ -203,7 +206,7 @@ mod tests {
 
     #[test]
     fn parse_pipfile() {
-        let pkgs = parse_file(PipFile, "tests/fixtures/Pipfile").unwrap();
+        let pkgs = PipFile.parse_file("tests/fixtures/Pipfile").unwrap();
         assert_eq!(pkgs.len(), 4);
 
         let expected_pkgs = [
@@ -231,7 +234,7 @@ mod tests {
 
     #[test]
     fn lock_parse_pipfile() {
-        let pkgs = parse_file(PipFile, "tests/fixtures/Pipfile.lock").unwrap();
+        let pkgs = PipFile.parse_file("tests/fixtures/Pipfile.lock").unwrap();
         assert_eq!(pkgs.len(), 27);
 
         let expected_pkgs = [
@@ -259,7 +262,7 @@ mod tests {
 
     #[test]
     fn parse_poetry_lock() {
-        let pkgs = parse_file(Poetry, "tests/fixtures/poetry.lock").unwrap();
+        let pkgs = Poetry.parse_file("tests/fixtures/poetry.lock").unwrap();
         assert_eq!(pkgs.len(), 44);
 
         let expected_pkgs = [
@@ -288,7 +291,7 @@ mod tests {
     /// Ensure sources other than PyPi are ignored.
     #[test]
     fn poetry_ignore_other_sources() {
-        let pkgs = parse_file(Poetry, "tests/fixtures/poetry.lock").unwrap();
+        let pkgs = Poetry.parse_file("tests/fixtures/poetry.lock").unwrap();
 
         let invalid_package_names = ["toml", "directory-test", "requests"];
         for pkg in pkgs {

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -8,13 +8,13 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::parsers::pypi;
-use crate::lockfiles::{ParseResult, Parser};
+use crate::lockfiles::{Parse, ParseResult};
 
 pub struct PyRequirements;
 pub struct PipFile;
 pub struct Poetry;
 
-impl Parser for PyRequirements {
+impl Parse for PyRequirements {
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let (_, entries) = pypi::parse(data)
@@ -29,7 +29,7 @@ impl Parser for PyRequirements {
     }
 }
 
-impl Parser for PipFile {
+impl Parse for PipFile {
     /// Parses `Pipfile` or `Pipfile.lock` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let mut input: HashMap<String, Value> = match toml::from_str::<toml::Value>(data).ok() {
@@ -87,7 +87,7 @@ impl Parser for PipFile {
     }
 }
 
-impl Parser for Poetry {
+impl Parse for Poetry {
     /// Parses `poetry.lock` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let mut lock: PoetryLock = toml::from_str(data)?;

--- a/cli/src/lockfiles/ruby.rs
+++ b/cli/src/lockfiles/ruby.rs
@@ -4,11 +4,11 @@ use nom::Finish;
 use phylum_types::types::package::PackageType;
 
 use super::parsers::gem;
-use crate::lockfiles::{ParseResult, Parser};
+use crate::lockfiles::{Parse, ParseResult};
 
 pub struct GemLock;
 
-impl Parser for GemLock {
+impl Parse for GemLock {
     /// Parses `Gemfile.lock` files into a vec of packages
     fn parse(&self, data: &str) -> ParseResult {
         let (_, entries) = gem::parse(data)

--- a/cli/src/lockfiles/ruby.rs
+++ b/cli/src/lockfiles/ruby.rs
@@ -28,11 +28,10 @@ mod tests {
     use phylum_types::types::package::PackageType;
 
     use super::*;
-    use crate::lockfiles::parse_file;
 
     #[test]
     fn lock_parse_gem() {
-        let pkgs = parse_file(GemLock, "tests/fixtures/Gemfile.lock").unwrap();
+        let pkgs = GemLock.parse_file("tests/fixtures/Gemfile.lock").unwrap();
         assert_eq!(pkgs.len(), 214);
         assert_eq!(pkgs[0].name, "CFPropertyList");
         assert_eq!(pkgs[0].version, "2.3.6");


### PR DESCRIPTION
This changes our parsers to be strategy objects so that they are a bit
easier to use. This allows us to simplify the LOCKFILE_PARSERS array in
commands/parser.rs and use that array in try_get_packages instead of a
macro.

Closes #347

As @cd-work suggested in #398:

> Maybe having the parsers completely stateless, just taking a &str as parameter would be the way to go.

This patch takes that idea and runs with it.