### PR TITLE
Only use deno with the extensions feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "phylum-cli"
 version = "3.5.0"
-authors = ["Eric Freitag <eric@phylum.io>"]
-edition = "2018"
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
+edition = "2021"
+rust-version = "1.60"
 
 [features]
 default = ["selfmanage"]
 phylum-online = []
 selfmanage = []
-extensions = []
+extensions = ["dep:deno_ast", "dep:deno_core"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -54,8 +55,8 @@ url = { version = "2", features = ["serde"] }
 zip = "0.6.2"
 walkdir = "2.3.2"
 regex = "1.5.5"
-deno_core = "0.135.0"
-deno_ast = { version = "0.15.0", features = ["transpiling"] }
+deno_core = { version = "0.135.0", optional = true }
+deno_ast = { version = "0.15.0", features = ["transpiling"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 pub mod auth;
 pub mod commands;
 pub mod config;
+#[cfg(feature = "extensions")]
 pub mod deno;
 pub mod filter;
 pub mod lockfiles;

--- a/docs/building.md
+++ b/docs/building.md
@@ -4,7 +4,7 @@ category: 6255e67693d5200013b1fa41
 hidden: false
 ---
 
-Phylum is written in Rust, so you'll need a recent Rust installation to build it (we tested with v1.58.0). [Install Rust](https://www.rust-lang.org/tools/install)
+Phylum is written in Rust, so you'll need a recent Rust installation to build it (we tested with v1.61.0). [Install Rust](https://www.rust-lang.org/tools/install)
 
 1. Clone repository
 


### PR DESCRIPTION
Unfortunately, it looks like the deno crates we are using fail to build
on x86_64-unknown-linux-musl... That is now recorded in #426, but in the
meantime, this change avoids including deno in our default builds

While making this change, I decided to use the `dep:` syntax for features which was introduced in Rust 1.60. I have updated our MSRV and docs accordingly.