### PR TITLE
Add shellcheck to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,19 +57,20 @@ jobs:
         with:
           command: test
           args: --locked
-  shellcheck:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Script Style Check
-        if: github.event_name != 'schedule'
-        run: shellcheck -o all -S style -s sh $(find . -iname "*.sh")
 
       - name: All Features
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
+  shellcheck:
+    # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Script Style Check
+        if: github.event_name != 'schedule'
+        run: shellcheck -o all -S style -s sh $(find . -iname "*.sh")
 
   # This job reports the results of the test matrix above
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,13 @@ jobs:
         with:
           command: test
           args: --locked
+  shellcheck:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Script Style Check
+        if: github.event_name != 'schedule'
+        run: shellcheck -o all -S style -s sh $(find . -iname "*.sh")
 
       - name: All Features
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This adds a new shellcheck step to CI, which will validate that all
scripts within the repository are valid `sh` scripts without major style
issues.

Since shellcheck's lint might change independently, this step is
excluded from CI jobs running on a schedule.

Closes #215.
