### PR TITLE
Unify XDG directory methods

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -12,6 +12,7 @@ use walkdir::WalkDir;
 
 use crate::commands::{CommandResult, ExitCode};
 use crate::deno::DenoRuntime;
+use crate::dirs;
 
 const MANIFEST_NAME: &str = "PhylumExt.toml";
 
@@ -174,7 +175,7 @@ impl TryFrom<PathBuf> for Extension {
 
 // Construct and return the extension path: $XDG_DATA_HOME/phylum/extensions
 pub fn extensions_path() -> Result<PathBuf, anyhow::Error> {
-    Ok(crate::config::data_dir()?.join("phylum").join("extensions"))
+    Ok(dirs::data_dir()?.join("phylum").join("extensions"))
 }
 
 pub fn extension_path(name: &str) -> Result<PathBuf, anyhow::Error> {

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,31 +1,29 @@
 //! Phylum CLI removal.
 
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::{env, fs};
 
 use anyhow::{anyhow, Result};
 use clap::ArgMatches;
 use tempfile::NamedTempFile;
 
 use crate::commands::{CommandResult, ExitCode};
-use crate::{config, print_user_success, print_user_warning};
+use crate::{dirs, print_user_success, print_user_warning};
 
 /// Handle the `uninstall` subcommand.
 pub fn handle_uninstall(matches: &ArgMatches) -> CommandResult {
-    let home_dir = home_dir()?;
-
     if matches.is_present("purge") {
-        purge(&home_dir);
+        purge()?;
     }
 
-    remove_installed_files(&home_dir);
+    remove_installed_files()?;
 
-    if let Err(err) = Shell::Bash.cleanup(&home_dir) {
+    if let Err(err) = Shell::Bash.cleanup() {
         print_user_warning!("BASH config error: {}", err);
     }
 
-    if let Err(err) = Shell::Zsh.cleanup(&home_dir) {
+    if let Err(err) = Shell::Zsh.cleanup() {
         print_user_warning!("ZSH config error: {}", err);
     }
 
@@ -33,21 +31,21 @@ pub fn handle_uninstall(matches: &ArgMatches) -> CommandResult {
 }
 
 /// Remove the entire `~/.config/phylum` directory.
-fn purge(home_dir: &Path) {
-    let config_dir = config::config_dir(home_dir).join("phylum");
+fn purge() -> Result<()> {
+    let config_dir = dirs::config_dir()?.join("phylum");
 
     match fs::remove_dir_all(&config_dir) {
         Ok(()) => print_user_success!("Successfully removed {:?}", config_dir),
-        Err(err) => {
-            print_user_warning!("Could not remove phylum config directory: {}", err);
-        }
+        Err(err) => print_user_warning!("Could not remove phylum config directory: {}", err),
     }
+
+    Ok(())
 }
 
 /// Remove files created by `install.sh`.
-fn remove_installed_files(home_dir: &Path) {
-    let data_dir = data_dir(home_dir).join("phylum");
-    let bin_path = bin_dir(home_dir).join("phylum");
+fn remove_installed_files() -> Result<()> {
+    let data_dir = dirs::data_dir()?.join("phylum");
+    let bin_path = dirs::bin_dir()?.join("phylum");
 
     let data_result = fs::remove_dir_all(data_dir);
     let bin_result = fs::remove_file(bin_path);
@@ -63,20 +61,8 @@ fn remove_installed_files(home_dir: &Path) {
     if data_result.is_ok() && bin_result.is_ok() {
         print_user_success!("Successfully removed installer files");
     }
-}
 
-/// XDG data directory.
-fn data_dir(home_dir: &Path) -> PathBuf {
-    env::var("XDG_DATA_HOME")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home_dir.join(".local/share"))
-}
-
-/// XDG binary directory.
-fn bin_dir(home_dir: &Path) -> PathBuf {
-    home_dir.join(".local/bin")
+    Ok(())
 }
 
 /// Supported shells.
@@ -88,28 +74,30 @@ enum Shell {
 
 impl Shell {
     /// Get the shell's config path.
-    fn rc_path(&self, home_dir: &Path) -> PathBuf {
-        match self {
+    fn rc_path(&self) -> Result<PathBuf> {
+        let home_dir = dirs::home_dir()?;
+        let rc_path = match self {
             Self::Bash => home_dir.join(".bashrc"),
             Self::Zsh => home_dir.join(".zshrc"),
-        }
+        };
+        Ok(rc_path)
     }
 
     /// Get the shell's phylum config path
-    fn phylum_path(&self, home_dir: &Path) -> PathBuf {
-        let data_dir = data_dir(home_dir).join("phylum");
+    fn phylum_path(&self, data_dir: &Path) -> PathBuf {
+        let phylum_data = data_dir.join("phylum");
         match self {
-            Self::Bash => data_dir.join("bashrc"),
-            Self::Zsh => data_dir.join("zshrc"),
+            Self::Bash => phylum_data.join("bashrc"),
+            Self::Zsh => phylum_data.join("zshrc"),
         }
     }
 
     /// Remove all lines from the shell config which were added by the installer.
-    fn cleanup(&self, home_dir: &Path) -> Result<()> {
-        let rc_path = self.rc_path(home_dir);
+    fn cleanup(&self) -> Result<()> {
+        let rc_path = self.rc_path()?;
         let mut rc_content = fs::read_to_string(&rc_path)?;
 
-        let phylum_path = self.phylum_path(home_dir);
+        let phylum_path = self.phylum_path(&dirs::data_dir()?);
         let config_line = format!("source {}\n", phylum_path.to_string_lossy());
 
         // If the installer's config is present, remove it.
@@ -132,9 +120,4 @@ impl Shell {
 
         Ok(())
     }
-}
-
-/// Get the user's home directory.
-fn home_dir() -> Result<PathBuf> {
-    home::home_dir().ok_or_else(|| anyhow!("Unable to find home directory"))
 }

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -30,7 +30,7 @@ pub fn handle_uninstall(matches: &ArgMatches) -> CommandResult {
     Ok(ExitCode::Ok.into())
 }
 
-/// Remove the entire `~/.config/phylum` directory.
+/// Remove the entire phylum config directory.
 fn purge() -> Result<()> {
     let config_dir = dirs::config_dir()?.join("phylum");
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -15,6 +15,8 @@ use phylum_types::types::auth::*;
 use phylum_types::types::common::*;
 use phylum_types::types::package::*;
 
+use crate::dirs;
+
 pub const PROJ_CONF_FILE: &str = ".phylum_project";
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -164,7 +166,7 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
     let home_path =
         home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))?;
 
-    let config_path = config_dir(&home_path).join("phylum").join("settings.yaml");
+    let config_path = dirs::config_dir()?.join("phylum").join("settings.yaml");
     let old_config_path = home_path.join(".phylum").join("settings.yaml");
 
     // Migrate the config from the old location.
@@ -187,29 +189,6 @@ pub fn get_home_settings_path() -> Result<PathBuf> {
     }
 
     Ok(config_path)
-}
-
-/// Resolve XDG data directory.
-pub fn data_dir() -> Result<PathBuf> {
-    if let Some(data_dir) = env::var_os("XDG_DATA_HOME")
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-    {
-        Ok(data_dir)
-    } else {
-        home::home_dir()
-            .ok_or_else(|| anyhow!("Couldn't find the user's home directory"))
-            .map(|home_path| home_path.join(".local").join("share"))
-    }
-}
-
-/// Resolve XDG config directory.
-pub fn config_dir(home_path: &Path) -> PathBuf {
-    env::var("XDG_CONFIG_HOME")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home_path.join(".config"))
 }
 
 #[cfg(test)]

--- a/cli/src/dirs.rs
+++ b/cli/src/dirs.rs
@@ -1,0 +1,32 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+/// Resolve XDG data directory.
+pub fn data_dir() -> Result<PathBuf> {
+    xdg_dir("XDG_DATA_HOME", ".local/share")
+}
+
+/// Resolve XDG config directory.
+pub fn config_dir() -> Result<PathBuf> {
+    xdg_dir("XDG_CONFIG_HOME", ".config")
+}
+
+/// XDG binary directory.
+pub fn bin_dir() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".local/bin"))
+}
+
+/// User home directory.
+pub fn home_dir() -> Result<PathBuf> {
+    home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))
+}
+
+/// Resolve an XDG directory.
+pub fn xdg_dir(env_var: &str, path_suffix: impl AsRef<Path>) -> Result<PathBuf> {
+    env::var_os(env_var)
+        .filter(|s| !s.is_empty())
+        .map(|var| Ok(PathBuf::from(var)))
+        .unwrap_or_else(|| Ok(home_dir()?.join(path_suffix)))
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod config;
 #[cfg(feature = "extensions")]
 pub mod deno;
+pub mod dirs;
 pub mod filter;
 pub mod lockfiles;
 pub mod print;


### PR DESCRIPTION
This merges together the two separate `data_dir` methods and streamlines
all the other XDG-related utility functions.

Since the only error that is possible with these methods is the very
uncommon scenario where the user's home directory does not exist, error
handling of this scenario has been made less explicit and prominent.

Due to the current order of operations, the errors should still be the
same. However this would make it more likely that in the future an
uninstall is only partially attempted due to a missing home directory.

Closes #414.
