### PR TITLE
Report extension execution errors

### DIFF
--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -44,11 +44,13 @@ impl DenoRuntime {
             .runtime
             .load_main_module(&module_specifier, None)
             .await?;
-        let _ = self.runtime.mod_evaluate(module);
+        let result = self.runtime.mod_evaluate(module);
 
+        // Run loaded module to completion.
         self.runtime.run_event_loop(false).await?;
 
-        Ok(())
+        // Report execution errors.
+        result.await?
     }
 }
 


### PR DESCRIPTION
Currently the main module is loaded and executed, however the execution
is reported by the `mod_evaluate` call, not the `run_event_loop` call.

Since `mod_evaluate` will only return after `run_event_loop` is done, a
separate check has to be made after the event loop is finished to ensure
execution was completed without any errors.
