### PR TITLE
Added build script as workaround for Window debug builds

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,6 @@ version = "3.5.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"
-build = "build.rs"
 
 [features]
 default = ["selfmanage"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "3.5.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"
+build = "build.rs"
 
 [features]
 default = ["selfmanage"]

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -27,4 +27,3 @@ fn main() {
         println!("cargo:rustc-link-arg=/STACK:0x800000");
     }
 }
-

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -8,16 +8,15 @@ use std::env;
 // The CLI has a long `match` statement in the body of a function. LLVM makes it
 // so that the stack space required by the `match` statement is proportional to
 // the sum of the stack space requirements for each branch, rather than to the
-// maximum for all of the branches (which is what happens on higher optimization
+// maximum of all of the branches (which is what happens on higher optimization
 // levels and on different targets).
 //
-// As a result, Windows debug builds have too high a stack utilization, and will
-// result in a stack overflow when run. By expanding the available stack space
-// at link time, we prevent this from happening.
+// As a result, Windows debug builds will result in a stack overflow when run,
+// because of too high a stack utilization. We can prevent this by expanding the
+// available stack space at link time.
 //
-// We want to make sure this variation is only applied to the affected target(s)
-// as there are no advantages to a larger stack space other than preventing this
-// issue in this specific configuration.
+// Since a larger stack space has no advantage for us other than preventing this
+// issue, we apply the fix only to the affected platforms.
 
 fn main() {
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -5,16 +5,19 @@ use std::env;
 //
 // This issue is present under Windows in debug builds.
 //
-// The CLI has a long `match` statement in the body of a function. LLVM makes
-// it so that the stack space required by the `match` statement is proportional
-// to the sum of the stack space requirements for each branch, rather than
-// to the maximum for all of the branches (which is what happens on higher
-// optimization levels and on different targets). As a result, Windows debug
-// builds have too high a stack utilization, and will result in a stack overflow
-// when run. By expanding the available stack space at link time, we prevent
-// this from happening. We want to make sure this variation is only applied to
-// the affected target(s) as there are no advantages to a larger stack space
-// other than preventing this issue in this specific configuration.
+// The CLI has a long `match` statement in the body of a function. LLVM makes it
+// so that the stack space required by the `match` statement is proportional to
+// the sum of the stack space requirements for each branch, rather than to the
+// maximum for all of the branches (which is what happens on higher optimization
+// levels and on different targets).
+//
+// As a result, Windows debug builds have too high a stack utilization, and will
+// result in a stack overflow when run. By expanding the available stack space
+// at link time, we prevent this from happening.
+//
+// We want to make sure this variation is only applied to the affected target(s)
+// as there are no advantages to a larger stack space other than preventing this
+// issue in this specific configuration.
 
 fn main() {
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,27 @@
+use std::env;
+
+// This build script exists as a workaround for the following issue:
+// https://github.com/rust-lang/rust/issues/34283
+//
+// This issue is present under Windows in debug builds.
+//
+// The CLI has a long `match` statement in the body of a function. LLVM makes
+// it so that the stack space required by the `match` statement is proportional
+// to the sum of the stack space requirements for each branch, rather than
+// to the maximum for all of the branches (which is what happens on higher
+// optimization levels and on different targets). As a result, Windows debug
+// builds have too high a stack utilization, and will result in a stack overflow
+// when run. By expanding the available stack space at link time, we prevent
+// this from happening. We want to make sure this variation is only applied to
+// the affected target(s) as there are no advantages to a larger stack space
+// other than preventing this issue in this specific configuration.
+
+fn main() {
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let profile = env::var("PROFILE").unwrap();
+
+    if os == "windows" && profile == "debug" {
+        println!("cargo:rustc-link-arg=/STACK:0x800000");
+    }
+}
+


### PR DESCRIPTION
The build script added in this PR exists as a workaround for [this issue](https://github.com/rust-lang/rust/issues/34283).

This issue is present under Windows in debug builds.

The CLI has a long `match` statement in the body of a function. LLVM makes it so that the stack space required by the `match` statement is proportional to the sum of the stack space requirements for each branch, rather than to the maximum for all of the branches (which is what happens on higher optimization levels and on different targets). As a result, Windows debug
builds have too high a stack utilization, and will result in a stack overflow when run. By expanding the available stack space at link time, we prevent this from happening. We want to make sure this variation is only applied to the affected target(s) as there are no advantages to a larger stack space other than preventing this issue in this specific configuration.
