### PR TITLE
Fix messed up spinner output

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -6,7 +6,6 @@ use clap::ArgMatches;
 use env_logger::Env;
 use log::*;
 use phylum_cli::commands::parse::handle_parse;
-use spinners::{Spinner, Spinners};
 
 use phylum_cli::api::PhylumApi;
 use phylum_cli::commands::auth::*;
@@ -208,12 +207,7 @@ async fn handle_ping(mut api: PhylumApi) -> CommandResult {
 }
 
 async fn handle_update(matches: &ArgMatches) -> CommandResult {
-    let mut spinner = Spinner::new(
-        Spinners::Dots12,
-        "Downloading update and verifying binary signatures...".into(),
-    );
     let res = update::do_update(matches.is_present("prerelease")).await;
-    spinner.stop_with_newline();
     let message = res?;
     print_user_success!("{}", message);
     Ok(ExitCode::Ok.into())

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Cursor};
+use std::io::{self, Cursor, Write};
 use std::process::Command;
 use std::str;
 
@@ -213,11 +213,14 @@ impl ApplicationUpdater {
         if !self.has_valid_signature(&zip, str::from_utf8(&sig)?) {
             anyhow::bail!("The update binary failed signature validation");
         }
+        spinner.stop_with_message(
+            "Downloading update and verifying binary signatures... Done!".into(),
+        );
+        std::io::stdout().flush()?;
 
         debug!("Extracting package to temporary directory");
         let temp_dir = tempfile::tempdir()?;
         ZipArchive::new(Cursor::new(zip))?.extract(temp_dir.path())?;
-        spinner.stop_with_newline();
 
         debug!("Running the installer");
         let working_dir = temp_dir.path().join(archive_name);

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -7,6 +7,7 @@ use log::debug;
 use minisign_verify::{PublicKey, Signature};
 use reqwest::Client;
 use serde::de::DeserializeOwned;
+use spinners::{Spinner, Spinners};
 use zip::ZipArchive;
 
 #[cfg(test)]
@@ -190,6 +191,10 @@ impl ApplicationUpdater {
     ///
     /// Until we update the releases, this should suffice.
     async fn do_update(&self, latest: GithubRelease) -> anyhow::Result<GithubRelease> {
+        let mut spinner = Spinner::new(
+            Spinners::Dots12,
+            "Downloading update and verifying binary signatures...".into(),
+        );
         debug!("Performing the update process");
 
         let archive_name = format!("phylum-{}", current_platform()?);
@@ -212,6 +217,7 @@ impl ApplicationUpdater {
         debug!("Extracting package to temporary directory");
         let temp_dir = tempfile::tempdir()?;
         ZipArchive::new(Cursor::new(zip))?.extract(temp_dir.path())?;
+        spinner.stop_with_newline();
 
         debug!("Running the installer");
         let working_dir = temp_dir.path().join(archive_name);


### PR DESCRIPTION
The installer prints to stdout which messes up the loading animation:

#### current
```
❯ phs update
⠍⠉ Downloading update and verifying binary signatures...
    phylum-cli installer

⠋⠉ Downloading update and verifying binary signatures...    OK Copied completions to /Users/samtay/.local/share/phylum/completions
    OK Completions are enabled for bash.
    OK Completions are enabled for zsh.
    OK Successfully installed phylum.

    Source your /Users/samtay/.zshrc file, add /Users/samtay/.local/bin to your $PATH variable, or
    log in to a new terminal in order to make `phylum` available.

⠋⠉ Downloading update and verifying binary signatures...
✅ Successfully updated to v3.5.0!
```

#### after

```
❯ phs update
Downloading update and verifying binary signatures... Done!
    phylum-cli installer

    OK Copied completions to /Users/samtay/.local/share/phylum/completions
    OK Completions are enabled for bash.
    OK Completions are enabled for zsh.
    OK Successfully installed phylum.

    Source your /Users/samtay/.zshrc file, add /Users/samtay/.local/bin to your $PATH variable, or
    log in to a new terminal in order to make `phylum` available.

✅ Successfully updated to v3.5.0!
```

This spinner lib is a bit awkward actually. I do have a spinner that behaves very well [over here](https://github.com/samtay/so/blob/cffdef897645ec6f9fd71760f7b4849b46036c9b/src/term.rs#L108-L171) but it's written in terms of crossterm right now, so probably not worth bringing in that dependency on a such a small aesthetic thing. Maybe one day I'll rewrite that with minimal deps for fun.

Closes #465 

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
