### PR TITLE
feat: coordinate phylum-ci Docker image releases with new CLI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,19 @@ jobs:
             phylum-*.zip
             phylum-*.zip.minisig
 
+      - name: Trigger phylum-ci Docker image creation
+        # Don't trigger for pre-releases
+        if: ! contains(github.ref, 'rc')
+        # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+        run: >
+          curl
+          -X POST
+          --fail-with-body
+          -H "Accept: application/vnd.github.v3+json"
+          -H "Authorization: token ${{ secrets.GH_RELEASE_PAT }}"
+          -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"$GITHUB_REF_NAME"}}'
+          https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
+
   Update-Documentation:
     name: Update the documentation
     needs: Release


### PR DESCRIPTION
This PR adds a repository dispatch event trigger to the release workflow. It triggers the Docker workflow in the `phylum-dev/phylum-ci` repo to build and push Docker images containing the latest `phylum` Python package and the Phylum CLI version from the tag that caused the Release workflow to run. A `curl` command that POSTs to the `dispatches` endpoint with the expected payload is used instead of the [`actions/github-script` action](https://github.com/actions/github-script) because this is a simple trigger. The trigger is further limited so that it will not fire for pre-releases of the CLI.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
  - https://github.com/phylum-dev/phylum-ci/issues/50
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
  - It won't be possible to truly test this change until the corresponding work in `phylum-dev/phylum-ci` is merged to `main`
  - https://github.com/phylum-dev/phylum-ci/pull/63
- [x] Have you updated all affected documentation?
