### PR TITLE
fix: SHELL env var assumed to exist during install

### DIFF
--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -36,7 +36,7 @@ get_platform() {
 }
 
 get_rc_file() {
-    case $(basename "${SHELL}") in
+    case $(basename "${SHELL:-unknown}") in
         bash)
             echo "${HOME}/.bashrc"
             ;;
@@ -47,7 +47,7 @@ get_rc_file() {
             echo "${HOME}/.config/fish/config.fish"
             ;;
         *)
-            echo "shell's configuration file"
+            echo "shell configuration"
             ;;
     esac
 }


### PR DESCRIPTION
This PR ensures the `SHELL` environment variable has a default value when none exists. It also cleans up the language used in the instructions printed after install.

Closes #470 

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
- [x] ~Have you updated all affected documentation?~
