### PR TITLE
Use canonical URL paths for the API

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -12,9 +12,9 @@ const API_PATH: &str = "api/v0/";
 #[error("invalid API URL")]
 pub struct BaseUriError(#[from] pub ParseError);
 
-/// PUT /job
+/// PUT /data/jobs
 pub fn put_submit_package(api_uri: &str) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join("job")?)
+    Ok(get_api_path(api_uri)?.join("data/jobs")?)
 }
 
 /// GET /health
@@ -22,12 +22,12 @@ pub fn get_ping(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("health")?)
 }
 
-/// GET /job/
+/// GET /data/jobs/
 pub fn get_all_jobs_status(api_uri: &str, limit: u32) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join(&format!("job/?limit={limit}&verbose=1"))?)
+    Ok(get_api_path(api_uri)?.join(&format!("data/jobs/?limit={limit}&verbose=1"))?)
 }
 
-/// GET /job/<job_id>
+/// GET /data/jobs/<job_id>
 pub fn get_job_status(api_uri: &str, job_id: &JobId, verbose: bool) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;
 
@@ -35,7 +35,7 @@ pub fn get_job_status(api_uri: &str, job_id: &JobId, verbose: bool) -> Result<Ur
     url.path_segments_mut()
         .unwrap()
         .pop_if_empty()
-        .extend(["job", &job_id.to_string()]);
+        .extend(["data", "jobs", &job_id.to_string()]);
 
     if verbose {
         url.query_pairs_mut().append_pair("verbose", "True");
@@ -65,24 +65,24 @@ pub fn get_package_status(api_uri: &str, pkg: &PackageDescriptor) -> Result<Url,
     Ok(url)
 }
 
-/// GET /job/projects/name/<pkg_id>
+/// GET /data/projects/name/<pkg_id>
 pub fn get_project_details(api_uri: &str, pkg_id: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;
     url.path_segments_mut()
         .unwrap()
         .pop_if_empty()
-        .extend(["job", "projects", "name", pkg_id]);
+        .extend(["data", "projects", "name", pkg_id]);
     Ok(url)
 }
 
-/// GET /job/projects/overview
+/// GET /data/projects/overview
 pub fn get_project_summary(api_uri: &str) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join("job/projects/overview")?)
+    Ok(get_api_path(api_uri)?.join("data/projects/overview")?)
 }
 
-/// PUT /job/projects
-pub fn put_create_project(api_uri: &str) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join("job/projects")?)
+/// POST /data/projects
+pub fn post_create_project(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_api_path(api_uri)?.join("data/projects")?)
 }
 
 /// GET /settings/current-user
@@ -173,7 +173,7 @@ mod test {
     fn put_submit_package_is_correct() {
         assert_eq!(
             put_submit_package(API_URI).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job"),
+            format!("{API_URI}/{API_PATH}data/jobs"),
         );
     }
 
@@ -189,7 +189,7 @@ mod test {
     fn get_all_jobs_status_is_correct() {
         assert_eq!(
             get_all_jobs_status(API_URI, 123).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job/?limit=123&verbose=1"),
+            format!("{API_URI}/{API_PATH}data/jobs/?limit=123&verbose=1"),
         );
     }
 
@@ -200,11 +200,11 @@ mod test {
 
         assert_eq!(
             get_job_status(API_URI, &job_id, false).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job/{JOB_ID}"),
+            format!("{API_URI}/{API_PATH}data/jobs/{JOB_ID}"),
         );
         assert_eq!(
             get_job_status(API_URI, &job_id, true).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job/{JOB_ID}?verbose=True"),
+            format!("{API_URI}/{API_PATH}data/jobs/{JOB_ID}?verbose=True"),
         );
     }
 
@@ -227,7 +227,7 @@ mod test {
             get_project_details(API_URI, "acme/widgets")
                 .unwrap()
                 .as_str(),
-            format!("{API_URI}/{API_PATH}job/projects/name/acme%2Fwidgets"),
+            format!("{API_URI}/{API_PATH}data/projects/name/acme%2Fwidgets"),
         );
     }
 
@@ -235,15 +235,15 @@ mod test {
     fn get_project_summary_is_correct() {
         assert_eq!(
             get_project_summary(API_URI).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job/projects/overview"),
+            format!("{API_URI}/{API_PATH}data/projects/overview"),
         );
     }
 
     #[test]
     fn put_create_project_is_correct() {
         assert_eq!(
-            put_create_project(API_URI).unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}job/projects"),
+            post_create_project(API_URI).unwrap().as_str(),
+            format!("{API_URI}/{API_PATH}data/projects"),
         );
     }
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -198,8 +198,8 @@ impl PhylumApi {
     /// Create a new project
     pub async fn create_project(&mut self, name: &str, group: Option<&str>) -> Result<ProjectId> {
         let response: CreateProjectResponse = self
-            .put(
-                endpoints::put_create_project(&self.config.connection.uri)?,
+            .post(
+                endpoints::post_create_project(&self.config.connection.uri)?,
                 CreateProjectRequest {
                     name: name.to_owned(),
                     group_name: group.map(String::from),
@@ -407,7 +407,7 @@ mod tests {
         let responder_token_holder = token_holder.clone();
 
         Mock::given(method("PUT"))
-            .and(path("api/v0/job"))
+            .and(path("api/v0/data/jobs"))
             .respond_with_fn(move |request| {
                 let mut guard = responder_token_holder.lock().unwrap();
                 let auth_header = HeaderName::from_str("Authorization").unwrap();
@@ -447,7 +447,7 @@ mod tests {
     async fn submit_request() -> Result<()> {
         let mock_server = build_mock_server().await;
         Mock::given(method("PUT"))
-            .and(path("api/v0/job"))
+            .and(path("api/v0/data/jobs"))
             .respond_with_fn(|_| {
                 ResponseTemplate::new(200)
                     .set_body_string(r#"{"job_id": "59482a54-423b-448d-8325-f171c9dc336b"}"#)
@@ -523,7 +523,7 @@ mod tests {
 
         let mock_server = build_mock_server().await;
         Mock::given(method("GET"))
-            .and(path("api/v0/job/"))
+            .and(path("api/v0/data/jobs/"))
             .and(query_param("limit", "30"))
             .and(query_param("verbose", "1"))
             .respond_with_fn(move |_| ResponseTemplate::new(200).set_body_string(body))
@@ -643,7 +643,7 @@ mod tests {
 
         let mock_server = build_mock_server().await;
         Mock::given(method("GET"))
-            .and(path_regex(r"^/api/v0/job/[-\dabcdef]+$".to_string()))
+            .and(path_regex(r"^/api/v0/data/jobs/[-\dabcdef]+$".to_string()))
             .respond_with_fn(move |_| ResponseTemplate::new(200).set_body_string(body))
             .mount(&mock_server)
             .await;
@@ -718,7 +718,7 @@ mod tests {
 
         let mock_server = build_mock_server().await;
         Mock::given(method("GET"))
-            .and(path_regex(r"^/api/v0/job/[-\dabcdef]+".to_string()))
+            .and(path_regex(r"^/api/v0/data/jobs/[-\dabcdef]+".to_string()))
             .and(query_param("verbose", "True"))
             .respond_with_fn(move |_| ResponseTemplate::new(200).set_body_string(body))
             .mount(&mock_server)


### PR DESCRIPTION
This patch updates old paths (under the /job/ prefix) that were used
with request manager and uses the canonical API paths (under the /data/
prefix).

Fix #468