### PR TITLE
Remove user-components from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @phylum-dev/user-components @phylum-dev/integrations
+* @phylum-dev/integrations


### PR DESCRIPTION
We don't need to bother the @phylum-dev/user-components team to do code reviews on CLI.