### PR TITLE
Bump to v3.6.0 - Add support for gradle.lockfile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.6.0 - Add support for gradle.lockfile
 * 3.5.0 - Automatically detect OIDC URL
 * 3.4.0 - Group account support
 * 3.3.0 - Introduce parse command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.5.0"
+version = "3.6.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
A few bug fixes and some additional gradle support will be the main features of this release. Lots of refactors and lots of work on extensions as well, but that's still behind a feature flag.

Release-Version: v3.6.0
Release-Summary: Add support for gradle.lockfile