### PR TITLE
fix: phylum-ci Docker image trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,10 @@ jobs:
   Trigger:
     name: Trigger phylum-ci Docker image creation
     needs: Release
+    # Don't trigger for pre-releases
+    # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
+    #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
+    if: ${{ !contains(github.ref, 'rc') }}
     # The `--fail-with-body` option in `curl` was added in v7.76.0, which is too
     # new for the `ubuntu-latest` runner that currently makes use of Ubuntu 20.04.
     # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
@@ -166,10 +170,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Trigger phylum-ci Docker image creation
-        # Don't trigger for pre-releases
-        # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
-        #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
-        if: ${{ !contains(github.ref, 'rc') }}
         # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
         run: |
           curl \
@@ -178,7 +178,7 @@ jobs:
             --no-progress-meter \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.GH_RELEASE_PAT }}" \
-            -d '{"event_type":"build-push-docker-images","client_payload":{"CLI_version":"$GITHUB_REF_NAME"}}' \
+            -d "{\"event_type\":\"build-push-docker-images\",\"client_payload\":{\"CLI_version\":\"$GITHUB_REF_NAME\"}}" \
             https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
 
   Update-Documentation:


### PR DESCRIPTION
The change in this PR is to encapsulate the `curl` based trigger's data
payload in double quotes since expressions do not expand in single
quotes. This means that the inner double quotes have to be escaped
because they are still needed since the payload includes a JSON string.

Promote the `if` condition for triggers from step to job level.
This change will ensure the Trigger job does not run for pre-releases.
Previously, the conditional was one level lower, on a step within the
job. That was confusing because the UI would show that the Job ran, but
it wasn't until drilling into the results that it would be clear that
the trigger step was skipped.

Closes #488


## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
