### PR TITLE
Bump to latest phylum-types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
           components: rustfmt
 
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: v1
 
       - name: Format check
         if: github.event_name != 'schedule'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
  "winapi",
 ]
 
@@ -2847,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#c943a84b3d3d306350a63f296ec71f0162473e9c"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#9cb9f47fd7fd9e6ac58be551988e260f0555786c"
 dependencies = [
  "chrono",
  "log",
@@ -3759,7 +3758,7 @@ checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.10",
+ "time",
 ]
 
 [[package]]
@@ -4428,17 +4427,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82501a4c1c0330d640a6e176a3d6a204f5ec5237aca029029d21864a902e27b0"
@@ -4933,12 +4921,6 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -5316,7 +5298,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "sha1",
- "time 0.3.10",
+ "time",
  "zstd",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ ansi_term = "0.12.1"
 anyhow = "1.0.44"
 base64 = "0.13.0"
 bytes = "1.1.0"
-chrono = { version = "^0.4", features = ["serde"] }
+chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
 cidr = "0.2.0"
 clap = { version = "3.0.14" }
 dialoguer = "0.10.0"


### PR DESCRIPTION
This removes the last usage of the `oldtime` feature of the `chrono` crate.