### PR TITLE
Add phylum extension new command

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Result};
 use futures::future::BoxFuture;
 use lazy_static::lazy_static;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 pub(crate) use super::api::ExtensionState;
@@ -22,17 +22,23 @@ lazy_static! {
     static ref EXTENSION_NAME_RE: Regex = Regex::new(r#"^[a-z][a-z0-9-]+$"#).unwrap();
 }
 
-#[derive(Debug)]
-pub struct Extension {
-    path: PathBuf,
-    manifest: ExtensionManifest,
-}
-
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ExtensionManifest {
     name: String,
     description: Option<String>,
     entry_point: String,
+}
+
+impl ExtensionManifest {
+    pub fn new(name: String, entry_point: String, description: Option<String>) -> Self {
+        Self { description, entry_point, name }
+    }
+}
+
+#[derive(Debug)]
+pub struct Extension {
+    path: PathBuf,
+    manifest: ExtensionManifest,
 }
 
 impl Extension {

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -1,19 +1,27 @@
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{arg, ArgMatches, Command, ValueHint};
-use extension::Extension;
 use futures::future::BoxFuture;
 use log::{error, warn};
 
 use crate::api::PhylumApi;
+use crate::commands::extensions::extension::{Extension, ExtensionManifest};
 use crate::commands::{CommandResult, CommandValue, ExitCode};
+use crate::print_user_success;
 
 pub mod api;
 pub mod extension;
+
+const EXTENSION_SKELETON: &[u8] = b"\
+import { PhylumApi } from 'phylum';
+
+console.log('Hello, World!');
+";
 
 pub fn command<'a>() -> Command<'a> {
     Command::new("extension")
@@ -25,6 +33,9 @@ pub fn command<'a>() -> Command<'a> {
         )
         .subcommand(
             Command::new("remove").about("Uninstall extension").arg(arg!([NAME]).required(true)),
+        )
+        .subcommand(
+            Command::new("new").about("Create a new extension").arg(arg!([PATH]).required(true)),
         )
         .subcommand(Command::new("list").about("List installed extensions"))
 }
@@ -62,6 +73,7 @@ pub async fn handle_extensions(matches: &ArgMatches) -> CommandResult {
         Some(("remove", matches)) => {
             handle_remove_extension(matches.value_of("NAME").unwrap()).await
         },
+        Some(("new", matches)) => handle_create_extension(matches.value_of("PATH").unwrap()).await,
         Some(("list", _)) | None => handle_list_extensions().await,
         _ => unreachable!(),
     }
@@ -105,6 +117,47 @@ async fn handle_remove_extension(name: &str) -> CommandResult {
     let extension = Extension::load(name)?;
 
     extension.uninstall()?;
+
+    Ok(CommandValue::Code(ExitCode::Ok))
+}
+
+/// Handle the `extension new` command path.
+///
+/// Create a new extension in the current directory.
+pub async fn handle_create_extension(path: &str) -> CommandResult {
+    // Error out when target is already occupied.
+    //
+    // This allows use to use [`fs::create_dir_all`] without having to worry about
+    // reusing an existing directory.
+    let extension_path = PathBuf::from(path);
+    if extension_path.exists() {
+        return Err(anyhow!("Destination {path:?} already exists"));
+    }
+
+    // Extract extension name.
+    let name = extension_path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .ok_or_else(|| anyhow!("Last segment in {path:?} is not a valid extension name"))?;
+
+    // Create all missing directories.
+    fs::create_dir_all(&extension_path)
+        .with_context(|| format!("Unable to create all directories in {path:?}"))?;
+
+    // Write manifest file.
+    let manifest = ExtensionManifest::new(name.into(), "main.ts".into(), None);
+    let manifest_path = extension_path.join("PhylumExt.toml");
+    fs::write(manifest_path, toml::to_string(&manifest)?.as_bytes())?;
+
+    // Create "Hello, World!" example.
+    let entry_path = extension_path.join("main.ts");
+    fs::write(entry_path, EXTENSION_SKELETON)?;
+
+    print_user_success!(
+        "\
+        Extension created successfully
+        \nRun `phylum extension add {path}` to install it."
+    );
 
     Ok(CommandValue::Code(ExitCode::Ok))
 }

--- a/cli/src/lockfiles/csharp.rs
+++ b/cli/src/lockfiles/csharp.rs
@@ -8,7 +8,7 @@ pub struct CSProj;
 
 const INVALID_CHAR: &str = "\u{feff}";
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct PackageReference {
     #[serde(alias = "Include", default)]
     pub name: String,
@@ -17,13 +17,13 @@ pub struct PackageReference {
     pub version: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 struct ItemGroup {
     #[serde(alias = "PackageReference", default)]
     pub dependencies: Vec<PackageReference>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 struct Project {
     #[serde(rename = "ItemGroup", default)]
     pub item_groups: Vec<ItemGroup>,

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -13,7 +13,7 @@ pub struct AuthStatusResponse {
     pub authenticated: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     Admin,


### PR DESCRIPTION
This patch adds a new command for automatically creating extension
skeletons in the specified repository, making the initial steps for
getting started with writing your own extensions much simpler.

Closes #412.