### PR TITLE
Rename extension add/remove to install/uninstall

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -28,12 +28,12 @@ pub fn command<'a>() -> Command<'a> {
     Command::new("extension")
         .about("Run extensions")
         .subcommand(
-            Command::new("add")
+            Command::new("install")
                 .about("Install extension")
                 .arg(arg!([PATH]).required(true).value_hint(ValueHint::DirPath)),
         )
         .subcommand(
-            Command::new("remove").about("Uninstall extension").arg(arg!([NAME]).required(true)),
+            Command::new("uninstall").about("Uninstall extension").arg(arg!([NAME]).required(true)),
         )
         .subcommand(
             Command::new("new").about("Create a new extension").arg(arg!([PATH]).required(true)),
@@ -70,9 +70,11 @@ pub fn add_extensions_subcommands(command: Command<'_>) -> Command<'_> {
 /// Entry point for the `extensions` subcommand.
 pub async fn handle_extensions(matches: &ArgMatches) -> CommandResult {
     match matches.subcommand() {
-        Some(("add", matches)) => handle_add_extension(matches.value_of("PATH").unwrap()).await,
-        Some(("remove", matches)) => {
-            handle_remove_extension(matches.value_of("NAME").unwrap()).await
+        Some(("install", matches)) => {
+            handle_install_extension(matches.value_of("PATH").unwrap()).await
+        },
+        Some(("uninstall", matches)) => {
+            handle_uninstall_extension(matches.value_of("NAME").unwrap()).await
         },
         Some(("new", matches)) => handle_create_extension(matches.value_of("PATH").unwrap()).await,
         Some(("list", _)) | None => handle_list_extensions().await,
@@ -94,10 +96,10 @@ pub async fn handle_run_extension(
     Ok(CommandValue::Code(ExitCode::Ok))
 }
 
-/// Handle the `extension add` subcommand path.
+/// Handle the `extension install` subcommand path.
 ///
-/// Add the extension from the specified path.
-async fn handle_add_extension(path: &str) -> CommandResult {
+/// Install the extension from the specified path.
+async fn handle_install_extension(path: &str) -> CommandResult {
     // NOTE: Extension installation without slashes is reserved for the marketplace.
     if !path.contains('/') && !path.contains('\\') {
         return Err(anyhow!("Ambiguous extension URI '{}', use './{0}' instead", path));
@@ -111,10 +113,10 @@ async fn handle_add_extension(path: &str) -> CommandResult {
     Ok(CommandValue::Code(ExitCode::Ok))
 }
 
-/// Handle the `extension remove` subcommand path.
+/// Handle the `extension uninstall` subcommand path.
 ///
-/// Remove the extension named as specified.
-async fn handle_remove_extension(name: &str) -> CommandResult {
+/// Uninstall the extension named as specified.
+async fn handle_uninstall_extension(name: &str) -> CommandResult {
     let extension = Extension::load(name)?;
 
     extension.uninstall()?;

--- a/cli/tests/extensions.rs
+++ b/cli/tests/extensions.rs
@@ -33,7 +33,7 @@ fn extension_is_installed_correctly() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert()
         .success();
@@ -58,7 +58,7 @@ fn can_run_installed_extension() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert()
         .success();
@@ -82,7 +82,7 @@ fn successful_installation_prints_message() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert()
         .success();
@@ -110,7 +110,7 @@ fn unsuccessful_installation_prints_failure_message() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert()
         .success();
@@ -121,7 +121,7 @@ fn unsuccessful_installation_prints_failure_message() {
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
             .arg("extension")
-            .arg("add")
+            .arg("install")
             .arg(fixtures_path().join("sample-extension"))
             .assert()
             .failure(),
@@ -135,7 +135,7 @@ fn unsuccessful_installation_prints_failure_message() {
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
             .arg("extension")
-            .arg("add")
+            .arg("install")
             .arg(
                 PathBuf::from(tempdir.path())
                     .join("phylum")
@@ -158,7 +158,7 @@ fn extension_is_uninstalled_correctly() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert()
         .success();
@@ -172,7 +172,7 @@ fn extension_is_uninstalled_correctly() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("remove")
+        .arg("uninstall")
         .arg("sample-extension")
         .assert()
         .success();
@@ -205,7 +205,7 @@ fn extension_list_should_emit_output() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("sample-extension"))
         .assert();
 
@@ -230,7 +230,7 @@ async fn injected_api() {
     Command::cargo_bin("phylum")
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
-        .args(&["extension", "add"])
+        .args(&["extension", "install"])
         .arg(fixtures_path().join("api-extension"))
         .assert()
         .success();
@@ -263,7 +263,7 @@ fn conflicting_extension_name_is_filtered() {
         .unwrap()
         .env("XDG_DATA_HOME", tempdir.path())
         .arg("extension")
-        .arg("add")
+        .arg("install")
         .arg(fixtures_path().join("ping-extension"))
         .assert()
         .success();
@@ -306,7 +306,7 @@ mod module_loader_tests {
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
             .arg("extension")
-            .arg("add")
+            .arg("install")
             .arg(fixtures_path().join("module-import-extension").join("successful"))
             .assert()
             .success();
@@ -331,7 +331,7 @@ mod module_loader_tests {
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
             .arg("extension")
-            .arg("add")
+            .arg("install")
             .arg(fixtures_path().join("module-import-extension").join("fail-local"))
             .assert()
             .success();
@@ -357,7 +357,7 @@ mod module_loader_tests {
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
             .arg("extension")
-            .arg("add")
+            .arg("install")
             .arg(fixtures_path().join("module-import-extension").join("fail-remote"))
             .assert()
             .success();
@@ -384,7 +384,7 @@ mod module_loader_tests {
         Command::cargo_bin("phylum")
             .unwrap()
             .env("XDG_DATA_HOME", tempdir.path())
-            .args(&["extension", "add"])
+            .args(&["extension", "install"])
             .arg(fixtures_path().join("symlink-extension"))
             .assert()
             .success();


### PR DESCRIPTION
This changes the `phylum extension add` and `phylum extension remove`
subcommands to install use `install` and `uninstall`, since the latter
is more in sync with what developers should be used to.

Some notable examples sharing this naming pattern are `cargo` and `apt`.

Closes #501.
