### PR TITLE
Add npm package check extensions

### DIFF
--- a/extensions/npm/PhylumExt.toml
+++ b/extensions/npm/PhylumExt.toml
@@ -1,0 +1,6 @@
+name = "npm"
+description = "NPM package manager hooks"
+entry_point = "main.ts"
+
+[permissions]
+run = ["npm"]

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -1,0 +1,32 @@
+import { PhylumApi } from "phylum";
+
+// Parse CLI args.
+const args = Deno.args;
+if (args.length != 2 || args[0] !== "install") {
+    console.error("Usage: phylum npm install <PKG>");
+} else {
+    await install(args[1]);
+}
+
+// Analyze and install package.
+async function install(pkg: string) {
+    console.log("Updating package lock…");
+    await Deno.run({ cmd: ["npm", "i", "--package-lock-only", pkg] }).status();
+    console.log("Package lock updated.\n");
+
+    console.log("Analyzing packages…");
+    const jobId = await PhylumApi.analyze("./package-lock.json");
+    const jobStatus = await PhylumApi.getJobStatus(jobId);
+
+    if (jobStatus.pass && jobStatus.status === "complete") {
+        console.log("All packages pass project thresholds.\n");
+
+        console.log(`Installing '${pkg}'…`);
+        await Deno.run({ cmd: ["npm", "i", pkg] }).status();
+        console.log("Package install complete.");
+    } else if (jobStatus.pass) {
+        console.warn("Unknown packages were submitted for analysis, please check again later.");
+    } else {
+        console.error(`Installing '${pkg}' caused threshold failure.`);
+    }
+}

--- a/extensions/yarn/PhylumExt.toml
+++ b/extensions/yarn/PhylumExt.toml
@@ -1,0 +1,6 @@
+name = "yarn"
+description = "yarn package manager hooks"
+entry_point = "main.ts"
+
+[permissions]
+run = ["yarn"]

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -1,0 +1,32 @@
+import { PhylumApi } from "phylum";
+
+// Parse CLI args.
+const args = Deno.args;
+if (args.length != 2 || args[0] !== "add") {
+    console.error("Usage: phylum yarn add <PKG>");
+} else {
+    await install(args[1]);
+}
+
+// Analyze and install package.
+async function install(pkg: string) {
+    console.log("Updating package lock…");
+    await Deno.run({ cmd: ["yarn", "add", "--mode=update-lockfile", pkg] }).status();
+    console.log("Package lock updated.\n");
+
+    console.log("Analyzing packages…");
+    const jobId = await PhylumApi.analyze("./yarn.lock");
+    const jobStatus = await PhylumApi.getJobStatus(jobId);
+
+    if (jobStatus.pass && jobStatus.status === "complete") {
+        console.log("All packages pass project thresholds.\n");
+
+        console.log(`Installing '${pkg}'…`);
+        await Deno.run({ cmd: ["yarn", "add", pkg] }).status();
+        console.log("Package install complete.");
+    } else if (jobStatus.pass) {
+        console.warn("Unknown packages were submitted for analysis, please check again later.");
+    } else {
+        console.error(`Installing '${pkg}' caused threshold failure.`);
+    }
+}


### PR DESCRIPTION
This adds two extensions for the NPM ecosystem, which provide support
for analyzing dependencies of yarn and npm lockfiles before installing
the packages themselves.

Closes #511.
