### PR TITLE
Fix permission prompting behavior

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -149,21 +149,28 @@ fn ask_permissions(extension: &Extension) -> Result<()> {
 
     println!("The `{}` extension requires the following permissions:", extension.name());
 
-    fn print_permissions_list<S: Display>(header: &str, items: Option<&Vec<S>>) {
-        println!("  {header}");
-        if let Some(items) = items {
-            for item in items {
-                println!("    {item}");
-            }
+    fn print_permissions_list<S: Display>(key: &str, detail: &str, items: Option<&Vec<S>>) {
+        // Don't prompt if no permissions are requested.
+        let permissions = match items {
+            Some(permissions) => permissions,
+            None => return,
+        };
+
+        // It should be impossible to create an empty permissions vector.
+        assert!(!permissions.is_empty(), "unexpected permissions value");
+
+        println!("\n  {} {detail}", Color::Blue.bold().paint(key));
+        for permission in permissions {
+            println!("    '{permission}'");
         }
     }
 
-    print_permissions_list("Read from the following paths:", permissions.read());
-    print_permissions_list("Write to the following paths:", permissions.write());
-    print_permissions_list("Run the following commands:", permissions.run());
-    print_permissions_list("Access the following domains:", permissions.net());
+    print_permissions_list("Read", "from the following paths:", permissions.read());
+    print_permissions_list("Write", "to the following paths:", permissions.write());
+    print_permissions_list("Run", "the following commands:", permissions.run());
+    print_permissions_list("Access", "the following domains:", permissions.net());
 
-    if !Confirm::new().with_prompt("Do you accept?").interact()? {
+    if !Confirm::new().with_prompt("\nDo you accept?").default(false).interact()? {
         Err(anyhow!("permissions not granted, aborting"))
     } else {
         Ok(())


### PR DESCRIPTION
Previously permissions were always prompted, regardless of how many of
them were actually requested by the extension. This patch fixes that and
only prints the requests when there are actual permissions being
requested.

The permission output is also reformatted a bit to distinguish the
important parts of the output more clearly from the prose describing
their purpose.

To ensure the user is correctly informed about what choice he should
make if he's incapable of answering the prompt, "no" has also been
selected and marked as the default.

Before:

```
The `x3` extension requires the following permissions:
  Read from the following paths:
  Write to the following paths:
  Run the following commands:
    bash
    zsh
  Access the following domains:
    phylum.io
Do you accept? [y/n]
```

After:

Note that `Run` and `Access` are highlighted in bold blue in the output.

```
The `x3` extension requires the following permissions:

  Run the following commands:
    'bash'
    'zsh'

  Access the following domains:
    'phylum.io'

Do you accept? [y/N]
```
