### PR TITLE
Make job ID mandatory in job status extension api

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -173,14 +173,11 @@ async fn get_refresh_token(state: Rc<RefCell<OpState>>) -> Result<RefreshToken> 
 #[op]
 async fn get_job_status(
     state: Rc<RefCell<OpState>>,
-    job_id: Option<String>,
+    job_id: String,
 ) -> Result<JobStatusResponse<PackageStatusExtended>> {
     let api = ExtensionStateRef::from(state).await?;
 
-    let job_id = job_id
-        .map(|job_id| JobId::from_str(&job_id).ok())
-        .unwrap_or_else(|| get_current_project().map(|p| p.id))
-        .ok_or_else(|| anyhow!("Failed to find a valid project configuration"))?;
+    let job_id = JobId::from_str(&job_id)?;
     api.get_job_status_ext(&job_id).await.map_err(Error::from)
 }
 

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -25,7 +25,7 @@ export class PhylumApi {
     }
 
     /// Get job results.
-    static async getJobStatus(jobId?: string): object {
+    static async getJobStatus(jobId: string): object {
         return await Deno.core.opAsync('get_job_status', jobId);
     }
 


### PR DESCRIPTION
Before this patch, the `get_job_status` extension API would fall back to
the project ID when no job ID was specified, however the project ID is
not a valid job ID.

Since there's no reasonable default for us to pick, this patch instead
switches the job ID parameter to be mandatory.

This also removes the alias for "current" as the latest job ID, since
this API changed due to the request manager removal.