### PR TITLE
Don't require Job ID for `phylum history` command

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -60,8 +60,7 @@ pub fn app<'a>() -> clap::Command<'a> {
                 .args(&[
                     Arg::new("JOB_ID")
                         .value_name("JOB_ID")
-                        .help("The job id to query (or `current` for the most recent job)")
-                        .required(true),
+                        .help("The job id to query (or `current` for the most recent job)"),
                     Arg::new("verbose")
                         .short('v')
                         .long("verbose")


### PR DESCRIPTION
This resolves a regression in CLI version 3.6.0 where the Job ID was
accidentally marked as a required argument for the command. Fixes #524
