### PR TITLE
Add `phylum project delete` command

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -75,6 +75,13 @@ pub fn post_create_project(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/projects")?)
 }
 
+/// DELETE /data/projects/<project_id>
+pub fn delete_project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["data", "projects", project_id]);
+    Ok(url)
+}
+
 /// GET /settings/current-user
 pub(crate) fn get_user_settings(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("settings/current-user")?)
@@ -225,6 +232,14 @@ mod test {
         assert_eq!(
             post_create_project(API_URI).unwrap().as_str(),
             format!("{API_URI}/{API_PATH}data/projects"),
+        );
+    }
+
+    #[test]
+    fn delete_project_is_correct() {
+        assert_eq!(
+            delete_project(API_URI, "12345678-90ab-cdef-1234-567890abcdef").unwrap().as_str(),
+            format!("{API_URI}/{API_PATH}data/projects/12345678-90ab-cdef-1234-567890abcdef"),
         );
     }
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -16,7 +16,7 @@ use phylum_types::types::project::{
 use phylum_types::types::user_settings::UserSettings;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client, IntoUrl, Method, StatusCode};
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, IgnoredAny};
 use serde::Serialize;
 use thiserror::Error as ThisError;
 
@@ -72,6 +72,10 @@ pub struct ResponseError {
 impl PhylumApi {
     async fn get<T: DeserializeOwned, U: IntoUrl>(&self, path: U) -> Result<T> {
         self.send_request(Method::GET, path, None::<()>).await
+    }
+
+    async fn delete<T: DeserializeOwned, U: IntoUrl>(&self, path: U) -> Result<T> {
+        self.send_request(Method::DELETE, path, None::<()>).await
     }
 
     async fn put<T: DeserializeOwned, S: serde::Serialize, U: IntoUrl>(
@@ -207,6 +211,17 @@ impl PhylumApi {
             )
             .await?;
         Ok(response.id)
+    }
+
+    /// Delete a project
+    pub async fn delete_project(&mut self, project_id: ProjectId) -> Result<()> {
+        let _: IgnoredAny = self
+            .delete(endpoints::delete_project(
+                &self.config.connection.uri,
+                &format!("{}", project_id),
+            )?)
+            .await?;
+        Ok(())
     }
 
     /// Get a list of projects

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -115,6 +115,19 @@ pub fn app<'a>() -> clap::Command<'a> {
                     ]),
                 )
                 .subcommand(
+                    Command::new("delete").about("Delete a project").aliases(&["rm"]).args(&[
+                        Arg::new("name")
+                            .value_name("name")
+                            .help("Name of the project")
+                            .required(true),
+                        Arg::new("group")
+                            .short('g')
+                            .long("group")
+                            .value_name("group_name")
+                            .help("Group that owns the project"),
+                    ]),
+                )
+                .subcommand(
                     Command::new("list").about("List all existing projects").args(&[
                         Arg::new("json")
                             .short('j')

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -59,6 +59,18 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         });
 
         print_user_success!("Successfully created new project, {}", name);
+    } else if let Some(matches) = matches.subcommand_matches("delete") {
+        let project_name = matches.value_of("name").unwrap();
+        let group_name = matches.value_of("group");
+
+        let proj_uuid = api
+            .get_project_id(project_name, group_name)
+            .await
+            .context("A project with that name does not exist")?;
+
+        api.delete_project(proj_uuid).await?;
+
+        print_user_success!("Successfully deleted project, {}", project_name);
     } else if let Some(matches) = matches.subcommand_matches("list") {
         let group = matches.value_of("group");
         let pretty_print = pretty_print && !matches.is_present("json");


### PR DESCRIPTION
Now that the endpoint to delete projects [is exposed](https://api.staging.phylum.io/api/v0/swagger/index.html#/Projects/projects_delete_project) (in staging at least), we can go ahead and implement the `phylum project delete` command.
