### PR TITLE
Validate extension name in `phylum extension new`

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -208,14 +208,6 @@ pub fn extensions_path() -> Result<PathBuf, anyhow::Error> {
     Ok(dirs::data_dir()?.join("phylum").join("extensions"))
 }
 
-pub fn extension_path(name: &str) -> Result<PathBuf, anyhow::Error> {
-    if !EXTENSION_NAME_RE.is_match(name) {
-        return Err(anyhow!(
-            "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or underscore \
-             (_) ",
-            name
-        ));
-    }
-
+fn extension_path(name: &str) -> Result<PathBuf, anyhow::Error> {
     Ok(extensions_path()?.join(name))
 }

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -203,8 +203,8 @@ pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
         Ok(())
     } else {
         Err(anyhow!(
-            "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or \
-             underscore (_)",
+            "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or underscore \
+             (_)",
             name
         ))
     }

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -188,18 +188,25 @@ impl TryFrom<PathBuf> for Extension {
             ));
         }
 
-        if !EXTENSION_NAME_RE.is_match(&manifest.name) {
-            return Err(anyhow!(
-                "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or \
-                 underscore (_)",
-                manifest.name
-            ));
-        }
+        validate_name(&manifest.name)?;
 
         // TODO add further validation if necessary:
         // - Check that the entry point is a supported format (.wasm?)
         // - Check that the entry point is appropriately signed
         Ok(Extension { path, manifest })
+    }
+}
+
+/// Check extension name for validity.
+pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
+    if EXTENSION_NAME_RE.is_match(&name) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or \
+             underscore (_)",
+            name
+        ))
     }
 }
 

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -207,6 +207,8 @@ pub async fn handle_create_extension(path: &str) -> CommandResult {
         .and_then(OsStr::to_str)
         .ok_or_else(|| anyhow!("Last segment in {path:?} is not a valid extension name"))?;
 
+    extension::validate_name(name)?;
+
     // Create all missing directories.
     fs::create_dir_all(&extension_path)
         .with_context(|| format!("Unable to create all directories in {path:?}"))?;

--- a/cli/tests/extensions.rs
+++ b/cli/tests/extensions.rs
@@ -264,6 +264,38 @@ fn arg_access() {
         .stdout("[ \"--test\", \"-x\", \"a\" ]\n");
 }
 
+// Extension creation works.
+#[test]
+fn create_extension() {
+    let tempdir = TempDir::new().unwrap();
+    Command::cargo_bin("phylum")
+        .unwrap()
+        .current_dir(tempdir.path())
+        .env("XDG_DATA_HOME", tempdir.path())
+        .arg("extension")
+        .arg("new")
+        .arg("my-ext")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("✅ Extension created successfully"));
+}
+
+// Extension creation with invalid name fails
+#[test]
+fn create_incorrect_name() {
+    let tempdir = TempDir::new().unwrap();
+    Command::cargo_bin("phylum")
+        .unwrap()
+        .current_dir(tempdir.path())
+        .env("XDG_DATA_HOME", tempdir.path())
+        .arg("extension")
+        .arg("new")
+        .arg("@@@")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("invalid extension name"));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Miscellaneous tests
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Since `phylum extension new` is likely the most common way users will
create new extensions, it should not be possible to creat invalid
extensions with it.

This patch validates the extension name during creation, refusing to
create one with an invalid name.

Closes #515.