### PR TITLE
Use main.ts as default entry_point

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -214,7 +214,7 @@ pub async fn handle_create_extension(path: &str) -> CommandResult {
         .with_context(|| format!("Unable to create all directories in {path:?}"))?;
 
     // Write manifest file.
-    let manifest = ExtensionManifest::new(name.into(), "main.ts".into(), None, None);
+    let manifest = ExtensionManifest::new(name);
     let manifest_path = extension_path.join("PhylumExt.toml");
     fs::write(manifest_path, toml::to_string(&manifest)?.as_bytes())?;
 


### PR DESCRIPTION
Since most extensions will likely follow the suggestions made by the
skeleton created from `phylum extension new`, it's unnecessary to have
the entry_point specified explicitly in the extension manifest.

Closes #509.