### PR TITLE
Use POST for job submission instead of PUT

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -12,8 +12,8 @@ const API_PATH: &str = "api/v0/";
 #[error("invalid API URL")]
 pub struct BaseUriError(#[from] pub ParseError);
 
-/// PUT /data/jobs
-pub fn put_submit_package(api_uri: &str) -> Result<Url, BaseUriError> {
+/// POST /data/jobs
+pub fn post_submit_package(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/jobs")?)
 }
 
@@ -164,7 +164,7 @@ mod test {
     #[test]
     fn put_submit_package_is_correct() {
         assert_eq!(
-            put_submit_package(API_URI).unwrap().as_str(),
+            post_submit_package(API_URI).unwrap().as_str(),
             format!("{API_URI}/{API_PATH}data/jobs"),
         );
     }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -291,7 +291,7 @@ impl PhylumApi {
         };
         log::debug!("==> Sending package submission: {:?}", req);
         let resp: SubmitPackageResponse =
-            self.put(endpoints::put_submit_package(&self.config.connection.uri)?, req).await?;
+            self.post(endpoints::post_submit_package(&self.config.connection.uri)?, req).await?;
         Ok(resp.job_id)
     }
 
@@ -405,7 +405,7 @@ mod tests {
 
         let responder_token_holder = token_holder.clone();
 
-        Mock::given(method("PUT"))
+        Mock::given(method("POST"))
             .and(path("api/v0/data/jobs"))
             .respond_with_fn(move |request| {
                 let mut guard = responder_token_holder.lock().unwrap();
@@ -440,7 +440,7 @@ mod tests {
     #[tokio::test]
     async fn submit_request() -> Result<()> {
         let mock_server = build_mock_server().await;
-        Mock::given(method("PUT"))
+        Mock::given(method("POST"))
             .and(path("api/v0/data/jobs"))
             .respond_with_fn(|_| {
                 ResponseTemplate::new(200)


### PR DESCRIPTION
The `/api/v0/data/jobs` endpoint is adding support for the more correct `POST` method. The CLI should update to match as soon as this method is available in prod.