### PR TITLE
Remove `[permissions]` from generated manifest

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fs::{self, DirBuilder};
 #[cfg(unix)]
@@ -29,8 +30,7 @@ pub struct ExtensionManifest {
     name: String,
     description: Option<String>,
     entry_point: Option<String>,
-    #[serde(default)]
-    permissions: Permissions,
+    permissions: Option<Permissions>,
 }
 
 impl ExtensionManifest {
@@ -67,8 +67,11 @@ impl Extension {
         self.manifest.entry_point()
     }
 
-    pub fn permissions(&self) -> &Permissions {
-        &self.manifest.permissions
+    pub fn permissions(&self) -> Cow<'_, Permissions> {
+        match self.manifest.permissions.as_ref() {
+            Some(permissions) => Cow::Borrowed(permissions),
+            None => Cow::Owned(Permissions::default()),
+        }
     }
 
     /// Install the extension in the default path.

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fmt::Display;
@@ -126,7 +127,8 @@ async fn handle_install_extension(path: &str, accept_permissions: bool) -> Comma
 
     // Attempt to construct a `PermissionsOptions` from the `Permissions`
     // object in order to validate the permissions.
-    let _ = PermissionsOptions::try_from(extension.permissions())?;
+    let permissions = extension.permissions();
+    let _ = PermissionsOptions::try_from(permissions.borrow())?;
 
     if !accept_permissions && !extension.permissions().is_allow_none() {
         ask_permissions(&extension)?;

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -1,5 +1,6 @@
 //! Deno runtime for extensions.
 
+use std::borrow::Borrow;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -10,7 +11,7 @@ use deno_ast::{MediaType, ParseParams, SourceTextInfo};
 use deno_runtime::deno_core::{
     self, Extension, ModuleLoader, ModuleSource, ModuleSourceFuture, ModuleSpecifier, ModuleType,
 };
-use deno_runtime::permissions::Permissions;
+use deno_runtime::permissions::{Permissions, PermissionsOptions};
 use deno_runtime::worker::{MainWorker, WorkerOptions};
 use deno_runtime::{colors, BootstrapOptions};
 use tokio::fs;
@@ -71,7 +72,8 @@ pub async fn run(
     };
 
     // Build permissions object from extension's requested permissions.
-    let permissions = Permissions::from_options(&extension.permissions().try_into()?);
+    let permissions_options = PermissionsOptions::try_from(extension.permissions().borrow())?;
+    let permissions = Permissions::from_options(&permissions_options);
 
     // Initialize Deno runtime.
     let mut worker = MainWorker::bootstrap_from_options(main_module.clone(), permissions, options);


### PR DESCRIPTION
Before this patch, the generated `PhylumExt.toml` manifest would always
contain an empty `[permissions]` section, which did not do anything
other than cluttering the manifest.

By making the permission section itself optional, it will never be
serialized into the generated toml file.

Closes #532.
