### PR TITLE
Remove Deno CLI flag from permission error output

### DIFF
--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -40,7 +40,7 @@ fn incorrect_read_permission_unsuccessful_run() {
     test_cli
         .run(&["incorrect-read-perms"])
         .failure()
-        .stderr(predicate::str::contains("Error: Requires read access"));
+        .stderr("❗ Error: Execution failed caused by: Requires read access to \"/tmp/passwd\"\n");
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn incorrect_net_permission_unsuccessful_run() {
     test_cli
         .run(&["incorrect-net-perms"])
         .failure()
-        .stderr(predicate::str::contains(r#"Error: Requires net access to "phylum.io""#));
+        .stderr("❗ Error: Execution failed caused by: Requires net access to \"phylum.io\"\n");
 }
 
 #[test]

--- a/docs/extensions/example.md
+++ b/docs/extensions/example.md
@@ -213,13 +213,8 @@ When replacing the `console.log` with this function call and executing our
 extension, you'll run into the following error:
 
 ```
-❗ Error: Execution failed caused by: Error: Requires write access to "./duplicates.txt", run again with the --allow-write flag
+❗ Error: Execution failed caused by: Error: Requires write access to "./duplicates.txt"
 ```
-
-The error message comes directly from Deno and is misleading (see issue [#520]).
-The `--allow-write` flag is **not** supported for Phylum's CLI extensions.
-
-[#520]: https://github.com/phylum-dev/cli/issues/520
 
 This is exactly what should have happened, since Deno's sandbox doesn't allow us
 to interact with the outside world unless we've been granted permission to do


### PR DESCRIPTION
This patch checks for JS runtime execution errors and truncates the
Deno-specific suffix from permission errors, if it is present.

Closes #520.
