### PR TITLE
Fix clippy ref warning in extension API

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -33,7 +33,7 @@ async fn analyze(
 ) -> Result<ProjectId> {
     // Ensure extension has file read-access.
     let state = ExtensionState::from(op_state);
-    state.permissions().read.validate(&lockfile, "read")?;
+    state.permissions.read.validate(&lockfile, "read")?;
 
     let api = state.api().await?;
 
@@ -168,7 +168,7 @@ async fn parse_lockfile(
 ) -> Result<Vec<PackageDescriptor>> {
     // Ensure extension has file read-access.
     let state = ExtensionState::from(op_state);
-    state.permissions().read.validate(&lockfile, "read")?;
+    state.permissions.read.validate(&lockfile, "read")?;
 
     // Fallback to automatic parser without lockfile type specified.
     let lockfile_type = match lockfile_type {

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -1,12 +1,12 @@
-use std::cell::{Ref, RefCell};
-use std::ops::Deref;
+//! Extension API functions.
+
+use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Error, Result};
 use deno_runtime::deno_core::{op, OpDecl, OpState};
-use futures::future::BoxFuture;
 use phylum_types::types::auth::{AccessToken, RefreshToken};
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::job::JobStatusResponse;
@@ -15,107 +15,14 @@ use phylum_types::types::package::{
 };
 use phylum_types::types::project::ProjectDetailsResponse;
 use tokio::fs;
-use tokio::sync::Mutex;
 
-use crate::api::PhylumApi;
 use crate::auth::UserInfo;
-use crate::commands::extensions::permissions::Permissions;
+use crate::commands::extensions::state::ExtensionState;
 use crate::commands::parse::{self, get_packages_from_lockfile, LOCKFILE_PARSERS};
 use crate::config::get_current_project;
 
-/// Holds either an unawaited, boxed `Future`, or the result of awaiting the
-/// future.
-enum OnceFuture<T: Unpin> {
-    Future(BoxFuture<'static, T>),
-    Awaited(T),
-}
-
-impl<T: Unpin> OnceFuture<T> {
-    fn new(inner: BoxFuture<'static, T>) -> Self {
-        OnceFuture::Future(inner)
-    }
-
-    async fn get(&mut self) -> &T {
-        match *self {
-            OnceFuture::Future(ref mut inner) => {
-                *self = OnceFuture::Awaited(inner.await);
-                match *self {
-                    OnceFuture::Future(..) => unreachable!(),
-                    OnceFuture::Awaited(ref mut inner) => inner,
-                }
-            },
-            OnceFuture::Awaited(ref mut inner) => inner,
-        }
-    }
-}
-
-// XXX: Holding a mutable reference to any field inside `ExtensionState` across
-// await points, will cause issues when that field is accessed from another
-// extension API method.
-//
-// Accessing the `ExtensionState` is only safe through `ExtensionStateRef`,
-// since that ensures that `OpState` is not accessed through a mutable reference
-// which could be held across await points.
-//
-// When making a field of `ExtensionState` mutably accessible, the mutation
-// should occur internally through SYNCHRONOUS methods (e.g. `with_x(|x| ...)`),
-// so holding a mutable reference is impossible.
-//
-// If a mutable reference MUST be held across await points, like `PhylumApi`,
-// its synchronization should force blocking through an async-safe `Mutex`. This
-// will stall all extension API methods trying to access this field, so ensure
-// the blocking duration is minimal.
-//
-/// Extension state the APIs have access to.
-pub struct ExtensionState {
-    api: Mutex<OnceFuture<Result<Rc<PhylumApi>>>>,
-    permissions: Permissions,
-}
-
-impl ExtensionState {
-    pub fn new(api: BoxFuture<'static, Result<PhylumApi>>, permissions: Permissions) -> Self {
-        Self {
-            permissions,
-            api: Mutex::new(OnceFuture::new(Box::pin(async { api.await.map(Rc::new) }))),
-        }
-    }
-
-    async fn api(&self) -> Result<Rc<PhylumApi>> {
-        // The mutex guard is only useful for synchronizing internally mutable access to
-        // the encapsulated future. Once a `Result<Rc<PhylumApi>>` is obtained,
-        // the guard is dropped: subsequent awaits on `PhylumApi` methods are
-        // not synchronized via this mutex, and can happen concurrently.
-        let mut guard = self.api.lock().await;
-        Ok(Rc::clone(guard.get().await.as_ref().map_err(|e| anyhow!("{:?}", e))?))
-    }
-}
-
-/// Extension state reference.
-///
-/// This type allows easily getting an immutable reference to the extension
-/// state stored in deno's [`OpState`].
-struct ExtensionStateRef<'a>(Ref<'a, ExtensionState>);
-
-impl<'a> ExtensionStateRef<'a> {
-    fn from_op(op_state: &'a Rc<RefCell<OpState>>) -> Self {
-        Self(Ref::map(op_state.borrow(), |op_state| op_state.borrow::<ExtensionState>()))
-    }
-}
-
-impl<'a> Deref for ExtensionStateRef<'a> {
-    type Target = ExtensionState;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-// Extension API functions
-// These functions need not be public, as Deno's declarations (`::decl()`) cloak
-// them in a data structure that is consumed by the runtime extension builder.
-//
-
 /// Analyze a lockfile.
+///
 /// Equivalent to `phylum analyze`.
 #[op]
 async fn analyze(
@@ -125,8 +32,8 @@ async fn analyze(
     group: Option<String>,
 ) -> Result<ProjectId> {
     // Ensure extension has file read-access.
-    let state = ExtensionStateRef::from_op(&op_state);
-    state.permissions.read.validate(&lockfile, "read")?;
+    let state = ExtensionState::from(op_state);
+    state.permissions().read.validate(&lockfile, "read")?;
 
     let api = state.api().await?;
 
@@ -155,7 +62,7 @@ async fn analyze(
 /// Equivalent to `phylum auth status`.
 #[op]
 async fn get_user_info(op_state: Rc<RefCell<OpState>>) -> Result<UserInfo> {
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
     api.user_info().await.map_err(Error::from)
@@ -170,7 +77,7 @@ async fn get_access_token(
 ) -> Result<AccessToken> {
     let refresh_token = get_refresh_token::call(op_state.clone()).await?;
 
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
     let config = api.config();
 
@@ -185,7 +92,7 @@ async fn get_access_token(
 /// Equivalent to `phylum auth token`.
 #[op]
 async fn get_refresh_token(op_state: Rc<RefCell<OpState>>) -> Result<RefreshToken> {
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
     let config = api.config();
 
@@ -203,7 +110,7 @@ async fn get_job_status(
     op_state: Rc<RefCell<OpState>>,
     job_id: String,
 ) -> Result<JobStatusResponse<PackageStatusExtended>> {
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
     let job_id = JobId::from_str(&job_id)?;
@@ -217,7 +124,7 @@ async fn get_project_details(
     op_state: Rc<RefCell<OpState>>,
     project_name: Option<String>,
 ) -> Result<ProjectDetailsResponse> {
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
     let project_name = project_name.map(String::from).map(Result::Ok).unwrap_or_else(|| {
@@ -237,7 +144,7 @@ async fn get_package_details(
     version: String,
     package_type: String,
 ) -> Result<Package> {
-    let state = ExtensionStateRef::from_op(&op_state);
+    let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
     let package_type = PackageType::from_str(&package_type)
@@ -260,8 +167,8 @@ async fn parse_lockfile(
     lockfile_type: Option<String>,
 ) -> Result<Vec<PackageDescriptor>> {
     // Ensure extension has file read-access.
-    let state = ExtensionStateRef::from_op(&op_state);
-    state.permissions.read.validate(&lockfile, "read")?;
+    let state = ExtensionState::from(op_state);
+    state.permissions().read.validate(&lockfile, "read")?;
 
     // Fallback to automatic parser without lockfile type specified.
     let lockfile_type = match lockfile_type {

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -15,7 +15,6 @@ use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 use crate::api::PhylumApi;
-pub(crate) use crate::commands::extensions::api::ExtensionState;
 use crate::commands::extensions::permissions::Permissions;
 use crate::commands::{CommandResult, ExitCode};
 use crate::{deno, dirs};

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -23,6 +23,7 @@ use crate::print_user_success;
 pub mod api;
 pub mod extension;
 pub mod permissions;
+pub mod state;
 
 const EXTENSION_SKELETON: &[u8] = b"\
 import { PhylumApi } from 'phylum';

--- a/cli/src/commands/extensions/state.rs
+++ b/cli/src/commands/extensions/state.rs
@@ -1,0 +1,94 @@
+//! Shared extension state.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use anyhow::{anyhow, Result};
+use deno_runtime::deno_core::OpState;
+use futures::future::BoxFuture;
+use tokio::sync::Mutex;
+
+use crate::commands::extensions::permissions::Permissions;
+use crate::commands::extensions::PhylumApi;
+
+/// Holds either an unawaited, boxed `Future`, or the result of awaiting the
+/// future.
+enum OnceFuture<T: Unpin> {
+    Future(BoxFuture<'static, T>),
+    Awaited(T),
+}
+
+impl<T: Unpin> OnceFuture<T> {
+    fn new(inner: BoxFuture<'static, T>) -> Self {
+        OnceFuture::Future(inner)
+    }
+
+    async fn get(&mut self) -> &T {
+        match *self {
+            OnceFuture::Future(ref mut inner) => {
+                *self = OnceFuture::Awaited(inner.await);
+                match *self {
+                    OnceFuture::Future(..) => unreachable!(),
+                    OnceFuture::Awaited(ref mut inner) => inner,
+                }
+            },
+            OnceFuture::Awaited(ref mut inner) => inner,
+        }
+    }
+}
+
+// XXX: Holding a `Ref`, `RefMut`, or guard across await points, can cause
+// issues when that field is accessed from another extension API
+// method.
+//
+// If a field in [`ExtensionStateInner`] requires mutable access, it should be
+// synchronized with an async-safe `Mutex` or `RwLock`, so an attempted access
+// to the inner value will cause blocking until the initial guard is resolved.
+//
+// This also means that if this guard is held across an await point, all other
+// access will stall until that future is completed. Avoid holding guards across
+// await points, especially when depending on other methods accessing the same
+// lock.
+//
+// Using `RefCell` to avoid locking should only be done when the value is
+// private and never held across await points internally. Prefer [`Cell`] if the
+// inner value only needs to be replaced.
+//
+/// Extension state the APIs have access to.
+struct ExtensionStateInner {
+    api: Mutex<OnceFuture<Result<Rc<PhylumApi>>>>,
+    permissions: Permissions,
+}
+
+/// Extension state wrapper.
+///
+/// This wrapper allows safely retrieving the extension state from Deno's
+/// `Rc<RefCell<OpState>>`, without running the risk of holding a reference to
+/// the [`OpState`] across await points.
+#[derive(Clone)]
+pub struct ExtensionState(Rc<ExtensionStateInner>);
+
+impl ExtensionState {
+    pub fn new(api: BoxFuture<'static, Result<PhylumApi>>, permissions: Permissions) -> Self {
+        let api = Mutex::new(OnceFuture::new(Box::pin(async { api.await.map(Rc::new) })));
+        Self(Rc::new(ExtensionStateInner { permissions, api }))
+    }
+
+    pub async fn api(&self) -> Result<Rc<PhylumApi>> {
+        // This mutex guard is only useful for synchronizing mutable access while
+        // awaiting the PhylumApi future. Subsequent access to the API is
+        // immediate and will not hold the Mutex for extended periods of time.
+        let mut guard = self.0.api.lock().await;
+        Ok(guard.get().await.as_ref().map_err(|e| anyhow!("{:?}", e))?.clone())
+    }
+
+    pub fn permissions(&self) -> &Permissions {
+        &self.0.permissions
+    }
+}
+
+impl From<Rc<RefCell<OpState>>> for ExtensionState {
+    fn from(op_state: Rc<RefCell<OpState>>) -> Self {
+        op_state.borrow().borrow::<ExtensionState>().clone()
+    }
+}

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -18,8 +18,8 @@ use tokio::fs;
 use url::{Host, Url};
 
 use crate::api::PhylumApi;
-use crate::commands::extensions::api;
-use crate::commands::extensions::extension::{self, ExtensionState};
+use crate::commands::extensions::state::ExtensionState;
+use crate::commands::extensions::{api, extension};
 
 /// Load Phylum API for module injection.
 const EXTENSION_API: &str = include_str!("./extension_api.ts");


### PR DESCRIPTION
This fixes an issue where clippy would complain about references being
held across await points in our async extension APIs.

The underlying issue is that mutable access to our `RefCell` state would
panic when another asynchronous method held a reference to it across
await points.

This patch does not fix the underlying issue, but instead provides
guidelines to help developers avoid the pitfalls with mutable references
in asynchronous code.
