### PR TITLE
Bump to v3.7.0 - ARM64 Linux support and Maven workspaces

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.7.0 - ARM64 Linux support and Maven workspaces
 * 3.6.0 - Add support for gradle.lockfile
 * 3.5.0 - Automatically detect OIDC URL
 * 3.4.0 - Group account support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.6.0"
+version = "3.7.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
The next release!

Release-Version: v3.7.0
Release-Summary: ARM64 Linux support and Maven workspaces
