### PR TITLE
Fix CI release readme release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,4 +194,4 @@ jobs:
       - name: Update v2-latest using rdme
         uses: readmeio/rdme@7.3.0
         with:
-          rdme: docs ./docs/*/* --key=${{ secrets.README_API }} --version=2-latest
+          rdme: docs ./docs --key=${{ secrets.README_API }} --version=2-latest


### PR DESCRIPTION
The `docs` command is expecting a directory as parameter, but we were
incorrectly passing all documentation files.