### PR TITLE
docs: Category correction to phylum_extension.md

### DIFF
--- a/docs/command_line_tool/phylum_extension.md
+++ b/docs/command_line_tool/phylum_extension.md
@@ -1,6 +1,6 @@
 ---
 title: phylum extension
-category: 6255e67693d5200013b1fa41
+category: 6255e67693d5200013b1fa3e
 hidden: true
 ---
 


### PR DESCRIPTION
Correcting the `category` for this file so it goes to the `Command Line Tool` category (currently pointing at `Knowledge Base`). This file remains `hidden` until it is appropriate to expose it in our user docs. I checked the other "extension" related docs in this folder and they were set appropriately 👍 
