### PR TITLE
Remove warnings from generic lockfile parser

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -11,6 +11,7 @@ use super::{CommandResult, ExitCode};
 use crate::lockfiles::{
     CSProj, GemLock, GradleLock, PackageLock, Parse, PipFile, Poetry, Pom, PyRequirements, YarnLock,
 };
+use crate::{print_user_success, print_user_warning};
 
 pub const LOCKFILE_PARSERS: &[(&str, &dyn Parse)] = &[
     ("yarn", &YarnLock),
@@ -53,7 +54,7 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 }
 /// Attempt to get packages from an unknown lockfile type
 pub fn try_get_packages(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
-    log::warn!(
+    print_user_warning!(
         "Attempting to obtain packages from unrecognized lockfile type: {}",
         path.to_string_lossy()
     );
@@ -63,7 +64,7 @@ pub fn try_get_packages(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageT
     for (name, parser) in LOCKFILE_PARSERS.iter() {
         if let Ok(pkgs) = parser.parse(data.as_str()) {
             if !pkgs.is_empty() {
-                log::debug!("File detected as type: {}", name);
+                print_user_success!("Identified lockfile type: {}", name);
                 return Ok((pkgs, parser.package_type()));
             }
         }

--- a/cli/src/lockfiles/parsers/pypi.rs
+++ b/cli/src/lockfiles/parsers/pypi.rs
@@ -94,7 +94,7 @@ fn package(input: &str) -> Option<PackageDescriptor> {
         None => match get_git_version(&version).ok() {
             Some((_, s)) => Some(s.to_string()),
             None => {
-                log::warn!("Could not determine version for package: {}", name);
+                log::debug!("Could not determine version for package: {}", name);
                 None
             },
         },

--- a/cli/src/lockfiles/python.rs
+++ b/cli/src/lockfiles/python.rs
@@ -74,7 +74,7 @@ impl Parse for PipFile {
                         })
                     }),
                     None => {
-                        log::warn!("Could not determine version for package: {}", k);
+                        log::debug!("Could not determine version for package: {}", k);
                         None
                     },
                 }
@@ -94,9 +94,8 @@ impl Parse for Poetry {
 
         // Warn if the version of this lockfile might not be supported.
         if !lock.metadata.lock_version.starts_with("1.") {
-            log::warn!(
-                "Expected poetry lockfile version ^1.0.0, found {}. Attempting to continue, but \
-                 results might be inaccurate.",
+            log::debug!(
+                "Expected poetry lockfile version ^1.0.0, found {}.",
                 lock.metadata.lock_version
             );
         }


### PR DESCRIPTION
Since the generic lockfile parser attempts to parse every single
lockfile, its output would be rather verbose and misleading, complaining
about invalid packages when parsing an invalid lockfile.

This patch removes all warnings during lockfile parsing and provides
some additional output informing the user about the generic lockfile
parsing status.

Closes #556.
