### PR TITLE
Use package list parameter for analyze API

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -199,8 +199,7 @@ async fn parse_lockfile(
     let lockfile_type = match lockfile_type {
         Some(lockfile_type) => lockfile_type,
         None => {
-            let (packages, package_type) =
-                parse::get_packages_from_lockfile(Path::new(&lockfile))?;
+            let (packages, package_type) = parse::get_packages_from_lockfile(Path::new(&lockfile))?;
             return Ok(PackageLock {
                 package_type,
                 packages: packages.into_iter().map(PackageSpecifier::from).collect(),

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -49,7 +49,7 @@ struct PackageLock {
 async fn analyze(
     op_state: Rc<RefCell<OpState>>,
     package_type: PackageType,
-    mut packages: Vec<Package>,
+    mut packages: Vec<PackageSpecifier>,
     project: Option<String>,
     group: Option<String>,
 ) -> Result<JobId> {

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -8,18 +8,39 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Error, Result};
 use deno_runtime::deno_core::{op, OpDecl, OpState};
 use phylum_types::types::auth::{AccessToken, RefreshToken};
-use phylum_types::types::common::{JobId, ProjectId};
+use phylum_types::types::common::JobId;
 use phylum_types::types::job::JobStatusResponse;
 use phylum_types::types::package::{
     Package, PackageDescriptor, PackageStatusExtended, PackageType,
 };
 use phylum_types::types::project::ProjectDetailsResponse;
+use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use crate::auth::UserInfo;
 use crate::commands::extensions::state::ExtensionState;
-use crate::commands::parse::{self, get_packages_from_lockfile, LOCKFILE_PARSERS};
+use crate::commands::parse::{self, LOCKFILE_PARSERS};
 use crate::config::get_current_project;
+
+/// Package descriptor for any ecosystem.
+#[derive(Serialize, Deserialize, Debug)]
+struct PackageSpecifier {
+    name: String,
+    version: String,
+}
+
+impl From<PackageDescriptor> for PackageSpecifier {
+    fn from(descriptor: PackageDescriptor) -> Self {
+        Self { name: descriptor.name, version: descriptor.version }
+    }
+}
+
+/// Parsed lockfile content.
+#[derive(Serialize, Deserialize, Debug)]
+struct PackageLock {
+    packages: Vec<PackageSpecifier>,
+    package_type: PackageType,
+}
 
 /// Analyze a lockfile.
 ///
@@ -27,18 +48,13 @@ use crate::config::get_current_project;
 #[op]
 async fn analyze(
     op_state: Rc<RefCell<OpState>>,
-    lockfile: String,
+    package_type: PackageType,
+    mut packages: Vec<Package>,
     project: Option<String>,
     group: Option<String>,
-) -> Result<ProjectId> {
-    // Ensure extension has file read-access.
+) -> Result<JobId> {
     let state = ExtensionState::from(op_state);
-    state.permissions.read.validate(&lockfile, "read")?;
-
     let api = state.api().await?;
-
-    let (packages, request_type) = get_packages_from_lockfile(Path::new(&lockfile))
-        .context("Unable to locate any valid package in package lockfile")?;
 
     let (project, group) = match (project, group) {
         (Some(project), group) => (api.get_project_id(&project, group.as_deref()).await?, None),
@@ -51,8 +67,17 @@ async fn analyze(
         },
     };
 
+    let packages = packages
+        .drain(..)
+        .map(|package| PackageDescriptor {
+            package_type,
+            version: package.version,
+            name: package.name,
+        })
+        .collect::<Vec<_>>();
+
     let job_id = api
-        .submit_request(&request_type, &packages, false, project, None, group.map(String::from))
+        .submit_request(&package_type, &packages, false, project, None, group.map(String::from))
         .await?;
 
     Ok(job_id)
@@ -165,7 +190,7 @@ async fn parse_lockfile(
     op_state: Rc<RefCell<OpState>>,
     lockfile: String,
     lockfile_type: Option<String>,
-) -> Result<Vec<PackageDescriptor>> {
+) -> Result<PackageLock> {
     // Ensure extension has file read-access.
     let state = ExtensionState::from(op_state);
     state.permissions.read.validate(&lockfile, "read")?;
@@ -173,7 +198,14 @@ async fn parse_lockfile(
     // Fallback to automatic parser without lockfile type specified.
     let lockfile_type = match lockfile_type {
         Some(lockfile_type) => lockfile_type,
-        None => return Ok(parse::get_packages_from_lockfile(Path::new(&lockfile))?.0),
+        None => {
+            let (mut packages, package_type) =
+                parse::get_packages_from_lockfile(Path::new(&lockfile))?;
+            return Ok(PackageLock {
+                package_type,
+                packages: packages.drain(..).map(PackageSpecifier::from).collect(),
+            });
+        },
     };
 
     // Attempt to parse as requested lockfile type.
@@ -186,7 +218,12 @@ async fn parse_lockfile(
     let lockfile_data = fs::read_to_string(&lockfile)
         .await
         .with_context(|| format!("Could not read lockfile at '{lockfile}'"))?;
-    parser.parse(&lockfile_data)
+    let mut packages = parser.parse(&lockfile_data)?;
+
+    Ok(PackageLock {
+        package_type: parser.package_type(),
+        packages: packages.drain(..).map(PackageSpecifier::from).collect(),
+    })
 }
 
 pub(crate) fn api_decls() -> Vec<OpDecl> {

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -49,7 +49,7 @@ struct PackageLock {
 async fn analyze(
     op_state: Rc<RefCell<OpState>>,
     package_type: PackageType,
-    mut packages: Vec<PackageSpecifier>,
+    packages: Vec<PackageSpecifier>,
     project: Option<String>,
     group: Option<String>,
 ) -> Result<JobId> {
@@ -68,7 +68,7 @@ async fn analyze(
     };
 
     let packages = packages
-        .drain(..)
+        .into_iter()
         .map(|package| PackageDescriptor {
             package_type,
             version: package.version,
@@ -199,11 +199,11 @@ async fn parse_lockfile(
     let lockfile_type = match lockfile_type {
         Some(lockfile_type) => lockfile_type,
         None => {
-            let (mut packages, package_type) =
+            let (packages, package_type) =
                 parse::get_packages_from_lockfile(Path::new(&lockfile))?;
             return Ok(PackageLock {
                 package_type,
-                packages: packages.drain(..).map(PackageSpecifier::from).collect(),
+                packages: packages.into_iter().map(PackageSpecifier::from).collect(),
             });
         },
     };
@@ -218,11 +218,11 @@ async fn parse_lockfile(
     let lockfile_data = fs::read_to_string(&lockfile)
         .await
         .with_context(|| format!("Could not read lockfile at '{lockfile}'"))?;
-    let mut packages = parser.parse(&lockfile_data)?;
+    let packages = parser.parse(&lockfile_data)?;
 
     Ok(PackageLock {
         package_type: parser.package_type(),
-        packages: packages.drain(..).map(PackageSpecifier::from).collect(),
+        packages: packages.into_iter().map(PackageSpecifier::from).collect(),
     })
 }
 

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -4,11 +4,31 @@ export class PhylumApi {
     /// This expects a `.phylum_project` file to be present if the `project`
     /// parameter is undefined.
     ///
+    /// # Parameters
+    ///
+    /// Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
+    ///
+    /// Packages are expected in the following format:
+    ///
+    /// ```
+    /// [
+    ///   { name: "accepts", version: "1.3.8" },
+    ///   { name: "ms", version: "2.0.0" },
+    ///   { name: "negotiator", version: "0.6.3" },
+    ///   { name: "ms", version: "2.1.3" }
+    /// ]
+    /// ```
+    ///
     /// # Returns
     ///
     /// Analyze Job ID, which can later be queried with `getJobStatus`.
-    static async analyze(lockfile: string, project?: string, group?: string): string {
-        return await Deno.core.opAsync('analyze', lockfile, project, group);
+    static async analyze(
+        package_type: string,
+        packages: [object],
+        project?: string,
+        group?: string,
+    ): string {
+        return await Deno.core.opAsync('analyze', package_type, packages, project, group);
     }
 
     /// Get info about the logged in user.
@@ -179,14 +199,17 @@ export class PhylumApi {
     /// List of dependencies:
     ///
     /// ```
-    /// [
-    ///   { name: "accepts", version: "1.3.8", type: "npm" },
-    ///   { name: "ms", version: "2.0.0", type: "npm" },
-    ///   { name: "negotiator", version: "0.6.3", type: "npm" },
-    ///   { name: "ms", version: "2.1.3", type: "npm" }
-    /// ]
+    /// {
+    ///   package_type: "npm",
+    ///   packages: [
+    ///     { name: "accepts", version: "1.3.8" },
+    ///     { name: "ms", version: "2.0.0" },
+    ///     { name: "negotiator", version: "0.6.3" },
+    ///     { name: "ms", version: "2.1.3" }
+    ///   ]
+    /// }
     /// ```
-    static async parseLockfile(lockfile: string, lockfileType?: string): [object] {
+    static async parseLockfile(lockfile: string, lockfileType?: string): object {
         return await Deno.core.opAsync('parse_lockfile', lockfile, lockfileType);
     }
 }

--- a/cli/tests/fixtures/extensions/api/main.ts
+++ b/cli/tests/fixtures/extensions/api/main.ts
@@ -1,4 +1,4 @@
 import { PhylumApi } from "phylum";
 
-const packages = await PhylumApi.parseLockfile("./tests/fixtures/poetry.lock", "poetry");
-console.log(packages.length);
+const lockfile = await PhylumApi.parseLockfile("./tests/fixtures/poetry.lock", "poetry");
+console.log(lockfile.packages.length);


### PR DESCRIPTION
This patch changes the `analyze` extension API to take in the package
type and a list of packages, rather than a lockfile path. This comes
with several advantages.

Since we don't do any file I/O anymore, we don't have to worry about
checking for permissions. The lockfile type also doesn't need to be
known to us, instead people can just freely submit any packages for
their ecosystem.

This new API provides a much more composable interface which allows
future extension developers to easily integrate the CLI into their
custom workflows even with custom proprietary lockfiles.

The previous usecase of just analyzing a known lockfile without the
extension having to parse it themselves is still covered by plumbing the
`parseLockfile` API's output into `analyze`.