### PR TITLE
Remove Deno's built-in permission prompts

### DIFF
--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -40,7 +40,8 @@ pub async fn run(
             "op_request_permission" => op.disable(),
             _ => op,
         })
-        .ops(api::api_decls()).build();
+        .ops(api::api_decls())
+        .build();
 
     let main_module = deno_core::resolve_path(&extension.entry_point().to_string_lossy())?;
 

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -35,7 +35,12 @@ pub async fn run(
     extension: &extension::Extension,
     args: Vec<String>,
 ) -> CommandResult {
-    let phylum_api = Extension::builder().ops(api::api_decls()).build();
+    let phylum_api = Extension::builder()
+        .middleware(|op| match op.name {
+            "op_request_permission" => op.disable(),
+            _ => op,
+        })
+        .ops(api::api_decls()).build();
 
     let main_module = deno_core::resolve_path(&extension.entry_point().to_string_lossy())?;
 

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -87,10 +87,12 @@ pub async fn get_package_details() {
     let test_cli = TestCli::builder().with_config(true).build();
 
     test_cli
-        .extension("\
+        .extension(
+            "\
         await Deno.permissions.request({ name: 'net' });
-        await fetch('https://phylum.io');
-        ")
+        await fetch('https://phylum.io');\
+             ",
+        )
         .build()
         .run()
         .failure()

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -81,3 +81,18 @@ fn correct_run_permission_successful_install_and_run() {
 
     test_cli.run(&["correct-run-perms"]).success().stdout(predicate::str::contains("install"));
 }
+
+#[tokio::test]
+pub async fn get_package_details() {
+    let test_cli = TestCli::builder().with_config(true).build();
+
+    test_cli
+        .extension("\
+        await Deno.permissions.request({ name: 'net' });
+        await fetch('https://phylum.io');
+        ")
+        .build()
+        .run()
+        .failure()
+        .stderr("❗ Error: Execution failed caused by: Requires net access to \"phylum.io\"\n");
+}

--- a/docs/extensions/extension_api.md
+++ b/docs/extensions/extension_api.md
@@ -26,6 +26,9 @@ standard library docs].
 [Deno's API docs]: https://doc.deno.land/deno/stable
 [Deno's standard library docs]: https://deno.land/std
 
+The following API methods are not supported:
+ - https://doc.deno.land/deno/stable/~/Deno.Permissions#request
+
 ## Phylum API
 
 The Phylum extension API is documented in the [TypeScript module file].


### PR DESCRIPTION
This removes the JavaScript `Deno.permissions.request` operation to
prevent extension developers from sidestepping our manifest permission
system.
