### PR TITLE
Validate permissions using Deno's `check`

### DIFF
--- a/cli/src/commands/extensions/state.rs
+++ b/cli/src/commands/extensions/state.rs
@@ -9,7 +9,6 @@ use deno_runtime::deno_core::OpState;
 use futures::future::BoxFuture;
 use tokio::sync::OnceCell;
 
-use crate::commands::extensions::permissions::Permissions;
 use crate::commands::extensions::PhylumApi;
 
 struct OnceFuture<T> {
@@ -54,8 +53,6 @@ impl<T: Unpin> OnceFuture<T> {
 //
 /// Extension state the APIs have access to.
 pub struct ExtensionStateInner {
-    pub permissions: Permissions,
-
     api: OnceFuture<Result<PhylumApi>>,
 }
 
@@ -78,9 +75,9 @@ impl ExtensionStateInner {
 pub struct ExtensionState(Rc<ExtensionStateInner>);
 
 impl ExtensionState {
-    pub fn new(api: BoxFuture<'static, Result<PhylumApi>>, permissions: Permissions) -> Self {
+    pub fn new(api: BoxFuture<'static, Result<PhylumApi>>) -> Self {
         let api = OnceFuture::new(api);
-        Self(Rc::new(ExtensionStateInner { permissions, api }))
+        Self(Rc::new(ExtensionStateInner { api }))
     }
 }
 

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -84,8 +84,7 @@ pub async fn run(
     };
 
     // Build permissions object from extension's requested permissions.
-    let permissions = extension.permissions().into_owned();
-    let permissions_options = PermissionsOptions::from(&permissions);
+    let permissions_options = PermissionsOptions::from(&*extension.permissions());
     let worker_permissions = Permissions::from_options(&permissions_options);
 
     // Initialize Deno runtime.
@@ -93,7 +92,7 @@ pub async fn run(
         MainWorker::bootstrap_from_options(main_module.clone(), worker_permissions, options);
 
     // Export shared state.
-    let state = ExtensionState::new(api, permissions);
+    let state = ExtensionState::new(api);
     worker.js_runtime.op_state().borrow_mut().put(state);
 
     // Execute extension code.


### PR DESCRIPTION
This modifies the extension API's permission validation checks to rely
on Deno's internal `check` method rather than trying to validate
permissions ourselves.

Closes #579.
