### PR TITLE
ignore empty refresh token from environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#aef4ec8d348aab3520c8b9ecf75cc7d5a3c6b8fa"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#fa98a960b42fa303ba662fcc813fb45a1c63dfe1"
 dependencies = [
  "chrono",
  "log",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -136,6 +136,12 @@ pub fn read_configuration(path: &Path) -> Result<Config> {
         Err(VarError::NotPresent) => {},
     }
 
+    // The code that checks if we have a token expects `Some(token)` to always be a
+    // usable token.
+    if config.auth_info.offline_access.as_ref().map(|t| t.as_str().is_empty()).unwrap_or_default() {
+        config.auth_info.offline_access = None;
+    }
+
     Ok(config)
 }
 
@@ -197,10 +203,12 @@ mod tests {
 
     use super::*;
 
+    const CONFIG_TOKEN: &str = "FAKE TOKEN";
+
     fn write_test_config(path: &Path) {
         let con = ConnectionInfo { uri: "http://127.0.0.1".into() };
 
-        let auth = AuthInfo { offline_access: Some(RefreshToken::new("FAKE TOKEN")) };
+        let auth = AuthInfo { offline_access: Some(RefreshToken::new(CONFIG_TOKEN)) };
 
         let config = Config {
             connection: con,
@@ -247,6 +255,6 @@ mod tests {
 
         let config: Config = read_configuration(tempfile.path()).unwrap();
 
-        assert_eq!(config.auth_info.offline_access, None);
+        assert_eq!(config.auth_info.offline_access, Some(RefreshToken::new(CONFIG_TOKEN)));
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -126,6 +126,10 @@ pub fn read_configuration(path: &Path) -> Result<Config> {
         config.auth_info.offline_access = Some(RefreshToken::new(key));
     }
 
+    if config.auth_info.offline_access.as_ref().map(|t| t.as_str().is_empty()).unwrap_or_default() {
+        config.auth_info.offline_access = None;
+    }
+
     Ok(config)
 }
 
@@ -227,5 +231,16 @@ mod tests {
         let config: Config = read_configuration(tempfile.path()).unwrap();
 
         assert_eq!(config.auth_info.offline_access, Some(RefreshToken::new(ENV_TOKEN)));
+    }
+
+    #[test]
+    fn test_ignore_empty_token() {
+        let tempfile = NamedTempFile::new().unwrap();
+        write_test_config(tempfile.path());
+        env::set_var("PHYLUM_API_KEY", "");
+
+        let config: Config = read_configuration(tempfile.path()).unwrap();
+
+        assert_eq!(config.auth_info.offline_access, None);
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -138,7 +138,7 @@ pub fn read_configuration(path: &Path) -> Result<Config> {
 
     // The code that checks if we have a token expects `Some(token)` to always be a
     // usable token.
-    if config.auth_info.offline_access.as_ref().map(|t| t.as_str().is_empty()).unwrap_or_default() {
+    if config.auth_info.offline_access.as_ref().map(|t| t.as_str()) == Some("") {
         config.auth_info.offline_access = None;
     }
 


### PR DESCRIPTION
This PR updates the configuration loading code such that if the offline access token is an empty string it gets replaced with `None`. There is already code in a few places that checks whether we have an access token by checking if the access token is `None`, but in certain situations it's possible to set the access token to `Some("")` (I think commonly this happens by setting the environment variable to an empty string), which gets past all the checks and results in an "invalid refresh token" error from the authentication server. After this PR, if the refresh token is empty string, CLI will behave as if the refresh token were not configured at all, displaying a message in some situations and beginning authentication in others.

I think this resolves will resolve the "invalid refresh token" error we see sometimes when running the CI integration, but the integration would still fail in those cases, just with a different behavior. It doesn't seem like we currently have a notion of running noninteractively, so the CLI will likely try to start interactive authentication from the build agent and fail. I'm not sure exactly what that failure will look like. There might need to be some further enhancement there.

Potential issue: If the token is set via an environment variable, it looks like we currently still renew the refresh token and save it back to the config file. If the user is for some reason temporarily using a different refresh token by overriding via environment variables, this may cause their saved credentials to be unexpectedly overwritten. Also, if the environment variable is set to an empty string, every command will prompt for authentication because the environment variable in the calling process scope cannot be updated.

Closes #572 

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?

I don't think there's documentation to update for this change, but I'm not that familiar with the documentation for this area.