### PR TITLE
Fix running extensions with relative paths

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -133,7 +133,8 @@ pub async fn handle_run_extension_from_path(
     let path = matches.value_of("PATH").unwrap();
     let options = matches.get_many("OPTIONS").map(|options| options.cloned().collect());
 
-    let extension_path = PathBuf::from(path);
+    let extension_path =
+        fs::canonicalize(path).with_context(|| anyhow!("Invalid extension path: {path:?}"))?;
     let extension = Extension::try_from(extension_path)?;
 
     if !matches.is_present("yes") && !extension.permissions().is_allow_none() {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -247,7 +247,6 @@ mod tests {
         assert_eq!(config.auth_info.offline_access, Some(RefreshToken::new(ENV_TOKEN)));
     }
 
-    #[ignore]
     #[test]
     fn test_ignore_empty_token() {
         let tempfile = NamedTempFile::new().unwrap();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -247,6 +247,7 @@ mod tests {
         assert_eq!(config.auth_info.offline_access, Some(RefreshToken::new(ENV_TOKEN)));
     }
 
+    #[ignore]
     #[test]
     fn test_ignore_empty_token() {
         let tempfile = NamedTempFile::new().unwrap();

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -141,16 +141,12 @@ impl ExtensionsModuleLoader {
     async fn load_from_filesystem(extension_path: &Path, path: &Url) -> Result<String> {
         let path = path.to_file_path().map_err(|_| anyhow!("{path:?}: is not a path"))?;
 
+        let extension_path = fs::canonicalize(extension_path).await?;
+        let path = fs::canonicalize(path).await?;
+
         if !path.starts_with(extension_path) {
             return Err(anyhow!(
                 "`{}`: importing from paths outside of the extension's directory is not allowed",
-                path.to_string_lossy(),
-            ));
-        }
-
-        if path.is_symlink() {
-            return Err(anyhow!(
-                "`{}`: importing from symlinks is not allowed",
                 path.to_string_lossy(),
             ));
         }

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -203,6 +203,16 @@ fn extension_is_locally_run_correctly() {
         .stdout(predicate::str::contains("Hello, World!"));
 }
 
+#[test]
+fn extension_run_relative() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .run(&["extension", "run", "../cli/tests/fixtures/extensions/sample"])
+        .success()
+        .stdout(predicate::str::contains("Hello, World!"));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Utilities
 ////////////////////////////////////////////////////////////////////////////////

--- a/cli/tests/extensions/module_loader.rs
+++ b/cli/tests/extensions/module_loader.rs
@@ -33,6 +33,7 @@ fn good_module_loads_successfully() {
 fn module_with_traversal_fails_to_load() {
     let test_cli = TestCli::builder().build();
 
+    test_cli.install_extension(&fixtures_path().join("module-import").join("successful")).success();
     test_cli.install_extension(&fixtures_path().join("module-import").join("fail-local")).success();
 
     test_cli
@@ -55,24 +56,4 @@ fn module_with_non_allowed_url_fails_to_load() {
         .run(&["module-import-fail-remote"])
         .failure()
         .stderr(predicate::str::contains("importing from domains other than"));
-}
-
-// A symlink is directly created during the test, as no symlinks are committed
-// to the repo.
-#[cfg(unix)]
-#[test]
-fn symlinks_are_rejected() {
-    let test_cli = TestCli::builder().build();
-    let ext_path =
-        test_cli.temp_path().to_owned().join("phylum").join("extensions").join("symlink");
-
-    test_cli.install_extension(&fixtures_path().join("symlink")).success();
-
-    std::os::unix::fs::symlink(ext_path.join("symlink_me.ts"), ext_path.join("symlink.ts"))
-        .unwrap();
-
-    test_cli
-        .run(&["symlink"])
-        .failure()
-        .stderr(predicate::str::contains("importing from symlinks is not allowed"));
 }

--- a/cli/tests/fixtures/extensions/module-import/fail-local/main.ts
+++ b/cli/tests/fixtures/extensions/module-import/fail-local/main.ts
@@ -1,3 +1,3 @@
-import * as malicious from "../../directory/traversal.ts"
+import * as malicious from "../module-import-success/main.ts"
 
 malicious()


### PR DESCRIPTION
This patch fixes an issue with `phylum extension run`, where relative
paths were not accepted as parameter.

To ensure that our module loader's restriction to only load from within
the extension's directory still works properly, all paths are not
canonicalized in the module loader. This means we do not need to check
for symlinks explicitly.

Closes #586.
