### PR TITLE
Restore error trace output

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -7,8 +7,7 @@ use super::{JobId, PackageDescriptor};
 const API_PATH: &str = "api/v0/";
 
 // This wrapper provides important context to the user when their configuration
-// has a bad URL. Without it, the message can be something like "Error creating
-// client" caused by "empty host".
+// has a bad URL. Without it, the message can be something like "empty host".
 #[derive(Debug, ThisError)]
 #[error("invalid API URL")]
 pub struct BaseUriError(#[from] pub ParseError);

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use phylum_types::types::auth::TokenResponse;
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::group::{CreateGroupRequest, CreateGroupResponse, ListUserGroupsResponse};
@@ -149,11 +149,13 @@ impl PhylumApi {
         let tokens: TokenResponse = match &config.auth_info.offline_access {
             Some(refresh_token) => {
                 handle_refresh_tokens(refresh_token, config.ignore_certs, &config.connection.uri)
-                    .await?
+                    .await
+                    .context("Token refresh failed")?
             },
             None => {
                 handle_auth_flow(&AuthAction::Login, config.ignore_certs, &config.connection.uri)
-                    .await?
+                    .await
+                    .context("User login failed")?
             },
         };
 

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -37,7 +37,7 @@ async fn api_factory(
     config_path: PathBuf,
     timeout: Option<u64>,
 ) -> Result<PhylumApi> {
-    let api = PhylumApi::new(config, timeout).await.context("Error creating client")?;
+    let api = PhylumApi::new(config, timeout).await?;
 
     // PhylumApi may have had to log in, updating the auth info so we should save
     // the config

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -193,6 +193,6 @@ async fn main() {
             ),
         },
         Ok(CommandValue::Code(code)) => code.exit(),
-        Err(error) => exit_fail(error, ExitCode::Generic),
+        Err(error) => exit_fail(format!("{:?}", error), ExitCode::Generic),
     }
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -35,7 +35,7 @@ pub async fn handle_auth_status(config: Config, timeout: Option<u64>) -> Command
     }
 
     // Create a client with our auth token attached.
-    let api = PhylumApi::new(config, timeout).await.context("Error creating client")?;
+    let api = PhylumApi::new(config, timeout).await?;
 
     let user_info = api.user_info().await;
 


### PR DESCRIPTION
Fix #594 by restoring error trace output and removing the unhelpful `"Error creating client"` context.

## Before
```
❯ phylum auth status
❗ Error: Error creating client
```
## After
```
❯ phylum auth status
❗ Error: error sending request for url (https://api.staging.phylum.io/api/v0/.well-known/openid-configuration): operation timed out

Caused by:
    operation timed out
```