### PR TITLE
ci: disable failing targets in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+          # - target: x86_64-unknown-linux-musl
+          #   os: ubuntu-latest
+          # - target: aarch64-unknown-linux-musl
+          #   os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
+          # - target: aarch64-apple-darwin
+          #   os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -158,30 +158,30 @@ jobs:
             phylum-*.zip
             phylum-*.zip.minisig
 
-  Trigger:
-    name: Trigger phylum-ci Docker image creation
-    needs: Release
-    # Don't trigger for pre-releases
-    # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
-    #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
-    if: ${{ !contains(github.ref, 'rc') }}
-    # The `--fail-with-body` option in `curl` was added in v7.76.0, which is too
-    # new for the `ubuntu-latest` runner that currently makes use of Ubuntu 20.04.
-    # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
-    #       https://github.com/phylum-dev/cli/issues/467
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Trigger phylum-ci Docker image creation
-        # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-        run: |
-          curl \
-            -X POST \
-            --fail-with-body \
-            --no-progress-meter \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_RELEASE_PAT }}" \
-            -d "{\"event_type\":\"build-push-docker-images\",\"client_payload\":{\"CLI_version\":\"$GITHUB_REF_NAME\"}}" \
-            https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
+  # Trigger:
+  #   name: Trigger phylum-ci Docker image creation
+  #   needs: Release
+  #   # Don't trigger for pre-releases
+  #   # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
+  #   #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
+  #   if: ${{ !contains(github.ref, 'rc') }}
+  #   # The `--fail-with-body` option in `curl` was added in v7.76.0, which is too
+  #   # new for the `ubuntu-latest` runner that currently makes use of Ubuntu 20.04.
+  #   # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
+  #   #       https://github.com/phylum-dev/cli/issues/467
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Trigger phylum-ci Docker image creation
+  #       # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+  #       run: |
+  #         curl \
+  #           -X POST \
+  #           --fail-with-body \
+  #           --no-progress-meter \
+  #           -H "Accept: application/vnd.github.v3+json" \
+  #           -H "Authorization: token ${{ secrets.GH_RELEASE_PAT }}" \
+  #           -d "{\"event_type\":\"build-push-docker-images\",\"client_payload\":{\"CLI_version\":\"$GITHUB_REF_NAME\"}}" \
+  #           https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
 
   Update-Documentation:
     name: Update the documentation


### PR DESCRIPTION
The musl and arm targets have been temporarily disabled in order to get
an automated release out that contains the working target artifacts.
The `phylum-ci` Docker image trigger was also disabled so as not to affect the integrations that are already working.

This workflow can be viewed [here, for the branch](https://github.com/phylum-dev/cli/actions/runs/2820468964). If it works there as expected, then it should be merged to `main` for the `v3.8.0` release (or `v3.8.0-rc0` release) and then reverted after a solution is found for automating the MUSL and ARM64 release targets and artifacts in CI.
