### PR TITLE
docs: update artifact signature and docs to match current tagline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           echo -e $MINISIGN_KEY > minisign.key
           for archive in phylum-*.zip;
           do
-            echo $MINISIGN_PASSWORD | minisign -Sm ${archive} -s minisign.key -t 'Phylum - the future of software supply chain security'
+            echo $MINISIGN_PASSWORD | minisign -Sm ${archive} -s minisign.key -t 'Phylum - The Software Supply Chain Company'
           done
         env:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}

--- a/docs/command_line_tool/alternate_install.md
+++ b/docs/command_line_tool/alternate_install.md
@@ -13,7 +13,7 @@ hidden: false
    ```sh
    $ minisign -Vm phylum-*.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
    Signature and comment signature verified
-   Trusted comment: Phylum - the future of software supply chain security
+   Trusted comment: Phylum - The Software Supply Chain Company
    ```
 
 1. Unzip the archive
@@ -23,10 +23,10 @@ hidden: false
    ```
 
 1. Run the installer script for installation
- 
-    ```
+
+   ```sh
    ./install.sh
-    ```
+   ```
 
 ## Build from source
 


### PR DESCRIPTION
This change matches the language marketing has approved. A check of `phylum-ci` revealed that the signature is verified but the trusted comment content is not (it just needs to exist).