### PR TITLE
Fix `phylum update`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             cp -R shell-completions ${archive}/completions
             cp cli/cli/src/install.sh ${archive}/install.sh
             chmod a+x ${archive}/phylum
-            zip -r ${archive}.zip ${archive}
+            zip -0 -r ${archive}.zip ${archive}
           done
 
       - name: Upload release artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,6 +5220,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
  "byteorder",
+ "bzip2",
  "crc32fast",
  "crossbeam-utils",
+ "flate2",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.10.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.6+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,7 +54,7 @@ tokio = { version = "^1.0", features = ["full"] }
 toml = "0.5.8"
 unicode-width = "0.1.9"
 url = { version = "2", features = ["serde"] }
-zip = { version = "0.6.2", default-features = false, features = [] }
+zip = { version = "0.6.2", default-features = false, features = ["bzip2", "deflate", "zstd"] }
 walkdir = "2.3.2"
 regex = "1.5.5"
 once_cell = "1.12.0"


### PR DESCRIPTION
In 15c2a5a, all features were removed from the `zip` dependency, causing
the `phylum update` command to break since it was no longer able to
unzip the release assets.

This adds back all the default zip compression feature flags, while
keeping the `aes-crypto` feature disabled, which caused the original
dependency conflicts.

Closes #610.
