### PR TITLE
Fix link dependencies in yarn parser

### DIFF
--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -120,7 +120,9 @@ impl Parse for YarnLock {
                 resolver = resolver.replace("%25", "%");
             }
 
-            let (name, version) = if resolver.starts_with("workspace:") {
+            let (name, version) = if resolver.starts_with("workspace:")
+                || resolver.starts_with("link:")
+            {
                 // Ignore filesystem dependencies like the project ("project@workspace:.").
                 continue;
             } else if resolver.starts_with("npm:") {

--- a/cli/tests/fixtures/yarn.lock
+++ b/cli/tests/fixtures/yarn.lock
@@ -484,3 +484,9 @@ __metadata:
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
   languageName: node
   linkType: hard
+
+"~@link:./src::locator=consumer-native-app%40workspace%3Aapp":
+  version: 0.0.0-use.local
+  resolution: "~@link:./src::locator=consumer-native-app%40workspace%3Aapp"
+  languageName: node
+  linkType: soft


### PR DESCRIPTION
This resolves an issue with the yarn parser which would cause the
parsing to fail when encountering a link dependency.

This is fixed by accepting link dependencies as a dependency that is
ignored by Phylum. All other unknown dependency types will still cause a
failure.

Closes #598.