### PR TITLE
Add git dependency support to package-lock.json

### DIFF
--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -18,11 +18,7 @@ impl Parse for PackageLock {
 
         // Get a field as string from a JSON object.
         let get_field = |value: &JsonValue, key| {
-            value
-                .as_object()
-                .and_then(|keys| keys.get(key))
-                .and_then(|value| value.as_str())
-                .map(|value| value.to_string())
+            value.get(key).and_then(|value| value.as_str()).map(|value| value.to_string())
         };
 
         // Get version field from JSON object.

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -49,8 +49,8 @@ impl Parse for PackageLock {
                 // Get dependency version.
                 let version = if resolved.starts_with("https://registry.npmjs.org") {
                     get_version(keys, name)?
-                } else if resolved.starts_with("git+") {
-                    resolved["git+".len()..].to_owned()
+                } else if let Some(git_url) = resolved.strip_prefix("git+") {
+                    git_url.to_owned()
                 } else {
                     // Filter filesystem dependencies.
                     continue;

--- a/cli/tests/fixtures/package-lock.json
+++ b/cli/tests/fixtures/package-lock.json
@@ -12,6 +12,26 @@
         "express": "^4.17.3"
       }
     },
+    "../test": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/test": {
+      "resolved": "../test",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "4.9.0",
+      "resolved": "git+ssh://git@github.com/Microsoft/TypeScript.git#9189e42b1c8b1a91906a245a24697da5e0c11a08",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",


### PR DESCRIPTION
This resolves an issue with the v7+ package-lock.json parser where
remote git dependencies would be submitted as npm packages, causing the
analysis to never complete.

This patch uses the `resolved` field instead of `version` for all
packages that do not resolve to the `registry.npmjs.org` domain.

This leaves the v6 lockfile parser unaffected, since backporting
shouldn't be necessary given that most people should move on to v7+
automatically over time.

Closes #622.