### PR TITLE
Transitioning away from `musl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - target: x86_64-unknown-linux-musl
-          #   os: ubuntu-latest
-          # - target: aarch64-unknown-linux-musl
-          #   os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }}
-          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The command line interface (CLI) allows users to submit their project package de
 
    | Target | Package |
    | --- | --- |
-   | x86_64-unknown-linux-musl | [phylum-x86_64-unknown-linux-musl.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-musl.zip) <br /> [phylum-x86_64-unknown-linux-musl.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-musl.zip.minisig) |
-   | aarch64-unknown-linux-musl | [phylum-aarch64-unknown-linux-musl.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-unknown-linux-musl.zip) <br /> [phylum-aarch64-unknown-linux-musl.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-unknown-linux-musl.zip.minisig) |
+   | x86_64-unknown-linux-gnu | [phylum-x86_64-unknown-linux-gnu.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-gnu.zip) <br /> [phylum-x86_64-unknown-linux-gnu.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-gnu.zip.minisig) |
+   | aarch64-unknown-linux-gnu | [phylum-aarch64-unknown-linux-gnu.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-unknown-linux-gnu.zip) <br /> [phylum-aarch64-unknown-linux-gnu.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-unknown-linux-gnu.zip.minisig) |
    | x86_64-apple-darwin | [phylum-x86_64-apple-darwin.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-apple-darwin.zip) <br /> [phylum-x86_64-apple-darwin.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-apple-darwin.zip.minisig) |
    | aarch64-apple-darwin | [phylum-aarch64-apple-darwin.zip](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-apple-darwin.zip) <br /> [phylum-aarch64-apple-darwin.zip.minisig](https://github.com/phylum-dev/cli/releases/latest/download/phylum-aarch64-apple-darwin.zip.minisig) |
 
@@ -79,6 +79,16 @@ new features. You can start exploring by taking a look at the official Phylum
 extensions:
 
 https://github.com/phylum-dev/cli/tree/main/extensions
+
+### musl support
+
+Following the release of the extensions feature, as of version 3.8.0, Phylum CLI
+has a dependency on `glibc` and thus can no longer support `musl` compilation targets.
+
+This means that `phylum` won't be executable in environments such as Alpine Linux.
+
+If your use case requires a lightweight Docker base image, consider using
+[Debian slim](https://hub.docker.com/_/debian).
 
 ---
 ## Slack

--- a/README.md
+++ b/README.md
@@ -80,20 +80,17 @@ extensions:
 
 https://github.com/phylum-dev/cli/tree/main/extensions
 
-### musl support
+### musl binaries
 
 As of version 3.8.0, the provided Linux binaries of the Phylum CLI depend on
 `glibc`. We no longer provide binaries that are statically compiled with the
 `musl` libc.
 
 This means the provided binaries won't be executable in environments such as
-Alpine Linux.
-
-If your use case requires a lightweight Docker base image, consider using
-[Debian slim](debian-slim) or [building from source](build-src).
+Alpine Linux. If your use case requires a lightweight Docker base image,
+consider using [Debian slim](debian-slim) instead.
 
 [debian-slim]: https://hub.docker.com/_/debian
-[build-src]: https://docs.phylum.io/docs/alternate_install
 
 ---
 ## Slack

--- a/README.md
+++ b/README.md
@@ -82,13 +82,18 @@ https://github.com/phylum-dev/cli/tree/main/extensions
 
 ### musl support
 
-Following the release of the extensions feature, as of version 3.8.0, Phylum CLI
-has a dependency on `glibc` and thus can no longer support `musl` compilation targets.
+As of version 3.8.0, the provided Linux binaries of the Phylum CLI depend on
+`glibc`. We no longer provide binaries that are statically compiled with the
+`musl` libc.
 
-This means that `phylum` won't be executable in environments such as Alpine Linux.
+This means the provided binaries won't be executable in environments such as
+Alpine Linux.
 
 If your use case requires a lightweight Docker base image, consider using
-[Debian slim](https://hub.docker.com/_/debian).
+[Debian slim](debian-slim) or [building from source](build-src).
+
+[debian-slim]: https://hub.docker.com/_/debian
+[build-src]: https://docs.phylum.io/docs/alternate_install
 
 ---
 ## Slack

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -96,12 +96,17 @@ source ${completions_dir}/phylum.bash" \
 }
 
 check_glibc() {
+    # Skip check on non-Linux systems.
+    if [ $(uname) != "Linux" ]; then
+        return 0
+    fi
+
     # On systems with musl libc, running ldd on phylum will exit with an error.
     # If that happens, report an explanation and exit.
-    ldd phylum >/dev/null 2>&1
-    if [ $? != 0 ]; then
+    if ! ldd phylum >/dev/null 2>&1; then
         error "The current operating system does not support running Phylum. Please use a system with glibc."
         error "See: https://github.com/phylum-dev/cli#musl-support"
+        echo
         exit 1
     fi
 }

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -95,6 +95,17 @@ source ${completions_dir}/phylum.bash" \
     success "Completions are enabled for bash."
 }
 
+check_glibc() {
+    # On systems with musl libc, running ldd on phylum will exit with an error.
+    # If that happens, report an explanation and exit.
+    ldd phylum >/dev/null 2>&1
+    if [ $? != 0 ]; then
+        error "The current operating system does not support running Phylum. Please use a system with glibc."
+        error "See: https://github.com/phylum-dev/cli#musl-support"
+        exit 1
+    fi
+}
+
 copy_files() {
     # Copy the specific platform binary.
     platform=$(set -e; get_platform)
@@ -141,6 +152,7 @@ cleanup_pre_xdg() {
 
 cd "$(dirname "$0")"
 banner
+check_glibc
 cleanup_pre_xdg
 copy_files
 patch_bashrc

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -96,8 +96,10 @@ source ${completions_dir}/phylum.bash" \
 }
 
 check_glibc() {
+    platform_str=$(uname)
+
     # Skip check on non-Linux systems.
-    if [ "$(uname)" != "Linux" ]; then
+    if [ "${platform_str}" != "Linux" ]; then
         return 0
     fi
 

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -107,7 +107,7 @@ check_glibc() {
     # If that happens, report an explanation and exit.
     if ! ldd phylum >/dev/null 2>&1; then
         error "The current operating system does not support running Phylum. Please use a system with glibc."
-        error "See: https://github.com/phylum-dev/cli#musl-support"
+        error "See: https://github.com/phylum-dev/cli#musl-binaries"
         exit 1
     fi
 }

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -108,7 +108,6 @@ check_glibc() {
     if ! ldd phylum >/dev/null 2>&1; then
         error "The current operating system does not support running Phylum. Please use a system with glibc."
         error "See: https://github.com/phylum-dev/cli#musl-support"
-        echo
         exit 1
     fi
 }

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -97,7 +97,7 @@ source ${completions_dir}/phylum.bash" \
 
 check_glibc() {
     # Skip check on non-Linux systems.
-    if [ $(uname) != "Linux" ]; then
+    if [ "$(uname)" != "Linux" ]; then
         return 0
     fi
 

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -81,8 +81,8 @@ async fn download_github_asset(latest: &GithubReleaseAsset) -> anyhow::Result<by
 }
 
 const SUPPORTED_PLATFORMS: &[&str] = &[
-    "x86_64-unknown-linux-musl",
-    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
 ];
@@ -97,11 +97,7 @@ fn current_platform() -> anyhow::Result<String> {
         "unsupported"
     };
     let os = if cfg!(target_os = "linux") {
-        // We could check cfg!(target_env = "musl") here, but I think that's
-        // unnecessary. If a user compiles the CLI for x86_64-unknown-linux-gnu
-        // and then runs `phylum update`, we should be able to upgrade them to a
-        // x86_64-unknown-linux-musl binary without breaking anything.
-        "unknown-linux-musl"
+        "unknown-linux-gnu"
     } else if cfg!(target_os = "macos") {
         "apple-darwin"
     } else {

--- a/scripts/phylum-init.sh
+++ b/scripts/phylum-init.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SUPPORTED_TARGETS="aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-musl x86_64-unknown-linux-musl"
+SUPPORTED_TARGETS="aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu"
 BASE_URL="https://github.com/phylum-dev/cli/releases/latest/download"
 MINISIG_PUBKEY="RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf"
 
@@ -11,7 +11,7 @@ get_platform() {
     platform=$(uname -s | tr '[:upper:]' '[:lower:]')
 
     case "${platform}" in
-        linux) platform="unknown-linux-musl" ;;
+        linux) platform="unknown-linux-gnu" ;;
         darwin) platform="apple-darwin" ;;
         *) ;;
     esac


### PR DESCRIPTION
This PR changes the installation scripts and the `README` to refer to the new `gnu` based binaries.

Opening as draft PR to request feedback on wording and alternative strategies.

Closes #426.