### PR TITLE
Handle `-h`, `--help` and `help` as first argument of `extension run`

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -147,7 +147,7 @@ async fn handle_commands() -> CommandResult {
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),
 
-        "extension" => extensions::handle_extensions(app_helper, Box::pin(api), sub_matches).await,
+        "extension" => extensions::handle_extensions(Box::pin(api), sub_matches, app_helper).await,
         extension_subcmd => {
             extensions::handle_run_extension(Box::pin(api), extension_subcmd, sub_matches).await
         },

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -147,7 +147,7 @@ async fn handle_commands() -> CommandResult {
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),
 
-        "extension" => extensions::handle_extensions(Box::pin(api), sub_matches).await,
+        "extension" => extensions::handle_extensions(app_helper, Box::pin(api), sub_matches).await,
         extension_subcmd => {
             extensions::handle_run_extension(Box::pin(api), extension_subcmd, sub_matches).await
         },

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -90,9 +90,9 @@ pub fn add_extensions_subcommands(command: Command<'_>) -> Command<'_> {
 
 /// Entry point for the `extensions` subcommand.
 pub async fn handle_extensions(
-    app: &mut Command<'_>,
     api: BoxFuture<'static, Result<PhylumApi>>,
     matches: &ArgMatches,
+    app: &mut Command<'_>,
 ) -> CommandResult {
     match matches.subcommand() {
         Some(("install", matches)) => {

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -137,10 +137,7 @@ pub async fn handle_run_extension_from_path(
     let path = matches.value_of("PATH").unwrap();
     let options = matches.get_many("OPTIONS").map(|options| options.cloned().collect());
 
-    if path == "--help" {
-        app.print_long_help()?;
-        return Ok(CommandValue::Code(ExitCode::Ok));
-    } else if path == "-h" {
+    if ["--help", "-h", "help"].contains(&path) {
         app.print_help()?;
         return Ok(CommandValue::Code(ExitCode::Ok));
     }

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -90,6 +90,7 @@ pub fn add_extensions_subcommands(command: Command<'_>) -> Command<'_> {
 
 /// Entry point for the `extensions` subcommand.
 pub async fn handle_extensions(
+    app: &mut Command<'_>,
     api: BoxFuture<'static, Result<PhylumApi>>,
     matches: &ArgMatches,
 ) -> CommandResult {
@@ -101,7 +102,7 @@ pub async fn handle_extensions(
         Some(("uninstall", matches)) => {
             handle_uninstall_extension(matches.value_of("NAME").unwrap()).await
         },
-        Some(("run", matches)) => handle_run_extension_from_path(api, matches).await,
+        Some(("run", matches)) => handle_run_extension_from_path(app, api, matches).await,
         Some(("new", matches)) => handle_create_extension(matches.value_of("PATH").unwrap()).await,
         Some(("list", _)) | None => handle_list_extensions().await,
         _ => unreachable!(),
@@ -129,11 +130,20 @@ pub async fn handle_run_extension(
 ///
 /// Run the extension located at the given path.
 pub async fn handle_run_extension_from_path(
+    app: &mut Command<'_>,
     api: BoxFuture<'static, Result<PhylumApi>>,
     matches: &ArgMatches,
 ) -> CommandResult {
     let path = matches.value_of("PATH").unwrap();
     let options = matches.get_many("OPTIONS").map(|options| options.cloned().collect());
+
+    if path == "--help" {
+        app.print_long_help()?;
+        return Ok(CommandValue::Code(ExitCode::Ok));
+    } else if path == "-h" {
+        app.print_help()?;
+        return Ok(CommandValue::Code(ExitCode::Ok));
+    }
 
     let extension_path =
         fs::canonicalize(path).with_context(|| anyhow!("Invalid extension path: {path:?}"))?;

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -227,6 +227,11 @@ fn extension_run_help_flags() {
     let test_cli = TestCli::builder().build();
 
     test_cli
+        .run(&["extension", "run", "help", "help subcommand"])
+        .success()
+        .stdout(predicate::str::contains("USAGE"));
+
+    test_cli
         .run(&["extension", "run", "--help", "long help"])
         .success()
         .stdout(predicate::str::contains("USAGE"));

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -222,6 +222,21 @@ fn extension_run_relative() {
         .stdout(predicate::str::contains("Hello, World!"));
 }
 
+#[test]
+fn extension_run_help_flags() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .run(&["extension", "run", "--help", "long help"])
+        .success()
+        .stdout(predicate::str::contains("USAGE"));
+
+    test_cli
+        .run(&["extension", "run", "-h", "short help"])
+        .success()
+        .stdout(predicate::str::contains("USAGE"));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Utilities
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #605.

Adds a hard-coded handling of the `-h` and `--help` flags and `help` subcommand when those are supplied as first parameter to `phylum extension run`.