### PR TITLE
Fix parsing gradle lockfile without classpath

### DIFF
--- a/cli/src/lockfiles/java.rs
+++ b/cli/src/lockfiles/java.rs
@@ -175,7 +175,7 @@ mod tests {
     fn lock_parse_gradle() {
         let pkgs = GradleLock.parse_file("tests/fixtures/gradle.lockfile").unwrap();
 
-        assert_eq!(pkgs.len(), 5);
+        assert_eq!(pkgs.len(), 6);
 
         assert_eq!(pkgs[0].name, "com.google.code.findbugs:jsr305");
         assert_eq!(pkgs[0].version, "1.3.9");
@@ -184,6 +184,10 @@ mod tests {
         assert_eq!(pkgs[2].name, "com.google.guava:guava");
         assert_eq!(pkgs[2].version, "23.3-jre");
         assert_eq!(pkgs[2].package_type, PackageType::Maven);
+
+        assert_eq!(pkgs[5].name, "org.springframework:spring-core");
+        assert_eq!(pkgs[5].version, "5.2.15.RELEASE");
+        assert_eq!(pkgs[5].package_type, PackageType::Maven);
     }
 
     #[test]

--- a/cli/src/lockfiles/parsers/gradle_dep.rs
+++ b/cli/src/lockfiles/parsers/gradle_dep.rs
@@ -13,7 +13,7 @@ fn group_id(input: &str) -> Result<&str, &str> {
 
 fn artifact_id_version(input: &str) -> Result<&str, &str> {
     let (input, artifact_id) = delimited(tag(":"), take_until(":"), tag(":"))(input)?;
-    let (_, version) = take_until("=")(input)?;
+    let (_, version) = take_until::<_, _, ()>("=")(input).unwrap_or(("", input));
     Ok((artifact_id, version))
 }
 

--- a/cli/src/lockfiles/parsers/gradle_dep.rs
+++ b/cli/src/lockfiles/parsers/gradle_dep.rs
@@ -13,7 +13,7 @@ fn group_id(input: &str) -> Result<&str, &str> {
 
 fn artifact_id_version(input: &str) -> Result<&str, &str> {
     let (input, artifact_id) = delimited(tag(":"), take_until(":"), tag(":"))(input)?;
-    let (_, version) = take_until::<_, _, ()>("=")(input).unwrap_or(("", input));
+    let (_, version) = take_till(|c| c == '=')(input)?;
     Ok((artifact_id, version))
 }
 

--- a/cli/src/lockfiles/parsers/mod.rs
+++ b/cli/src/lockfiles/parsers/mod.rs
@@ -1,5 +1,5 @@
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take, take_until};
+use nom::bytes::complete::{tag, take, take_till, take_until};
 use nom::character::complete::{line_ending, multispace0, none_of, space0};
 use nom::combinator::{eof, opt, recognize};
 use nom::error::{context, ParseError, VerboseError};

--- a/cli/tests/fixtures/gradle.lockfile
+++ b/cli/tests/fixtures/gradle.lockfile
@@ -6,4 +6,5 @@ com.google.errorprone:error_prone_annotations:2.0.18=classpath
 com.google.guava:guava:23.3-jre=classpath
 com.google.j2objc:j2objc-annotations:1.1=classpath
 org.codehaus.mojo:animal-sniffer-annotations:1.14=classpath
+org.springframework:spring-core:5.2.15.RELEASE
 empty=runtimeClasspath


### PR DESCRIPTION
This resolves an issue in the gradle parser where dependencies without a
trailing `=classpath` were just ignored.
