### PR TITLE
Fix PHYLUM_API_KEY overwriting config token

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -146,7 +146,7 @@ impl PhylumApi {
     /// any changes
     pub async fn new(mut config: Config, request_timeout: Option<u64>) -> Result<Self> {
         // Do we have a refresh token?
-        let tokens: TokenResponse = match &config.auth_info.offline_access {
+        let tokens: TokenResponse = match &config.auth_info.offline_access() {
             Some(refresh_token) => {
                 handle_refresh_tokens(refresh_token, config.ignore_certs, &config.connection.uri)
                     .await
@@ -159,7 +159,7 @@ impl PhylumApi {
             },
         };
 
-        config.auth_info.offline_access = Some(tokens.refresh_token.clone());
+        config.auth_info.set_offline_access(tokens.refresh_token.clone());
 
         let version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
@@ -191,7 +191,7 @@ impl PhylumApi {
         api_uri: &str,
     ) -> Result<AuthInfo> {
         let tokens = handle_auth_flow(&AuthAction::Login, ignore_certs, api_uri).await?;
-        auth_info.offline_access = Some(tokens.refresh_token);
+        auth_info.set_offline_access(tokens.refresh_token);
         Ok(auth_info)
     }
 
@@ -204,7 +204,7 @@ impl PhylumApi {
         api_uri: &str,
     ) -> Result<AuthInfo> {
         let tokens = handle_auth_flow(&AuthAction::Register, ignore_certs, api_uri).await?;
-        auth_info.offline_access = Some(tokens.refresh_token);
+        auth_info.set_offline_access(tokens.refresh_token);
         Ok(auth_info)
     }
 
@@ -390,7 +390,7 @@ mod tests {
         let api = PhylumApi::new(config, None).await?;
         // After auth, auth_info should have a offline access token
         assert!(
-            api.config().auth_info.offline_access.is_some(),
+            api.config().auth_info.offline_access().is_some(),
             "Offline access token was not set"
         );
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -29,7 +29,7 @@ async fn handle_auth_login(mut config: Config, config_path: &Path) -> Result<()>
 
 /// Display the current authentication status to the user.
 pub async fn handle_auth_status(config: Config, timeout: Option<u64>) -> CommandResult {
-    if config.auth_info.offline_access.is_none() {
+    if config.auth_info.offline_access().is_none() {
         print_user_warning!("User is not currently authenticated");
         return Ok(ExitCode::NotAuthenticated.into());
     }
@@ -56,7 +56,7 @@ pub async fn handle_auth_status(config: Config, timeout: Option<u64>) -> Command
 
 /// Display the current authentication token to the user, if one exists.
 pub async fn handle_auth_token(config: &Config, matches: &clap::ArgMatches) -> CommandResult {
-    let refresh_token = match &config.auth_info.offline_access {
+    let refresh_token = match config.auth_info.offline_access() {
         Some(refresh_token) => refresh_token,
         None => {
             print_user_warning!(

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -124,8 +124,8 @@ async fn get_refresh_token(op_state: Rc<RefCell<OpState>>) -> Result<RefreshToke
 
     config
         .auth_info
-        .offline_access
-        .clone()
+        .offline_access()
+        .cloned()
         .ok_or_else(|| anyhow!("User is not currently authenticated"))
 }
 

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -123,11 +123,11 @@ pub mod mockito {
     }
 
     pub fn build_authenticated_auth_info() -> AuthInfo {
-        AuthInfo { offline_access: Some(RefreshToken::new(DUMMY_REFRESH_TOKEN)) }
+        AuthInfo::new(Some(RefreshToken::new(DUMMY_REFRESH_TOKEN)))
     }
 
     pub fn build_unauthenticated_auth_info() -> AuthInfo {
-        AuthInfo { offline_access: None }
+        AuthInfo::default()
     }
 
     pub async fn build_phylum_api(mock_server: &MockServer) -> Result<PhylumApi, PhylumApiError> {

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -221,7 +221,7 @@ pub async fn create_project() -> &'static str {
     let offline_access = Some(RefreshToken::new(env::var("PHYLUM_API_KEY").unwrap()));
     let config = Config {
         connection: ConnectionInfo { uri: API_URL.into() },
-        auth_info: AuthInfo { offline_access },
+        auth_info: AuthInfo::new(offline_access),
         ..Config::default()
     };
 

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -4,7 +4,7 @@ use phylum_types::types::auth::RefreshToken;
 use crate::common::{TestCli, API_URL};
 
 #[test]
-fn test_pass_api_key_through_env() {
+fn pass_api_key_through_env() {
     const ENV_TOKEN: &str = "ENV VARIABLE TOKEN";
 
     TestCli::builder()
@@ -19,12 +19,12 @@ fn test_pass_api_key_through_env() {
 }
 
 #[test]
-fn test_ignore_empty_token() {
+fn ignore_empty_token() {
     const CONFIG_TOKEN: &str = "CONFIGTOKEN";
 
     let config = Config {
         connection: ConnectionInfo { uri: API_URL.into() },
-        auth_info: AuthInfo { offline_access: Some(RefreshToken::new(CONFIG_TOKEN)) },
+        auth_info: AuthInfo::new(Some(RefreshToken::new(CONFIG_TOKEN))),
         ..Config::default()
     };
 


### PR DESCRIPTION
This fixes an issue with the CLI where the config's token would be
overwritten whenever using the PHYLUM_API_KEY environment variable.

Instead of overwriting the config based on what is stored in the
environment variable, the variable and config value are now tracked
separately, always writing the config's value whenever a write is
instructed and returning the environment variable (if present) when
reading from it.

Closes #582.