### PR TITLE
Add -musl shims to release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,16 @@ jobs:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
           MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
 
+      # Temporarily provide glibc binaries as *-unknown-linux-musl, to allow
+      # upgrading to the new archive names.
+      - name: Create update compatability files
+        run: |
+          cp phylum-x86_64-unknown-linux-gnu.zip.minisig phylum-x86_64-unknown-linux-musl.zip.minisig
+          cp phylum-x86_64-unknown-linux-gnu.zip phylum-x86_64-unknown-linux-musl.zip
+
+          cp phylum-aarch64-unknown-linux-gnu.zip.minisig phylum-aarch64-unknown-linux-musl.zip.minisig
+          cp phylum-aarch64-unknown-linux-gnu.zip phylum-aarch64-unknown-linux-musl.zip
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This adds glibc releases as *-unknown-linux-musl to the release archives
to allow older versions to seamlessly transition to the new glibc
executables.

This does NOT provide a musl version, the archives are still glibc
executables and this will only help with updates on systems that support
both musl AND glibc.