### PR TITLE
Fix incorrect help for `phylum extension run -h`

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -102,23 +102,6 @@ async fn handle_commands() -> CommandResult {
         }
     }
 
-    // Subcommands with precedence
-    //
-
-    // For these commands, we want to just provide verbose help and exit if no
-    // arguments are supplied.
-    if let Some(matches) = matches.subcommand_matches("analyze") {
-        if !matches.is_present("LOCKFILE") {
-            print::print_sc_help(app_helper, "analyze");
-            return Ok(ExitCode::Ok.into());
-        }
-    } else if let Some(matches) = matches.subcommand_matches("package") {
-        if !(matches.is_present("name") && matches.is_present("version")) {
-            print::print_sc_help(app_helper, "package");
-            return Ok(ExitCode::Ok.into());
-        }
-    }
-
     // Get the future, but don't await. Commands that require access to the API will
     // await on this, so that the API is not instantiated ahead of time for
     // subcommands that don't require it.

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -107,7 +107,7 @@ pub async fn handle_auth(
     } else if let Some(matches) = matches.subcommand_matches("token") {
         handle_auth_token(&config, matches).await
     } else {
-        print_sc_help(app_helper, &["auth"]);
+        print_sc_help(app_helper, &["auth"])?;
         Ok(ExitCode::Ok.into())
     }
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -107,7 +107,7 @@ pub async fn handle_auth(
     } else if let Some(matches) = matches.subcommand_matches("token") {
         handle_auth_token(&config, matches).await
     } else {
-        print_sc_help(app_helper, "auth");
+        print_sc_help(app_helper, &["auth"]);
         Ok(ExitCode::Ok.into())
     }
 }

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -16,6 +16,7 @@ use log::{error, warn};
 use crate::api::PhylumApi;
 use crate::commands::extensions::extension::{Extension, ExtensionManifest};
 use crate::commands::{CommandResult, CommandValue, ExitCode};
+use crate::print::print_sc_help;
 use crate::print_user_success;
 
 pub mod api;
@@ -138,7 +139,7 @@ pub async fn handle_run_extension_from_path(
     let options = matches.get_many("OPTIONS").map(|options| options.cloned().collect());
 
     if ["--help", "-h", "help"].contains(&path) {
-        app.print_help()?;
+        print_sc_help(app, &["extension", "run"]);
         return Ok(CommandValue::Code(ExitCode::Ok));
     }
 

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -139,7 +139,7 @@ pub async fn handle_run_extension_from_path(
     let options = matches.get_many("OPTIONS").map(|options| options.cloned().collect());
 
     if ["--help", "-h", "help"].contains(&path) {
-        print_sc_help(app, &["extension", "run"]);
+        print_sc_help(app, &["extension", "run"])?;
         return Ok(CommandValue::Code(ExitCode::Ok));
     }
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use ansi_term::Color::{Blue, Cyan};
+use anyhow::{anyhow, Result};
 use clap::Command;
 use prettytable::format;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -37,16 +38,18 @@ pub fn print_update_message() {
     eprintln!("{:-^50}\n\n", "");
 }
 
-pub fn print_sc_help(mut app: &mut Command, subcommands: &[&str]) {
+pub fn print_sc_help(mut app: &mut Command, subcommands: &[&str]) -> Result<()> {
     for subcommand in subcommands {
-        match app.get_subcommands_mut().find(|sc| &sc.get_name() == subcommand) {
+        match app.find_subcommand_mut(*subcommand) {
             Some(subcommand) => app = subcommand,
             // Subcommand doesn't exist; don't print anything.
-            None => return,
+            None => return Err(anyhow!("Subcommand '{subcommand}' does not exist")),
         }
     }
 
-    let _ = app.print_help();
+    app.print_help()?;
+
+    Ok(())
 }
 
 /// Limit a string to a specific length, using an ellipsis to indicate

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -37,14 +37,16 @@ pub fn print_update_message() {
     eprintln!("{:-^50}\n\n", "");
 }
 
-pub fn print_sc_help(app: &mut Command, subcommand: &str) {
-    for sc in app.get_subcommands_mut() {
-        if sc.get_name() == subcommand {
-            let _ = sc.print_help();
-            break;
+pub fn print_sc_help(mut app: &mut Command, subcommands: &[&str]) {
+    for subcommand in subcommands {
+        match app.get_subcommands_mut().find(|sc| &sc.get_name() == subcommand) {
+            Some(subcommand) => app = subcommand,
+            // Subcommand doesn't exist; don't print anything.
+            None => return,
         }
     }
-    println!();
+
+    let _ = app.print_help();
 }
 
 /// Limit a string to a specific length, using an ellipsis to indicate


### PR DESCRIPTION
This resolves an issue for the `phylum extension run` subcommand where
invocations of `help`/`--help`/`-h` would cause it to print the `phylum`
help, rather than the `phylum extension run` help.

The patch also cleans up some unnecessary edge-case handling of
scenarios that are impossible to hit.

Closes #639.