### PR TITLE
Remove getProjectDetails() function from extension API

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -14,7 +14,6 @@ use phylum_types::types::job::JobStatusResponse;
 use phylum_types::types::package::{
     Package, PackageDescriptor, PackageStatusExtended, PackageType,
 };
-use phylum_types::types::project::ProjectDetailsResponse;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -143,24 +143,6 @@ async fn get_job_status(
     api.get_job_status_ext(&job_id).await.map_err(Error::from)
 }
 
-/// Retrieve a project's details.
-/// Equivalent to `phylum history project`.
-#[op]
-async fn get_project_details(
-    op_state: Rc<RefCell<OpState>>,
-    project_name: Option<String>,
-) -> Result<ProjectDetailsResponse> {
-    let state = ExtensionState::from(op_state);
-    let api = state.api().await?;
-
-    let project_name = project_name.map(String::from).map(Result::Ok).unwrap_or_else(|| {
-        get_current_project()
-            .map(|p| p.name)
-            .ok_or_else(|| anyhow!("Failed to find a valid project configuration"))
-    })?;
-    api.get_project_details(&project_name).await.map_err(Error::from)
-}
-
 /// Analyze a single package.
 /// Equivalent to `phylum package`.
 #[op]
@@ -236,7 +218,6 @@ pub(crate) fn api_decls() -> Vec<OpDecl> {
         get_access_token::decl(),
         get_refresh_token::decl(),
         get_job_status::decl(),
-        get_project_details::decl(),
         get_package_details::decl(),
         parse_lockfile::decl(),
     ]

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -115,28 +115,6 @@ export class PhylumApi {
         return await Deno.core.opAsync('get_job_status', jobId);
     }
 
-    /// Get project info.
-    ///
-    /// This expects a `.phylum_project` file to be present if the `project`
-    /// parameter is undefined.
-    ///
-    /// # Returns
-    ///
-    /// Project details:
-    ///
-    /// ```
-    /// {
-    ///   name: "integration-tests",
-    ///   id: "c61344f2-b9c9-44c6-adbb-f4b33dd890bd",
-    ///   ecosystem: "npm",
-    ///   thresholds: { author: 0, engineering: 0, license: 0, malicious: 0, total: 0, vulnerability: 0 },
-    ///   jobs: []
-    /// }
-    /// ```
-    static async getProjectDetails(projectName?: string): object {
-        return await Deno.core.opAsync('get_project_details', projectName);
-    }
-
     /// Get analysis results for a single package.
     ///
     /// This will not start a new package analysis, but only retrieve previous

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -52,24 +52,6 @@ pub async fn get_package_details() {
 }
 
 #[tokio::test]
-pub async fn get_project_details() {
-    let test_cli = TestCli::builder().with_config(None).build();
-
-    let project = create_project().await;
-    let permissions =
-        Permissions { net: Permission::List(vec![String::from("123")]), ..Permissions::default() };
-
-    let project_details = format!("console.log(await PhylumApi.getProjectDetails({project:?}))");
-    test_cli
-        .extension(&project_details)
-        .with_permissions(permissions)
-        .build()
-        .run()
-        .success()
-        .stdout(predicates::str::contains(r#"name: "integration-tests""#));
-}
-
-#[tokio::test]
 pub async fn parse_lockfile() {
     let test_cli = TestCli::builder().with_config(None).build();
 


### PR DESCRIPTION
None of our extensions use the `getProjectDetails()` function and it is based on a deprecated endpoint. This patch removes it from the extension API as a simple way to fix #642. We could deprecate it instead, but I am doubtful that it provides much, if any, value and I do not want the initial release of extensions to include a deprecated function.

New functions will be added to the extension API in #644 and #645 to handle any use cases that may exist involving "project details"