### PR TITLE
Add project extension APIs

### DIFF
--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -115,6 +115,72 @@ export class PhylumApi {
         return await Deno.core.opAsync('get_job_status', jobId);
     }
 
+    /// Get currently linked project.
+    ///
+    /// # Returns
+    ///
+    /// Project information:
+    ///
+    /// ```
+    /// {
+    ///   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
+    ///   name: "phylum",
+    ///   created_at: "2022-08-18T18:41:46.468054855+02:00",
+    ///   group_name: null
+    /// }
+    /// ```
+    ///
+    /// If no project is linked, this will return `null`.
+    static getCurrentProject(): object {
+        return Deno.core.opSync('get_current_project');
+    }
+
+    /// List the user's groups.
+    ///
+    /// # Returns
+    ///
+    /// Accessible groups:
+    ///
+    /// ```
+    /// {
+    ///   groups: [
+    ///     {
+    ///       created_at: "2022-05-02T14:25:24.184866508Z",
+    ///       last_modified: "2022-05-02T14:25:24.599950299Z",
+    ///       owner_email: "null@phylum.io",
+    ///       group_name: "phlock",
+    ///       is_admin: false,
+    ///       is_owner: true
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    static async getGroups(): object {
+        return Deno.core.opAsync('get_groups');
+    }
+
+    /// List the user's projects.
+    ///
+    /// # Returns
+    ///
+    /// Accessible projects:
+    ///
+    /// ```
+    /// [
+    ///   {
+    ///     name: "phylum",
+    ///     id: "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+    ///     updated_at: "2022-08-16T22:22:14.092474Z",
+    ///     created_at: "2022-06-24T22:45:47.054472Z",
+    ///     ecosystem: "npm",
+    ///     group_name: null
+    ///   }
+    /// ]
+    /// ```
+    static async getProjects(group?: string): object {
+        return Deno.core.opAsync('get_projects', group);
+    }
+
     /// Get analysis results for a single package.
     ///
     /// This will not start a new package analysis, but only retrieve previous

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -51,6 +51,42 @@ pub async fn get_package_details() {
         .stdout(predicates::str::contains("vulnerability: 1"));
 }
 
+#[test]
+pub fn get_current_project() {
+    let test_cli = TestCli::builder().cwd_temp().with_config(None).build();
+
+    test_cli
+        .extension("console.log(PhylumApi.getCurrentProject())")
+        .build()
+        .run()
+        .success()
+        .stdout("null\n");
+}
+
+#[tokio::test]
+pub async fn get_groups() {
+    let test_cli = TestCli::builder().with_config(None).build();
+
+    test_cli
+        .extension("console.log(await PhylumApi.getGroups())")
+        .build()
+        .run()
+        .success()
+        .stdout(predicates::str::contains("groups"));
+}
+
+#[tokio::test]
+pub async fn get_projects() {
+    let test_cli = TestCli::builder().with_config(None).build();
+
+    test_cli
+        .extension("console.log(await PhylumApi.getProjects())")
+        .build()
+        .run()
+        .success()
+        .stdout(predicates::str::contains("["));
+}
+
 #[tokio::test]
 pub async fn parse_lockfile() {
     let test_cli = TestCli::builder().with_config(None).build();


### PR DESCRIPTION
This patch adds some additional APIs to query for general project
information. This includes querying the linked project offline, the
user's groups and the user's projects.

Closes #645.
Closes #644.