### PR TITLE
fix: update shim for musl to gnu is broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v3
 
+      # Temporarily provide glibc binaries as *-unknown-linux-musl, to allow upgrading to the new archive names.
+      # NOTE: This does NOT provide a musl version; the archives are still glibc executables. This will
+      #       only help with updates on systems that support both musl AND glibc (e.g., WSL on Windows).
+      - name: Create update compatability files
+        run: |
+          cp -R phylum-x86_64-unknown-linux-gnu phylum-x86_64-unknown-linux-musl
+          cp -R phylum-aarch64-unknown-linux-gnu phylum-aarch64-unknown-linux-musl
+
       - name: Prep archives
         run: |
           for archive in phylum-*/;
@@ -145,16 +153,6 @@ jobs:
         env:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
           MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
-
-      # Temporarily provide glibc binaries as *-unknown-linux-musl, to allow
-      # upgrading to the new archive names.
-      - name: Create update compatability files
-        run: |
-          cp phylum-x86_64-unknown-linux-gnu.zip.minisig phylum-x86_64-unknown-linux-musl.zip.minisig
-          cp phylum-x86_64-unknown-linux-gnu.zip phylum-x86_64-unknown-linux-musl.zip
-
-          cp phylum-aarch64-unknown-linux-gnu.zip.minisig phylum-aarch64-unknown-linux-musl.zip.minisig
-          cp phylum-aarch64-unknown-linux-gnu.zip phylum-aarch64-unknown-linux-musl.zip
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This adds glibc releases as `*-unknown-linux-musl` to the release
archives at an earlier step in the release workflow to allow older
versions to seamlessly transition to the new glibc executables.

The previous shim renamed outer zip artifacts without accounting for
the directory naming within the archive, causing the update to fail to
find the `install.sh` script within the extracted contents.

This fix still does NOT provide a musl version; the archives are still
glibc executables. This will only help with updates on systems that
support both musl AND glibc (e.g., WSL on Windows).