### PR TITLE
Move error logging to API module

### DIFF
--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -1,28 +1,20 @@
 //! Subcommand `phylum group`.
 
 use clap::ArgMatches;
-use reqwest::StatusCode;
 
-use crate::api::{PhylumApi, PhylumApiError, ResponseError};
+use crate::api::PhylumApi;
 use crate::commands::{CommandResult, ExitCode};
 use crate::format::Format;
-use crate::{print_user_failure, print_user_success};
+use crate::print_user_success;
 
 /// Handle `phylum group` subcommand.
 pub async fn handle_group(api: &mut PhylumApi, mut matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         let group_name = matches.value_of("group_name").unwrap();
-        match api.create_group(group_name).await {
-            Ok(response) => {
-                print_user_success!("Successfully created group {}", response.group_name);
-                Ok(ExitCode::Ok.into())
-            },
-            Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-                print_user_failure!("Group '{}' already exists", group_name);
-                Ok(ExitCode::AlreadyExists.into())
-            },
-            Err(err) => Err(err.into()),
-        }
+        let response = api.create_group(group_name).await?;
+        print_user_success!("Successfully created group {}", response.group_name);
+
+        Ok(ExitCode::Ok.into())
     } else {
         matches = matches.subcommand_matches("list").unwrap_or(matches);
 

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 use ansi_term::Color::White;
 use anyhow::{anyhow, Context, Result};
 use chrono::Local;
-use reqwest::StatusCode;
 
 use super::{CommandResult, ExitCode};
-use crate::api::{PhylumApi, PhylumApiError, ResponseError};
+use crate::api::PhylumApi;
 use crate::config::{get_current_project, save_config, ProjectConfig, PROJ_CONF_FILE};
 use crate::format::Format;
 use crate::prompt::prompt_threshold;
@@ -37,14 +36,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         log::info!("Initializing new project: `{}`", name);
 
-        let project_id = match api.create_project(name, group).await {
-            Ok(project_id) => project_id,
-            Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-                print_user_failure!("Project '{}' already exists", name);
-                return Ok(ExitCode::AlreadyExists.into());
-            },
-            Err(err) => return Err(err.into()),
-        };
+        let project_id = api.create_project(name, group).await?;
 
         let proj_conf = ProjectConfig {
             id: project_id.to_owned(),

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -6,12 +6,11 @@ use std::{env, fs};
 
 pub use assert_cmd::assert::Assert;
 pub use assert_cmd::Command;
-use phylum_cli::api::{PhylumApi, PhylumApiError, ResponseError};
+use phylum_cli::api::{PhylumApi, PhylumApiError};
 use phylum_cli::commands::extensions::permissions::Permissions;
 use phylum_cli::config::{AuthInfo, Config, ConnectionInfo};
 use phylum_types::types::auth::RefreshToken;
 pub use predicates::prelude::*;
-use reqwest::StatusCode;
 use tempfile::TempDir;
 
 pub const API_URL: &str = "https://api.staging.phylum.io";
@@ -228,10 +227,9 @@ pub async fn create_project() -> &'static str {
     // Attempt to create the project, ignoring conflicts.
     let mut api = PhylumApi::new(config, None).await.unwrap();
     match api.create_project(PROJECT_NAME, None).await {
-        Ok(_) | Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-        },
+        Ok(_) | Err(PhylumApiError::Other(_)) => (),
         err @ Err(_) => {
-            err.unwrap();
+            let _ = err.unwrap();
         },
     }
 


### PR DESCRIPTION
Instead of handling the addition of higher-level detail to error
messages in the locations where the API is used, this moves it to the
API instead. This way all locations calling these API functions will
implicitly get the refined error messages without requiring additional
handling at a higher level.

This change was inspired by the existing `get_project_id` function,
which already provides a friendlier error message for missing projects.
So this patch also helps with consistency of error handling