### PR TITLE
Update Maven pom documentation

### DIFF
--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -39,7 +39,7 @@ phylum analyze [OPTIONS] <lockfile>
 $ phylum analyze package-lock.json
 
 # Analyze a Maven lock file with a verbose json response
-$ phylum analyze --json --verbose pom.xml
+$ phylum analyze --json --verbose effective-pom.xml
 
 # Analyze a PyPI lock file and apply a label
 $ phylum analyze -l test_branch requirements.txt

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -18,7 +18,7 @@ The Phylum CLI natively supports processing the lock/requirements files for seve
 * NuGet
     * `*.csproj`
 * Maven
-    * `pom.xml`
+    * `effective-pom.xml`
     * `gradle.lockfile`
 
 After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_project) , you can begin analysis by running:


### PR DESCRIPTION
The existing documentation still pointed to the `pom.xml` as supported
format for Maven. This has been changed to correctly indicate we only
support the `effective-pom.xml` format.
