### PR TITLE
Fix extensions continuing on error

### DIFF
--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -34,7 +34,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     } catch (e) {
         console.error(`[${red("phylum")}] \`package.json\` was not found in the current directory.`);
         console.error(`[${red("phylum")}] Please move to the npm project's top level directory and try again.`);
-        return 125;
+        Deno.exit(125);
     }
 
     // Backup package/lock files.

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -34,7 +34,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     } catch (e) {
         console.error(`[${red("phylum")}] \`package.json\` was not found in the current directory.`);
         console.error(`[${red("phylum")}] Please move to the yarn project's top level directory and try again.`);
-        return 125;
+        Deno.exit(125);
     }
 
     // Backup package/lock files.


### PR DESCRIPTION
This fixes an issues with some of the ecosystem extensions, where they
would continue running even after an error was encountered.

Closes #658.
