### PR TITLE
Fix parsing of nested package-lock dependencies

### DIFF
--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -33,8 +33,8 @@ impl Parse for PackageLock {
             let mut packages = Vec::new();
             for (name, keys) in deps {
                 // Ignore local filesystem dependencies.
-                let name = match name.strip_prefix("node_modules/") {
-                    Some(name) => name,
+                let name = match name.rsplit_once("node_modules/") {
+                    Some((_, name)) => name,
                     None => continue,
                 };
 
@@ -213,7 +213,7 @@ mod tests {
     fn lock_parse_package_v7() {
         let pkgs = PackageLock.parse_file("tests/fixtures/package-lock.json").unwrap();
 
-        assert_eq!(pkgs.len(), 51);
+        assert_eq!(pkgs.len(), 52);
 
         let expected_pkgs = [
             PackageDescriptor {
@@ -231,6 +231,11 @@ mod tests {
                 version: "ssh://git@github.com/Microsoft/TypeScript.git#\
                           9189e42b1c8b1a91906a245a24697da5e0c11a08"
                     .into(),
+                package_type: PackageType::Npm,
+            },
+            PackageDescriptor {
+                name: "form-data".into(),
+                version: "2.3.3".into(),
                 package_type: PackageType::Npm,
             },
         ];

--- a/cli/tests/fixtures/package-lock.json
+++ b/cli/tests/fixtures/package-lock.json
@@ -523,6 +523,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes an issue with npm package-lock.json dependencies where
packages placed in other dependencies' node_modules folders were not
correctly identified.

Instead of parsing `node_modules/dep/node_modules/dep2` as
`dep/node_modules/dep2`, it is now identified properly as `dep2`.

This kind of package structure can occur when dependencies exist
multiple times in the dependency graph. Placing it as a child of a
specific dependency is npm's way to keep multiple package versions,
since the directory on the root does not have the version as part of its
name. This is why both versions must be submitted.

Closes #662.