### PR TITLE
Bump to v3.9.1 - Fix package-lock.json parsing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.9.1 - Fix package-lock.json parsing
 * 3.9.0 - Add support for native certificate store
 * 3.8.0 - CLI extensions
 * 3.7.2 - Improved error messages and output formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.9.0"
+version = "3.9.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Release-Version: v3.9.1
Release-Summary: Fix package-lock.json parsing