### PR TITLE
Send an appropriate User-Agent header

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 
 use self::endpoints::BaseUriError;
+use crate::app::USER_AGENT;
 use crate::auth::{
     fetch_oidc_server_settings, handle_auth_flow, handle_refresh_tokens, AuthAction, UserInfo,
 };
@@ -161,7 +162,6 @@ impl PhylumApi {
 
         config.auth_info.set_offline_access(tokens.refresh_token.clone());
 
-        let version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
         // the cli runs a command or a few short commands then exits, so we do
         // not need to worry about refreshing the access token. We just set it
@@ -171,9 +171,9 @@ impl PhylumApi {
             HeaderValue::from_str(&format!("Bearer {}", tokens.access_token)).unwrap(),
         );
         headers.insert("Accept", HeaderValue::from_str("application/json").unwrap());
-        headers.insert("version", HeaderValue::from_str(version).unwrap());
 
         let client = Client::builder()
+            .user_agent(USER_AGENT.as_str())
             .timeout(Duration::from_secs(request_timeout.unwrap_or(std::u64::MAX)))
             .danger_accept_invalid_certs(config.ignore_certs)
             .default_headers(headers)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,9 +1,14 @@
 use clap::{Arg, Command, ValueHint};
 use git_version::git_version;
+use lazy_static::lazy_static;
 
 use crate::commands::{extensions, parse};
 
 const VERSION: &str = git_version!(args = ["--dirty=-modified", "--tags"], cargo_prefix = "cargo:");
+
+lazy_static! {
+    pub static ref USER_AGENT: String = format!("{}/{}", env!("CARGO_PKG_NAME"), VERSION);
+}
 
 const FILTER_ABOUT: &str = r#"Provide a filter used to limit the issues displayed
 

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 
 use super::ip_addr_ext::IpAddrExt;
 use crate::api::endpoints;
+use crate::app::USER_AGENT;
 
 pub const OIDC_SCOPES: [&str; 4] = ["openid", "offline_access", "profile", "email"];
 
@@ -149,7 +150,10 @@ pub async fn fetch_oidc_server_settings(
     ignore_certs: bool,
     api_uri: &str,
 ) -> Result<OidcServerSettings> {
-    let client = reqwest::Client::builder().danger_accept_invalid_certs(ignore_certs).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT.as_str())
+        .danger_accept_invalid_certs(ignore_certs)
+        .build()?;
     let response = client
         .get(endpoints::oidc_discovery(api_uri)?)
         .header("Accept", "application/json")
@@ -206,7 +210,10 @@ pub async fn acquire_tokens(
     let body =
         build_grant_type_auth_code_post_body(redirect_url, authorization_code, code_verifier)?;
 
-    let client = reqwest::Client::builder().danger_accept_invalid_certs(ignore_certs).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT.as_str())
+        .danger_accept_invalid_certs(ignore_certs)
+        .build()?;
     let response = client
         .post(token_url)
         .header("Content-Type", "application/json")
@@ -245,7 +252,10 @@ pub async fn refresh_tokens(
 
     let body = build_grant_type_refresh_token_post_body(refresh_token)?;
 
-    let client = reqwest::Client::builder().danger_accept_invalid_certs(ignore_certs).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT.as_str())
+        .danger_accept_invalid_certs(ignore_certs)
+        .build()?;
     let response = client
         .post(token_url)
         .header("Content-Type", "application/json")

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -11,6 +11,7 @@ use serde::de::DeserializeOwned;
 use wiremock::MockServer;
 use zip::ZipArchive;
 
+use crate::app::USER_AGENT;
 use crate::spinner::Spinner;
 use crate::types::{GithubRelease, GithubReleaseAsset};
 
@@ -57,7 +58,7 @@ impl Default for ApplicationUpdater {
 
 /// Generic function for fetching data via HTTP GET.
 async fn http_get(url: &str) -> anyhow::Result<reqwest::Response> {
-    let client = Client::builder().user_agent("phylum-cli").build()?;
+    let client = Client::builder().user_agent(USER_AGENT.as_str()).build()?;
     let response = client.get(url).send().await?;
     Ok(response)
 }


### PR DESCRIPTION
This patch adds a user-agent header to our HTTP requests. I chose to use the `git-version` (i.e., the same thing output by `phylum version`) for this in order to properly identify RC versions and local builds.

## Before
![before](https://user-images.githubusercontent.com/616067/188188150-20133fa4-95de-4ab1-96de-d3aff3033342.png)

## After
![after](https://user-images.githubusercontent.com/616067/188187874-36ed176a-3583-4052-99c7-266e7046ce2d.png)

