### PR TITLE
docs: Add extension how-to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ extensions:
 
 https://github.com/phylum-dev/cli/tree/main/extensions
 
-### musl binaries
+### How-tos
+
+How-to articles for the extension framework can be found [here](https://dev.to/phylum).
+
+## musl binaries
 
 As of version 3.8.0, the provided Linux binaries of the Phylum CLI depend on
 `glibc`. We no longer provide binaries that are statically compiled with the

--- a/docs/extensions/extension_howto.md
+++ b/docs/extensions/extension_howto.md
@@ -1,0 +1,7 @@
+---
+title: Extension How-to
+category: 62c5cb137dbdad00536291a6
+hidden: false
+---
+
+How-to articles for the extension framework can be found [here](https://dev.to/phylum).


### PR DESCRIPTION
Adding links for the how-to page

CC: @ambray 