### PR TITLE
Remove XDG migration code

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,13 +1,13 @@
 use std::env::VarError;
 #[cfg(unix)]
-use std::fs::{DirBuilder, Permissions};
+use std::fs::DirBuilder;
 use std::io::{self, Write};
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use chrono::{DateTime, Local};
 use phylum_types::types::auth::RefreshToken;
 use phylum_types::types::common::ProjectId;
@@ -180,28 +180,7 @@ pub fn get_current_project() -> Option<ProjectConfig> {
 }
 
 pub fn get_home_settings_path() -> Result<PathBuf> {
-    let home_path =
-        home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))?;
-
     let config_path = dirs::config_dir()?.join("phylum").join("settings.yaml");
-    let old_config_path = home_path.join(".phylum").join("settings.yaml");
-
-    // Migrate the config from the old location.
-    if !config_path.exists() && old_config_path.exists() {
-        let config_dir = config_path.parent().unwrap();
-
-        #[cfg(unix)]
-        {
-            fs::set_permissions(&old_config_path, Permissions::from_mode(0o600))?;
-            DirBuilder::new().recursive(true).mode(0o700).create(&config_dir)?;
-        }
-
-        #[cfg(not(unix))]
-        fs::create_dir_all(&config_dir)?;
-
-        fs::rename(old_config_path, &config_path).unwrap();
-    }
-
     Ok(config_path)
 }
 

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -133,33 +133,9 @@ copy_files() {
     success "Copied completions to ${completions_dir}"
 }
 
-# Remove old files and entries added before XDG directories conformity.
-cleanup_pre_xdg() {
-    if [ -f "${HOME}/.bashrc" ]; then
-        # Remove old entries from bashrc.
-        perl -i -n -e 'print unless /^source \$HOME\/.phylum\/completions\/phylum.bash$/' "${HOME}/.bashrc"
-        perl -i -n -e 'print unless /^export PATH="\$HOME\/.phylum:\$PATH"$/' "${HOME}/.bashrc"
-        perl -i -n -e "print unless /^alias ph='phylum'$/" "${HOME}/.bashrc"
-    fi
-
-    if [ -f "${HOME}/.zshrc" ]; then
-        # Remove old entries from zshrc.
-        perl -i -n -e 'print unless /^fpath\+=\("\$HOME\/.phylum\/completions"\)$/' "${HOME}/.zshrc"
-        perl -i -n -e 'print unless /^export PATH="\$HOME\/\.phylum:\$PATH"$/' "${HOME}/.zshrc"
-        perl -i -n -e "print unless /^alias ph='phylum'$/" "${HOME}/.zshrc"
-    fi
-
-    # Remove old phylum executable.
-    rm -f "${HOME}/.phylum/phylum"
-
-    # Remove old completions directory.
-    rm -rf "${HOME}/.phylum/completions"
-}
-
 cd "$(dirname "$0")"
 banner
 check_glibc
-cleanup_pre_xdg
 copy_files
 patch_bashrc
 patch_zshrc


### PR DESCRIPTION
The migration to XDG directories was months ago, so it should now be safe to remove the migration code.