### PR TITLE
Fix extension name regex

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -207,11 +207,7 @@ pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
     if EXTENSION_NAME_RE.is_match(name) {
         Ok(())
     } else {
-        Err(anyhow!(
-            "{}: invalid extension name, must be lowercase alphanumeric, dash (-) or underscore \
-             (_)",
-            name
-        ))
+        Err(anyhow!("{}: invalid extension name, must be lowercase alphanumeric, dash (-)", name))
     }
 }
 

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -207,7 +207,7 @@ pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
     if EXTENSION_NAME_RE.is_match(name) {
         Ok(())
     } else {
-        Err(anyhow!("{}: invalid extension name, must be lowercase alphanumeric, dash (-)", name))
+        Err(anyhow!("{}: invalid extension name, must start with a letter and can contain only lowercase alphanumeric character or dashes (-)", name))
     }
 }
 

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -207,7 +207,11 @@ pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
     if EXTENSION_NAME_RE.is_match(name) {
         Ok(())
     } else {
-        Err(anyhow!("{}: invalid extension name, must start with a letter and can contain only lowercase alphanumeric character or dashes (-)", name))
+        Err(anyhow!(
+            "{}: invalid extension name, must start with a letter and can contain only lowercase \
+             alphanumeric characters or dashes (-)",
+            name
+        ))
     }
 }
 


### PR DESCRIPTION
The extension name error message pointed out `_` as a legal character, however the regex itself did not allow for this character.

To ensure extension naming is consistent, the `_` is removed from the error and only `-` is allowed.
