### PR TITLE
Bump to v3.10.0 - Support legacy poetry dependency source type, remov…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.10.0 - Support legacy poetry dependency source type, remove XDG migration code, send better UA header, and bugfixes
 * 3.9.1 - Fix package-lock.json parsing
 * 3.9.0 - Add support for native certificate store
 * 3.8.0 - CLI extensions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.9.1"
+version = "3.10.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Release-Version: v3.10.0
Release-Summary: Support legacy poetry dependency source type, remove XDG migration code, send better UA header, and bugfixes
