### PR TITLE
Include pre-installed extensions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,11 @@ jobs:
           do
             archive=$(echo ${archive} | sed -e "s/\/$//")
             cp -R shell-completions ${archive}/completions
+            mkdir ${archive}/extensions
+            for extension in npm poetry yarn
+            do
+              cp -R cli/extensions/${extension} ${archive}/extensions/${extension}
+            done
             cp cli/cli/src/install.sh ${archive}/install.sh
             chmod a+x ${archive}/phylum
             zip -r ${archive}.zip ${archive}

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -101,7 +101,6 @@ impl Extension {
 
     /// Install the extension in the default path.
     pub fn install(&self) -> Result<()> {
-        println!("Installing extension {}...", self.name());
         let target_prefix = extension_path(self.name())?;
 
         if target_prefix == self.path {
@@ -113,8 +112,6 @@ impl Extension {
         }
 
         self.copy_to(target_prefix)?;
-
-        println!("Extension {} installed successfully", self.name());
 
         Ok(())
     }

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -187,7 +187,11 @@ async fn handle_install_extension(
     if !overwrite {
         if let Ok(installed_extension) = Extension::load(extension.name()) {
             if extension == installed_extension {
-                return Err(anyhow!("identical extension already installed, skipping"));
+                print_user_success!(
+                    "Extension {} already installed, nothing to do",
+                    extension.name()
+                );
+                return Ok(CommandValue::Code(ExitCode::Ok));
             }
             ask_overwrite(&extension)?;
         }

--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -182,6 +182,8 @@ async fn handle_install_extension(
     let extension_path = PathBuf::from(path);
     let extension = Extension::try_from(extension_path)?;
 
+    println!("Installing extension {}...", extension.name());
+
     if !overwrite {
         if let Ok(installed_extension) = Extension::load(extension.name()) {
             if extension == installed_extension {
@@ -196,6 +198,8 @@ async fn handle_install_extension(
     }
 
     extension.install()?;
+
+    print_user_success!("Extension {} installed successfully", extension.name());
 
     Ok(CommandValue::Code(ExitCode::Ok))
 }

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -138,7 +138,8 @@ copy_files() {
         ext=$(dirname "${ext}")
 
         # Install the extension
-        "${bin_dir}/${bin_name}" extension install --accept-permissions "${ext}"
+        # Note: We ignore the exit code here because the user might decline the install
+        "${bin_dir}/${bin_name}" extension install --accept-permissions "${ext}" || true
     done
     success "Installed default extensions"
 }

--- a/cli/src/install.sh
+++ b/cli/src/install.sh
@@ -131,6 +131,16 @@ copy_files() {
     (umask 077; mkdir -p "${data_dir}")
     cp -a "completions" "${data_dir}/"
     success "Copied completions to ${completions_dir}"
+
+    # Install extensions
+    for ext in extensions/*/PhylumExt.toml
+    do
+        ext=$(dirname "${ext}")
+
+        # Install the extension
+        "${bin_dir}/${bin_name}" extension install --accept-permissions "${ext}"
+    done
+    success "Installed default extensions"
 }
 
 cd "$(dirname "$0")"

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -9,8 +9,8 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 #[macro_export]
 macro_rules! print_user_success {
     ($($tts:tt)*) => {{
-        eprint!("✅ ");
-        eprintln!($($tts)*);
+        print!("✅ ");
+        println!($($tts)*);
     }}
 }
 

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -170,7 +170,7 @@ fn create_extension() {
     test_cli
         .run(&["extension", "new", "my-ext"])
         .success()
-        .stderr(predicates::str::contains("✅ Extension created successfully"));
+        .stdout(predicates::str::contains("✅ Extension created successfully"));
 }
 
 // Extension creation with invalid name fails

--- a/docs/extensions/extension_overview.md
+++ b/docs/extensions/extension_overview.md
@@ -36,3 +36,10 @@ Official Phylum CLI extensions can be found [on GitHub]. These are a great place
 to get started if you want to try out some CLI extensions or write your own.
 
 [on GitHub]: https://github.com/phylum-dev/cli/tree/main/extensions
+
+Additionally, many of the official extensions are distributed with the Phylum
+CLI and should already be available for use. The pre-installed extensions are:
+
+* [`npm`](https://github.com/phylum-dev/cli/tree/main/extensions/npm)
+* [`poetry`](https://github.com/phylum-dev/cli/tree/main/extensions/poetry)
+* [`yarn`](https://github.com/phylum-dev/cli/tree/main/extensions/npm)

--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -3,7 +3,11 @@
 A [Phylum CLI][phylum-cli] extension that checks your [npm][npm]
 dependencies through [Phylum][phylum] before installing them.
 
-## Installation and basic usage
+## Installation
+
+This is a pre-installed extension and may be available without any additional
+action. If, for some reason, this extension is not already available, follow
+these steps to install it:
 
 Clone the repository and install the extension via the Phylum CLI.
 
@@ -11,6 +15,8 @@ Clone the repository and install the extension via the Phylum CLI.
 git clone https://github.com/phylum-dev/cli
 phylum extension install cli/extensions/npm
 ```
+
+## Basic usage
 
 Prepend `phylum` to your `npm` command invocations:
 

--- a/extensions/poetry/README.md
+++ b/extensions/poetry/README.md
@@ -3,7 +3,11 @@
 A [Phylum CLI][phylum-cli] extension that checks your Python [Poetry][poetry]
 dependencies through [Phylum][phylum] before installing them.
 
-## Installation and basic usage
+## Installation
+
+This is a pre-installed extension and may be available without any additional
+action. If, for some reason, this extension is not already available, follow
+these steps to install it:
 
 Clone the repository and install the extension via the Phylum CLI.
 
@@ -11,6 +15,8 @@ Clone the repository and install the extension via the Phylum CLI.
 git clone https://github.com/phylum-dev/cli
 phylum extension install cli/extensions/poetry
 ```
+
+## Basic usage
 
 Prepend `phylum` to your `poetry` command invocations:
 

--- a/extensions/poetry/fixtures/pyproject.toml
+++ b/extensions/poetry/fixtures/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fixture"
 version = "0.1.0"
 description = ""
-authors = ["Andrea Venuta <andrea@phylum.io>"]
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -3,7 +3,11 @@
 A [Phylum CLI][phylum-cli] extension that checks your [yarn][yarn]
 dependencies through [Phylum][phylum] before installing them.
 
-## Installation and basic usage
+## Installation
+
+This is a pre-installed extension and may be available without any additional
+action. If, for some reason, this extension is not already available, follow
+these steps to install it:
 
 Clone the repository and install the extension via the Phylum CLI.
 
@@ -11,6 +15,8 @@ Clone the repository and install the extension via the Phylum CLI.
 git clone https://github.com/phylum-dev/cli
 phylum extension install cli/extensions/yarn
 ```
+
+## Basic usage
 
 Prepend `phylum` to your `yarn` command invocations:
 


### PR DESCRIPTION
Close #641

An example of running the installer after this change:

```
❯ ./install.sh                                         

    phylum-cli installer

    OK Copied completions to /Users/kyle/.local/share/phylum/completions
Installing extension npm...
✅ Extension npm already installed, nothing to do
Installing extension poetry...
Another version of the 'poetry' extension is already installed. Overwrite? no
❗ Error: install aborted
Installing extension yarn...
✅ Extension yarn installed successfully
    OK Installed default extensions
    OK Completions are enabled for bash.
    OK Completions are enabled for zsh.
    OK Successfully installed phylum.

    Source your /Users/kyle/.zshrc file, add /Users/kyle/.local/bin to your $PATH variable, or
    log in to a new terminal in order to make `phylum` available.
```
