### PR TITLE
update phylum-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#bb39c21c3d6f42f83219ff24bbe3ce3bdf4b25a1"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#1bc96d8158bba84c3382ae26f9f3d39d7a17137e"
 dependencies = [
  "chrono",
  "schemars",


### PR DESCRIPTION
This PR updates phylum-types to a version that has fields that are sent by the API but were previously missing. Phylum CLI deserializes the response data from the server and reserializes it when using the `--json` parameter, so even if CLI isn't using the property for anything, the property must be known in order for it to be accessible via `--json`.

Closes #711 

```diff
❯ diff -u <(phylum package -t npm e 0.2.2 -j) <(cargo run --bin phylum -- package -t npm e 0.2.2 -j)
⠈⡙   Compiling phylum-cli v3.10.0 (/Users/matt.donoughe/Documents/GitHub/cli/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 7.51s
     Running `/Users/matt.donoughe/Documents/GitHub/cli/target/debug/phylum package -t npm e 0.2.2 -j`
--- /dev/fd/11  2022-10-04 08:52:23.000000000 -0400
+++ /dev/fd/13  2022-10-04 08:52:23.000000000 -0400
@@ -42,5 +42,12 @@
     "high": 0,
     "critical": 0
   },
-  "complete": true
+  "complete": true,
+  "releaseData": {
+    "first_release_date": "2012-03-28T02:39:42.562+00:00",
+    "last_release_date": "2022-07-16T08:17:33.948+00:00"
+  },
+  "repoUrl": "https://github.com/gc/e",
+  "maintainers_recently_changed": null,
+  "is_abandonware": null
 }
```

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
