### PR TITLE
Skip end-to-end test for external PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,9 @@ jobs:
           command: test
           args: --locked
 
-      - name: All Features
+      # Skip this step for external PRs (because it requires a secret)
+      - if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        name: All Features
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
Github Actions don't allow access to secrets when triggered by a `pull_request` event from a fork. This PR adds a condition to skip this test so that it does not fail or hang (like we have seen in #714)