### PR TITLE
Fix help output sort order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: v2
+          key: v3
 
       - name: Format check
         if: github.event_name != 'schedule'

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -31,6 +31,7 @@ pub fn app() -> Command {
         .version(VERSION)
         .author("Phylum, Inc.")
         .about("Client interface to the Phylum system")
+        .next_display_order(None)
         .args(&[
             Arg::new("config")
                 .short('c')


### PR DESCRIPTION
This fixes a regression introduced in the clap 4 update (925de7d) which caused the help output to be sorted in order of definition rather than alphabetically.

Fixes #727.
