### PR TITLE
Optimize test workflows without caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,6 @@ jobs:
           profile: minimal
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: v3
-
       - name: Format check
         if: github.event_name != 'schedule'
         run: cargo +nightly fmt --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, [self-hosted, macos, arm64]]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
Attempting to make the cache smaller in #733 was a failure. Maybe we can speed up the tests in other ways and remove caching altogether.