### PR TITLE
Fix CLI certificate override modifying config

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -149,12 +149,12 @@ impl PhylumApi {
         // Do we have a refresh token?
         let tokens: TokenResponse = match &config.auth_info.offline_access() {
             Some(refresh_token) => {
-                handle_refresh_tokens(refresh_token, config.ignore_certs, &config.connection.uri)
+                handle_refresh_tokens(refresh_token, config.ignore_certs(), &config.connection.uri)
                     .await
                     .context("Token refresh failed")?
             },
             None => {
-                handle_auth_flow(&AuthAction::Login, config.ignore_certs, &config.connection.uri)
+                handle_auth_flow(&AuthAction::Login, config.ignore_certs(), &config.connection.uri)
                     .await
                     .context("User login failed")?
             },
@@ -175,7 +175,7 @@ impl PhylumApi {
         let client = Client::builder()
             .user_agent(USER_AGENT.as_str())
             .timeout(Duration::from_secs(request_timeout.unwrap_or(std::u64::MAX)))
-            .danger_accept_invalid_certs(config.ignore_certs)
+            .danger_accept_invalid_certs(config.ignore_certs())
             .default_headers(headers)
             .build()?;
 
@@ -219,7 +219,7 @@ impl PhylumApi {
     /// Get information about the authenticated user
     pub async fn user_info(&self) -> Result<UserInfo> {
         let oidc_settings =
-            fetch_oidc_server_settings(self.config.ignore_certs, &self.config.connection.uri)
+            fetch_oidc_server_settings(self.config.ignore_certs(), &self.config.connection.uri)
                 .await?;
         self.get(oidc_settings.userinfo_endpoint).await
     }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -387,11 +387,9 @@ mod tests {
         let mock_server = build_mock_server().await;
         let auth_info = build_unauthenticated_auth_info();
 
-        let config = Config {
-            connection: ConnectionInfo { uri: mock_server.uri() },
-            auth_info,
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.connection = ConnectionInfo { uri: mock_server.uri() };
+        config.auth_info = auth_info;
 
         let api = PhylumApi::new(config, None).await?;
         // After auth, auth_info should have a offline access token

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -92,9 +92,9 @@ async fn handle_commands() -> CommandResult {
     let mut config: Config = config::read_configuration(&config_path).map_err(|err| {
         anyhow!("Failed to read configuration at `{}`: {}", config_path.to_string_lossy(), err)
     })?;
-    config.ignore_certs |= matches.get_flag("no-check-certificate");
+    config.set_ignore_certs_cli(matches.get_flag("no-check-certificate"));
 
-    if config.ignore_certs {
+    if config.ignore_certs() {
         log::warn!("Ignoring TLS server certificate verification per user request.");
     }
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -13,7 +13,8 @@ use crate::{auth, print_user_success, print_user_warning};
 /// registration page
 async fn handle_auth_register(mut config: Config, config_path: &Path) -> Result<()> {
     let api_uri = &config.connection.uri;
-    config.auth_info = PhylumApi::register(config.auth_info, config.ignore_certs, api_uri).await?;
+    let ignore_certs = config.ignore_certs();
+    config.auth_info = PhylumApi::register(config.auth_info, ignore_certs, api_uri).await?;
     save_config(config_path, &config).map_err(|error| anyhow!(error))?;
     Ok(())
 }
@@ -22,7 +23,8 @@ async fn handle_auth_register(mut config: Config, config_path: &Path) -> Result<
 /// login page
 async fn handle_auth_login(mut config: Config, config_path: &Path) -> Result<()> {
     let api_uri = &config.connection.uri;
-    config.auth_info = PhylumApi::login(config.auth_info, config.ignore_certs, api_uri).await?;
+    let ignore_certs = config.ignore_certs();
+    config.auth_info = PhylumApi::login(config.auth_info, ignore_certs, api_uri).await?;
     save_config(config_path, &config).map_err(|error| anyhow!(error))?;
     Ok(())
 }
@@ -69,7 +71,7 @@ pub async fn handle_auth_token(config: &Config, matches: &clap::ArgMatches) -> C
     if matches.get_flag("bearer") {
         let api_uri = &config.connection.uri;
         let tokens =
-            auth::handle_refresh_tokens(refresh_token, config.ignore_certs, api_uri).await?;
+            auth::handle_refresh_tokens(refresh_token, config.ignore_certs(), api_uri).await?;
         println!("{}", tokens.access_token);
         Ok(ExitCode::Ok.into())
     } else {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -52,8 +52,35 @@ pub struct Config {
     pub auth_info: AuthInfo,
     pub request_type: PackageType,
     pub last_update: Option<usize>,
+    #[serde(skip)]
+    ignore_certs_cli: bool,
     #[serde(deserialize_with = "default_option_bool")]
-    pub ignore_certs: bool,
+    ignore_certs: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            connection: ConnectionInfo { uri: "https://api.phylum.io".into() },
+            auth_info: AuthInfo::default(),
+            request_type: PackageType::Npm,
+            ignore_certs_cli: false,
+            ignore_certs: false,
+            last_update: None,
+        }
+    }
+}
+
+impl Config {
+    /// Check if certificates should be ignored.
+    pub fn ignore_certs(&self) -> bool {
+        self.ignore_certs_cli || self.ignore_certs
+    }
+
+    /// Set the CLI `--no-check-certificate` override value.
+    pub fn set_ignore_certs_cli(&mut self, ignore_certs_cli: bool) {
+        self.ignore_certs_cli = ignore_certs_cli;
+    }
 }
 
 fn default_option_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
@@ -69,18 +96,6 @@ pub struct ProjectConfig {
     pub name: String,
     pub created_at: DateTime<Local>,
     pub group_name: Option<String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            connection: ConnectionInfo { uri: "https://api.phylum.io".into() },
-            auth_info: AuthInfo::default(),
-            request_type: PackageType::Npm,
-            ignore_certs: false,
-            last_update: None,
-        }
-    }
 }
 
 /// Create or open a file. If the file is created, it will restrict permissions

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -220,6 +220,7 @@ mod tests {
             connection: con,
             auth_info: auth,
             request_type: PackageType::Npm,
+            ignore_certs_cli: false,
             ignore_certs: false,
             last_update: None,
         };

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -131,11 +131,9 @@ pub mod mockito {
     }
 
     pub async fn build_phylum_api(mock_server: &MockServer) -> Result<PhylumApi, PhylumApiError> {
-        let config = Config {
-            connection: ConnectionInfo { uri: mock_server.uri() },
-            auth_info: build_authenticated_auth_info(),
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.connection = ConnectionInfo { uri: mock_server.uri() };
+        config.auth_info = build_authenticated_auth_info();
         let phylum = PhylumApi::new(config, None).await?;
         Ok(phylum)
     }

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -52,9 +52,10 @@ impl TestCliBuilder {
     /// If true, a configuration will be generated, stored and passed as an
     /// option.
     pub fn with_config(mut self, config: impl Into<Option<Config>>) -> Self {
-        self.config = Some(config.into().unwrap_or_else(|| Config {
-            connection: ConnectionInfo { uri: API_URL.into() },
-            ..Config::default()
+        self.config = Some(config.into().unwrap_or_else(|| {
+            let mut config = Config::default();
+            config.connection = ConnectionInfo { uri: API_URL.into() };
+            config
         }));
         self
     }
@@ -219,11 +220,9 @@ pub fn create_lockfile(dir: &Path) -> PathBuf {
 /// Ensure the specified project exists.
 pub async fn create_project() -> &'static str {
     let offline_access = Some(RefreshToken::new(env::var("PHYLUM_API_KEY").unwrap()));
-    let config = Config {
-        connection: ConnectionInfo { uri: API_URL.into() },
-        auth_info: AuthInfo::new(offline_access),
-        ..Config::default()
-    };
+    let mut config = Config::default();
+    config.connection =  ConnectionInfo { uri: API_URL.into() };
+    config.auth_info = AuthInfo::new(offline_access);
 
     // Attempt to create the project, ignoring conflicts.
     let api = PhylumApi::new(config, None).await.unwrap();

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -221,7 +221,7 @@ pub fn create_lockfile(dir: &Path) -> PathBuf {
 pub async fn create_project() -> &'static str {
     let offline_access = Some(RefreshToken::new(env::var("PHYLUM_API_KEY").unwrap()));
     let mut config = Config::default();
-    config.connection =  ConnectionInfo { uri: API_URL.into() };
+    config.connection = ConnectionInfo { uri: API_URL.into() };
     config.auth_info = AuthInfo::new(offline_access);
 
     // Attempt to create the project, ignoring conflicts.

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -22,11 +22,9 @@ fn pass_api_key_through_env() {
 fn ignore_empty_token() {
     const CONFIG_TOKEN: &str = "CONFIGTOKEN";
 
-    let config = Config {
-        connection: ConnectionInfo { uri: API_URL.into() },
-        auth_info: AuthInfo::new(Some(RefreshToken::new(CONFIG_TOKEN))),
-        ..Config::default()
-    };
+    let mut config = Config::default();
+    config.connection = ConnectionInfo { uri: API_URL.into() };
+    config.auth_info = AuthInfo::new(Some(RefreshToken::new(CONFIG_TOKEN)));
 
     TestCli::builder()
         .with_config(config)


### PR DESCRIPTION
This resolves an issue with the `--no-check-certificate` CLI option which would cause the `ignore_certs` flag to be permanently changed to `true` in the user's Phylum configuration file.

Closes #664.