### PR TITLE
Fix verbosity errors

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -88,11 +88,6 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("JOB_ID")
                     .value_name("JOB_ID")
                     .help("The job id to query (or `current` for the most recent job)"),
-                Arg::new("verbose")
-                    .action(ArgAction::SetTrue)
-                    .short('v')
-                    .long("verbose")
-                    .help("Increase verbosity of api response."),
                 Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)
@@ -259,11 +254,6 @@ pub fn add_subcommands(command: Command) -> Command {
                          system)",
                     ),
                     Arg::new("label").short('l').value_name("label"),
-                    Arg::new("verbose")
-                        .action(ArgAction::SetTrue)
-                        .short('v')
-                        .long("verbose")
-                        .help("Increase verbosity of api response."),
                     Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
                     Arg::new("json")
                         .action(ArgAction::SetTrue)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -50,11 +50,13 @@ pub fn app() -> Command {
                 .help("Don't validate the server certificate when performing api requests"),
             Arg::new("verbose")
                 .short('v')
+                .long("verbose")
                 .global(true)
                 .help("Increase the level of verbosity (the maximum is -vvv)")
                 .action(ArgAction::Count),
             Arg::new("quiet")
                 .short('q')
+                .long("quiet")
                 .global(true)
                 .help("Reduce the level of verbosity (the maximum is -qq)")
                 .action(ArgAction::Count)

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use console::style;
+use log::LevelFilter;
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::job::{Action, JobStatusResponse};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
@@ -74,7 +75,7 @@ pub async fn get_job_status(
 /// job run.
 pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> CommandResult {
     let pretty_print = !matches.get_flag("json");
-    let verbose = matches.get_flag("verbose");
+    let verbose = log::max_level() > LevelFilter::Warn;
     let mut action = Action::None;
     let display_filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
 
@@ -132,7 +133,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         request_type = res.1;
 
         label = matches.get_one::<String>("label");
-        verbose = matches.get_flag("verbose");
+        verbose = log::max_level() > LevelFilter::Warn;
         pretty_print = !matches.get_flag("json");
         display_filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
         is_user = !matches.get_flag("force");


### PR DESCRIPTION
This fixes a regression introduced in 8748152 where the CLI would panic when running the jobs/analyze subcommands since these had CLI arguments conflicting with the new global `verbose` flag.