### PR TITLE
Fix NPM dependency bundling

### DIFF
--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -41,6 +41,11 @@ impl Parse for PackageLock {
                     None => continue,
                 };
 
+                // Ignore bundled dependencies.
+                if keys.get("inBundle").is_some() {
+                    continue;
+                }
+
                 // Get dependency type.
                 let resolved = get_field(keys, "resolved")
                     .ok_or_else(|| anyhow!("Dependency '{name}' is missing \"resolved\" key"))?;
@@ -227,7 +232,7 @@ mod tests {
         let pkgs =
             PackageLock.parse(include_str!("../../tests/fixtures/package-lock.json")).unwrap();
 
-        assert_eq!(pkgs.len(), 52);
+        assert_eq!(pkgs.len(), 53);
 
         let expected_pkgs = [
             PackageDescriptor {
@@ -250,6 +255,11 @@ mod tests {
             PackageDescriptor {
                 name: "form-data".into(),
                 version: "2.3.3".into(),
+                package_type: PackageType::Npm,
+            },
+            PackageDescriptor {
+                name: "match-sorter".into(),
+                version: "3.1.1".into(),
                 package_type: PackageType::Npm,
             },
         ];

--- a/tests/fixtures/package-lock.json
+++ b/tests/fixtures/package-lock.json
@@ -536,6 +536,22 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/match-sorter": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-3.1.1.tgz",
+      "integrity": "sha512-Qlox3wRM/Q4Ww9rv1cBmYKNJwWVX/WC+eA3+1S3Fv4EOhrqyp812ZEfVFKQk0AP6RfzmPUUOwEZBbJ8IRt8SOw==",
+      "bundleDependencies": [
+        "remove-accents"
+      ],
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      }
+    },
+    "node_modules/match-sorter/node_modules/remove-accents": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
This fixes an issue with the NPM `package-lock.json` parser which would cause parsing failure when encountering a bundled dependency in the lockfile.

These bundled dependencies are filtered out, since their content is already analyzed when analyzing the root of the dependency bundle.

Closes #748.
