### PR TITLE
Bump to v3.10.1 - Fix NPM dependency bundling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.10.1 - Fix NPM dependency bundling
 * 3.10.0 - Support legacy poetry dependency source type, remove XDG migration code, send better UA header, and bugfixes
 * 3.9.1 - Fix package-lock.json parsing
 * 3.9.0 - Add support for native certificate store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.10.0"
+version = "3.10.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.60"

--- a/cli/src/lockfiles/javascript.rs
+++ b/cli/src/lockfiles/javascript.rs
@@ -38,6 +38,11 @@ impl Parse for PackageLock {
                     None => continue,
                 };
 
+                // Ignore bundled dependencies.
+                if keys.get("inBundle").is_some() {
+                    continue;
+                }
+
                 // Get dependency type.
                 let resolved = get_field(keys, "resolved")
                     .ok_or_else(|| anyhow!("Dependency '{name}' is missing \"resolved\" key"))?;
@@ -213,7 +218,7 @@ mod tests {
     fn lock_parse_package_v7() {
         let pkgs = PackageLock.parse_file("tests/fixtures/package-lock.json").unwrap();
 
-        assert_eq!(pkgs.len(), 52);
+        assert_eq!(pkgs.len(), 53);
 
         let expected_pkgs = [
             PackageDescriptor {
@@ -236,6 +241,11 @@ mod tests {
             PackageDescriptor {
                 name: "form-data".into(),
                 version: "2.3.3".into(),
+                package_type: PackageType::Npm,
+            },
+            PackageDescriptor {
+                name: "match-sorter".into(),
+                version: "3.1.1".into(),
                 package_type: PackageType::Npm,
             },
         ];

--- a/cli/tests/fixtures/package-lock.json
+++ b/cli/tests/fixtures/package-lock.json
@@ -536,6 +536,22 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/match-sorter": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-3.1.1.tgz",
+      "integrity": "sha512-Qlox3wRM/Q4Ww9rv1cBmYKNJwWVX/WC+eA3+1S3Fv4EOhrqyp812ZEfVFKQk0AP6RfzmPUUOwEZBbJ8IRt8SOw==",
+      "bundleDependencies": [
+        "remove-accents"
+      ],
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      }
+    },
+    "node_modules/match-sorter/node_modules/remove-accents": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
Release-Version: v3.10.1
Release-Summary: Fix NPM dependency bundling