### PR TITLE
Improve `phylum history` UUID error message

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -89,7 +89,7 @@ pub fn add_subcommands(command: Command) -> Command {
             Command::new("history").about("Return information about historical jobs").args(&[
                 Arg::new("JOB_ID")
                     .value_name("JOB_ID")
-                    .help("The job id to query (or `current` for the most recent job)"),
+                    .help("The job id to query"),
                 Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -79,9 +79,9 @@ pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
     let mut action = Action::None;
     let display_filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
 
-    if matches.get_flag("JOB_ID") {
+    if let Some(job_id) = matches.get_one::<String>("JOB_ID") {
         let job_id =
-            JobId::from_str(matches.get_one::<String>("JOB_ID").expect("No job id found"))?;
+            JobId::from_str(job_id).with_context(|| format!("{job_id:?} is not a valid Job ID"))?;
         action = get_job_status(api, &job_id, verbose, pretty_print, display_filter).await?;
     } else if let Some(project) = matches.get_one::<String>("project") {
         let resp = api.get_project_details(project).await?.jobs;


### PR DESCRIPTION
This removes the mention of `current` as a valid option from the `phylum history` command and also improves its error message to more clearly indicate why the operation failed when something other than a job ID was passed as argument.

Closes #751.