### PR TITLE
docs: Remove `current` from phylum_history.md

### DIFF
--- a/docs/command_line_tool/phylum_history.md
+++ b/docs/command_line_tool/phylum_history.md
@@ -9,7 +9,7 @@ Return information about historical scans
 phylum history [OPTIONS] [JOB_ID]
 ```
 `<JOB_ID>`
-&emsp; The job id to query, or `current` for the most recent job
+&emsp; The job id to query
 
 ### Options
 `--filter <filter>`
@@ -31,9 +31,6 @@ $ phylum history
 
 # View the analysis results of a historical job
 $ phylum history 338ea79f-0e82-4422-9769-4e583a84599f
-
-# View the analysis results of the most recent job
-$ phylum history current
 
 # View a list of analysis runs for the 'sample' project
 $ phylum history --project sample


### PR DESCRIPTION
Remove the use of `current` in the docs for `phylum history` based on this PR https://github.com/phylum-dev/cli/pull/753