### PR TITLE
Re-execute phylum for sandboxing extensions

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -350,6 +350,57 @@ pub fn add_subcommands(command: Command) -> Command {
         )
         .subcommand(extensions::command());
 
+    #[cfg(unix)]
+    {
+        app = app.subcommand(
+            Command::new("sandbox").hide(true).about("Run an application in a sandbox").args(&[
+                Arg::new("allow-read")
+                    .help("Add filesystem read sandbox exception")
+                    .long("allow-read")
+                    .value_name("PATH")
+                    .value_hint(ValueHint::FilePath)
+                    .action(ArgAction::Append),
+                Arg::new("allow-write")
+                    .help("Add filesystem write sandbox exception")
+                    .long("allow-write")
+                    .value_name("PATH")
+                    .value_hint(ValueHint::FilePath)
+                    .action(ArgAction::Append),
+                Arg::new("allow-run")
+                    .help("Add filesystem execute sandbox exception")
+                    .long("allow-run")
+                    .value_name("PATH")
+                    .value_hint(ValueHint::FilePath)
+                    .action(ArgAction::Append),
+                Arg::new("allow-env")
+                    .help("Add environment variable access sandbox exception")
+                    .long("allow-env")
+                    .value_name("ENV_VAR"),
+                // TODO: Can we combine this with allow-env?
+                Arg::new("allow-all-env")
+                    .help("Add full environment variable access sandbox exception")
+                    .long("allow-all-env")
+                    .conflicts_with("allow-env")
+                    .action(ArgAction::SetTrue),
+                Arg::new("allow-net")
+                    .help("Add network access sandbox exception")
+                    .long("allow-net")
+                    .action(ArgAction::SetTrue),
+                Arg::new("strict")
+                    .help("Do not add any default sandbox exceptions")
+                    .long("strict")
+                    .action(ArgAction::SetTrue),
+                Arg::new("cmd").help("Command to be executed").value_name("CMD").required(true),
+                Arg::new("args")
+                    .help("Command arguments")
+                    .value_name("ARG")
+                    .trailing_var_arg(true)
+                    .allow_hyphen_values(true)
+                    .action(ArgAction::Append),
+            ]),
+        )
+    }
+
     #[cfg(feature = "selfmanage")]
     {
         app = app.subcommand(

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -375,13 +375,10 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("allow-env")
                     .help("Add environment variable access sandbox exception")
                     .long("allow-env")
-                    .value_name("ENV_VAR"),
-                // TODO: Can we combine this with allow-env?
-                Arg::new("allow-all-env")
-                    .help("Add full environment variable access sandbox exception")
-                    .long("allow-all-env")
-                    .conflicts_with("allow-env")
-                    .action(ArgAction::SetTrue),
+                    .value_name("ENV_VAR")
+                    .num_args(0..=1)
+                    .default_missing_value("*")
+                    .action(ArgAction::Append),
                 Arg::new("allow-net")
                     .help("Add network access sandbox exception")
                     .long("allow-net")

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -9,8 +9,11 @@ use log::LevelFilter;
 use phylum_cli::api::PhylumApi;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
+#[cfg(unix)]
+use phylum_cli::commands::sandbox;
 use phylum_cli::commands::{
-    auth, extensions, group, jobs, packages, parse, project, CommandResult, CommandValue, ExitCode,
+    auth, extensions, group, jobs, packages, parse, project, CommandResult, CommandValue,
+    ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;
@@ -155,6 +158,8 @@ async fn handle_commands() -> CommandResult {
         "uninstall" => uninstall::handle_uninstall(sub_matches),
 
         "extension" => extensions::handle_extensions(Box::pin(api), sub_matches, app_helper).await,
+        #[cfg(unix)]
+        "sandbox" => sandbox::handle_sandbox(sub_matches).await,
         extension_subcmd => {
             extensions::handle_run_extension(Box::pin(api), extension_subcmd, sub_matches).await
         },

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -7,13 +7,12 @@ use clap::ArgMatches;
 use env_logger::Env;
 use log::LevelFilter;
 use phylum_cli::api::PhylumApi;
-#[cfg(feature = "selfmanage")]
-use phylum_cli::commands::uninstall;
 #[cfg(unix)]
 use phylum_cli::commands::sandbox;
+#[cfg(feature = "selfmanage")]
+use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, extensions, group, jobs, packages, parse, project, CommandResult, CommandValue,
-    ExitCode,
+    auth, extensions, group, jobs, packages, parse, project, CommandResult, CommandValue, ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -1,10 +1,10 @@
 //! Extension API functions.
 
 #[cfg(unix)]
-use std::env;
-#[cfg(unix)]
 use std::borrow::Cow;
 use std::cell::RefCell;
+#[cfg(unix)]
+use std::env;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -468,12 +468,13 @@ fn add_permission_args<'a>(
     // Add environment variable exception arguments.
     match &permissions.env {
         Permission::List(keys) => {
-            for key in keys {
+            // Filter out "*", since the CLI accepts this as allow-all.
+            for key in keys.iter().filter(|key| key != &"*") {
                 sandbox_args.push("--allow-env".into());
                 sandbox_args.push(key.into());
             }
         },
-        Permission::Boolean(true) => sandbox_args.push("--allow-all-env".into()),
+        Permission::Boolean(true) => sandbox_args.push("--allow-env".into()),
         Permission::Boolean(false) => (),
     }
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -416,7 +416,7 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
     }
 
     // Execute sandboxed command.
-    let output = Command::new(env::args().next().unwrap())
+    let output = Command::new(env::current_exe()?)
         .args(sandbox_args.iter_mut().map(|arg| arg.to_mut()))
         .stdin(stdin)
         .stdout(stdout)

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -433,6 +433,7 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
 }
 
 /// Convert [permissions::Permissions] to arguments for `phylum sandbox`.
+#[cfg(unix)]
 fn add_permission_args<'a>(
     sandbox_args: &mut Vec<Cow<'a, str>>,
     permissions: &'a permissions::Permissions,

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,6 +9,8 @@ pub mod jobs;
 pub mod packages;
 pub mod parse;
 pub mod project;
+#[cfg(unix)]
+pub mod sandbox;
 #[cfg(feature = "selfmanage")]
 pub mod uninstall;
 
@@ -32,21 +34,40 @@ pub type CommandResult = anyhow::Result<CommandValue>;
 /// Unique exit code values.
 #[derive(Copy, Clone)]
 pub enum ExitCode {
-    Ok = 0,
-    Generic = 1,
-    NotAuthenticated = 10,
-    AuthenticationFailure = 11,
-    PackageNotFound = 12,
-    SetThresholdsFailure = 13,
-    AlreadyExists = 14,
-    NoHistoryFound = 15,
-    JsError = 16,
-    FailedThresholds = 100,
+    Ok,
+    Generic,
+    NotAuthenticated,
+    AuthenticationFailure,
+    PackageNotFound,
+    SetThresholdsFailure,
+    AlreadyExists,
+    NoHistoryFound,
+    JsError,
+    FailedThresholds,
+    Custom(i32),
 }
 
 impl ExitCode {
     /// Terminate the application with this exit code.
     pub fn exit(&self) -> ! {
-        process::exit(*self as i32);
+        process::exit(self.into());
+    }
+}
+
+impl From<&ExitCode> for i32 {
+    fn from(code: &ExitCode) -> Self {
+        match code {
+            ExitCode::Ok => 0,
+            ExitCode::Generic => 1,
+            ExitCode::NotAuthenticated => 10,
+            ExitCode::AuthenticationFailure => 11,
+            ExitCode::PackageNotFound => 12,
+            ExitCode::SetThresholdsFailure => 13,
+            ExitCode::AlreadyExists => 14,
+            ExitCode::NoHistoryFound => 15,
+            ExitCode::JsError => 16,
+            ExitCode::FailedThresholds => 100,
+            ExitCode::Custom(code) => *code,
+        }
     }
 }

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -1,0 +1,67 @@
+//! Sandbox subcommand handling.
+
+use std::os::unix::process::ExitStatusExt;
+use std::process::Command;
+
+use anyhow::{anyhow, Result};
+use birdcage::{Birdcage, Exception, Sandbox};
+use clap::ArgMatches;
+
+use crate::commands::extensions::permissions;
+use crate::commands::{CommandResult, CommandValue, ExitCode};
+
+/// Entry point for the `sandbox` subcommand.
+pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
+    // Setup sandbox.
+    lock_process(matches)?;
+
+    // Start subprocess.
+    let cmd = matches.get_one::<String>("cmd").unwrap();
+    let args: Vec<&String> = matches.get_many("args").unwrap_or_default().collect();
+    let status = Command::new(cmd).args(&args).status()?;
+
+    if let Some(code) = status.code() {
+        Ok(CommandValue::Code(ExitCode::Custom(code)))
+    } else if let Some(signal) = status.signal() {
+        Err(anyhow!("Sandbox process failed with signal {signal}"))
+    } else {
+        unreachable!("Sandbox process terminated without exit code or signal");
+    }
+}
+
+/// Lock down the current process.
+#[cfg(unix)]
+fn lock_process(matches: &ArgMatches) -> Result<()> {
+    let mut birdcage =
+        if matches.get_flag("strict") { Birdcage::new()? } else { permissions::default_sandbox()? };
+
+    // Apply filesystem exceptions.
+    for path in matches.get_many::<String>("allow-read").unwrap_or_default() {
+        permissions::add_exception(&mut birdcage, Exception::Read(path.into()))?;
+    }
+    for path in matches.get_many::<String>("allow-write").unwrap_or_default() {
+        permissions::add_exception(&mut birdcage, Exception::Write(path.into()))?;
+    }
+    for path in matches.get_many::<String>("allow-run").unwrap_or_default() {
+        let absolute_path = permissions::resolve_bin_path(path);
+        permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead(absolute_path))?;
+    }
+
+    // Apply network exceptions.
+    if matches.get_flag("allow-net") {
+        birdcage.add_exception(Exception::Networking)?;
+    }
+
+    // Apply environment variable exceptions.
+    if matches.get_flag("allow-all-env") {
+        birdcage.add_exception(Exception::FullEnvironment)?;
+    }
+    for var in matches.get_many::<String>("allow-env").unwrap_or_default() {
+        birdcage.add_exception(Exception::Environment(var.to_owned()))?;
+    }
+
+    // Lock down the process.
+    birdcage.lock()?;
+
+    Ok(())
+}

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -53,11 +53,12 @@ fn lock_process(matches: &ArgMatches) -> Result<()> {
     }
 
     // Apply environment variable exceptions.
-    if matches.get_flag("allow-all-env") {
-        birdcage.add_exception(Exception::FullEnvironment)?;
-    }
     for var in matches.get_many::<String>("allow-env").unwrap_or_default() {
-        birdcage.add_exception(Exception::Environment(var.to_owned()))?;
+        if var == "*" {
+            birdcage.add_exception(Exception::FullEnvironment)?;
+        } else {
+            birdcage.add_exception(Exception::Environment(var.to_owned()))?;
+        }
     }
 
     // Lock down the process.

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -4,13 +4,12 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-pub use assert_cmd::assert::Assert;
-pub use assert_cmd::Command;
+use assert_cmd::assert::Assert;
+use assert_cmd::Command;
 use phylum_cli::api::{PhylumApi, PhylumApiError, ResponseError};
 use phylum_cli::commands::extensions::permissions::Permissions;
 use phylum_cli::config::{AuthInfo, Config, ConnectionInfo};
 use phylum_types::types::auth::RefreshToken;
-pub use predicates::prelude::*;
 use reqwest::StatusCode;
 use tempfile::TempDir;
 

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use predicates::prelude::*;
 use lazy_static::lazy_static;
 use phylum_cli::commands::extensions::extension::Extension;
 #[cfg(unix)]

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -5,11 +5,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use predicates::prelude::*;
 use lazy_static::lazy_static;
 use phylum_cli::commands::extensions::extension::Extension;
 #[cfg(unix)]
 use phylum_cli::commands::extensions::permissions::{Permission, Permissions};
+use predicates::prelude::*;
 #[cfg(unix)]
 use tempfile::NamedTempFile;
 

--- a/cli/tests/extensions/module_loader.rs
+++ b/cli/tests/extensions/module_loader.rs
@@ -11,6 +11,9 @@
 //
 // These tests are based on the fixtures under
 // `fixtures/module-import-extension`.
+
+use predicates::prelude::*;
+
 use crate::common::*;
 use crate::extensions::fixtures_path;
 

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -1,7 +1,7 @@
 use phylum_cli::commands::extensions::permissions::{Permission, Permissions};
 
-use crate::common::*;
-use crate::extensions::fixtures_path;
+use predicates::prelude::*;
+use crate::extensions::{fixtures_path, TestCli};
 
 #[test]
 fn permission_dialog_is_shown_without_yes_flag() {

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -1,6 +1,6 @@
 use phylum_cli::commands::extensions::permissions::{Permission, Permissions};
-
 use predicates::prelude::*;
+
 use crate::extensions::{fixtures_path, TestCli};
 
 #[test]

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -5,3 +5,5 @@ mod end_to_end;
 
 mod config;
 mod extensions;
+#[cfg(unix)]
+mod sandbox;

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -11,7 +11,7 @@ fn default_deny_fs() {
 
     // Test write access.
     test_cli
-        .run(&["sandbox", "sh", "-c", &format!("echo x > {test_file_path}")])
+        .run(&["sandbox", "--allow-read", "./", "sh", "-c", &format!("echo x > {test_file_path}")])
         .failure()
         .stderr(predicate::str::contains("Permission denied"));
 
@@ -32,6 +32,8 @@ fn allow_fs() {
     test_cli
         .run(&[
             "sandbox",
+            "--allow-read",
+            "./",
             "--allow-write",
             &test_file_path,
             "sh",
@@ -50,7 +52,7 @@ fn default_deny_env() {
 
     test_cli
         .cmd()
-        .args(&["sandbox", "sh", "-c", "echo $TEST"])
+        .args(&["sandbox", "--allow-read", "./", "sh", "-c", "echo $TEST"])
         .env("TEST", "VALUE")
         .assert()
         .success()
@@ -64,7 +66,7 @@ fn allow_env() {
 
     test_cli
         .cmd()
-        .args(&["sandbox", "--allow-env", "TEST", "sh", "-c", "echo $TEST"])
+        .args(&["sandbox", "--allow-read", "./", "--allow-env", "TEST", "sh", "-c", "echo $TEST"])
         .env("TEST", "VALUE")
         .assert()
         .success()

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -11,7 +11,7 @@ fn default_deny_fs() {
 
     // Test write access.
     test_cli
-        .run(&["sandbox", "--allow-read", "./", "sh", "-c", &format!("echo x > {test_file_path}")])
+        .run(&["sandbox", "bash", "-c", &format!("echo x > {test_file_path}")])
         .failure()
         .stderr(predicate::str::contains("Permission denied"));
 
@@ -32,11 +32,9 @@ fn allow_fs() {
     test_cli
         .run(&[
             "sandbox",
-            "--allow-read",
-            "./",
             "--allow-write",
             &test_file_path,
-            "sh",
+            "bash",
             "-c",
             &format!("echo x > {test_file_path}"),
         ])
@@ -52,12 +50,11 @@ fn default_deny_env() {
 
     test_cli
         .cmd()
-        .args(&["sandbox", "--allow-read", "./", "sh", "-c", "echo $TEST"])
+        .args(&["sandbox", "env"])
         .env("TEST", "VALUE")
         .assert()
         .success()
-        .stdout("\n")
-        .stderr("");
+        .stdout(predicate::str::contains("TEST=VALUE").not());
 }
 
 #[test]
@@ -66,12 +63,11 @@ fn allow_env() {
 
     test_cli
         .cmd()
-        .args(&["sandbox", "--allow-read", "./", "--allow-env", "TEST", "sh", "-c", "echo $TEST"])
+        .args(&["sandbox", "--allow-env", "TEST", "env"])
         .env("TEST", "VALUE")
         .assert()
         .success()
-        .stdout("VALUE\n")
-        .stderr("");
+        .stdout(predicate::str::contains("TEST=VALUE"));
 }
 
 #[test]

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -77,7 +77,7 @@ fn default_deny_net() {
     let test_cli = TestCli::builder().build();
 
     test_cli
-        .run(&["sandbox", "curl", "http://phylum.io"])
+        .run(&["sandbox", "--allow-env", "--", "curl", "http://phylum.io"])
         .failure()
         .stderr(predicate::str::contains("Could not resolve host: phylum.io"));
 }
@@ -86,5 +86,5 @@ fn default_deny_net() {
 fn allow_net() {
     let test_cli = TestCli::builder().build();
 
-    test_cli.run(&["sandbox", "--allow-net", "curl", "http://phylum.io"]).success();
+    test_cli.run(&["sandbox", "--allow-env", "--allow-net", "curl", "http://phylum.io"]).success();
 }

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -1,0 +1,92 @@
+use predicates::prelude::*;
+use tempfile::NamedTempFile;
+
+use crate::common::TestCli;
+
+#[test]
+fn default_deny_fs() {
+    let test_file = NamedTempFile::new().unwrap();
+    let test_file_path = test_file.path().to_str().unwrap();
+    let test_cli = TestCli::builder().build();
+
+    // Test write access.
+    test_cli
+        .run(&["sandbox", "sh", "-c", &format!("echo x > {test_file_path}")])
+        .failure()
+        .stderr(predicate::str::contains("Permission denied"));
+
+    // Test read access.
+    test_cli
+        .run(&["sandbox", "cat", test_file_path])
+        .failure()
+        .stderr(predicate::str::contains("Permission denied"));
+}
+
+#[test]
+fn allow_fs() {
+    let test_file = NamedTempFile::new().unwrap();
+    let test_file_path = test_file.path().to_str().unwrap();
+    let test_cli = TestCli::builder().build();
+
+    // Test write access.
+    test_cli
+        .run(&[
+            "sandbox",
+            "--allow-write",
+            &test_file_path,
+            "sh",
+            "-c",
+            &format!("echo x > {test_file_path}"),
+        ])
+        .success();
+
+    // Test read access.
+    test_cli.run(&["sandbox", "--allow-read", &test_file_path, "cat", &test_file_path]).success();
+}
+
+#[test]
+fn default_deny_env() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .cmd()
+        .args(&["sandbox", "sh", "-c", "echo $TEST"])
+        .env("TEST", "VALUE")
+        .assert()
+        .success()
+        .stdout("\n")
+        .stderr("");
+}
+
+#[test]
+fn allow_env() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .cmd()
+        .args(&["sandbox", "--allow-env", "TEST", "sh", "-c", "echo $TEST"])
+        .env("TEST", "VALUE")
+        .assert()
+        .success()
+        .stdout("VALUE\n")
+        .stderr("");
+}
+
+#[test]
+fn default_deny_net() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .run(&["sandbox", "curl", "http://phylum.io"])
+        .failure()
+        .stderr(predicate::str::contains("Could not resolve host: phylum.io"));
+}
+
+#[test]
+fn allow_net() {
+    let test_cli = TestCli::builder().build();
+
+    test_cli
+        .run(&["sandbox", "--allow-net", "curl", "http://phylum.io"])
+        .success();
+}

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -86,7 +86,5 @@ fn default_deny_net() {
 fn allow_net() {
     let test_cli = TestCli::builder().build();
 
-    test_cli
-        .run(&["sandbox", "--allow-net", "curl", "http://phylum.io"])
-        .success();
+    test_cli.run(&["sandbox", "--allow-net", "curl", "http://phylum.io"]).success();
 }

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -9,17 +9,22 @@ fn default_deny_fs() {
     let test_file_path = test_file.path().to_str().unwrap();
     let test_cli = TestCli::builder().build();
 
+    #[cfg(target_os = "linux")]
+    let expected_error = "Permission denied";
+    #[cfg(not(target_os = "linux"))]
+    let expected_error = "Operation not permitted";
+
     // Test write access.
     test_cli
         .run(&["sandbox", "bash", "-c", &format!("echo x > {test_file_path}")])
         .failure()
-        .stderr(predicate::str::contains("Permission denied"));
+        .stderr(predicate::str::contains(expected_error));
 
     // Test read access.
     test_cli
         .run(&["sandbox", "cat", test_file_path])
         .failure()
-        .stderr(predicate::str::contains("Permission denied"));
+        .stderr(predicate::str::contains(expected_error));
 }
 
 #[test]


### PR DESCRIPTION
This fixes any potential issues with setting up our sandboxing
environment in `pre_exec` or after a `fork` by adding a new `phylum
sandbox` subcommand. Using this subcommand we can simply re-execute
`phylum` with the appropriate arguments to setup a sandboxing
environment.

Closes #763.