### PR TITLE
Fix environment variable permission prompting

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -277,6 +277,7 @@ fn ask_permissions(extension: &Extension) -> Result<()> {
     print_permissions_list("Write", "path", permissions.write.get());
     print_permissions_list("Run", "command", permissions.run.get());
     print_permissions_list("Access", "domain", permissions.net.get());
+    print_permissions_list("Set", "environment variable", permissions.env.get());
 
     if !Confirm::new().with_prompt("\nDo you accept?").default(false).interact()? {
         Err(anyhow!("permissions not granted, aborting"))


### PR DESCRIPTION
While the current HEAD does prompt for accepting the permissions when
only an environment variable exception is requested, it does not
actually print to the user which environment variable access it needs.

This patch fixes this issue by adding another prompt for the environment
variable permissions.