### PR TITLE
docs: clean up options

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -90,7 +90,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("JOB_ID")
                     .value_name("JOB_ID")
                     .help("The job id to query"),
-                Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
+                Arg::new("filter").short('f').long("filter").value_name("filter").help(FILTER_ABOUT),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)
                     .short('j')
@@ -205,7 +205,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('j')
                     .long("json")
                     .help("Produce output in json format (default: false)"),
-                Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
+                Arg::new("filter").short('f').long("filter").value_name("filter").help(FILTER_ABOUT),
             ]),
         )
         .subcommand(
@@ -255,8 +255,12 @@ pub fn add_subcommands(command: Command) -> Command {
                         "Force re-processing of packages (even if they already exist in the \
                          system)",
                     ),
-                    Arg::new("label").short('l').value_name("label"),
-                    Arg::new("filter").long("filter").value_name("filter").help(FILTER_ABOUT),
+                    Arg::new("label")
+                        .short('l')
+                        .long("label")
+                        .value_name("label")
+                        .help("Specify a label to use for analysis"),
+                    Arg::new("filter").short('f').long("filter").value_name("filter").help(FILTER_ABOUT),
                     Arg::new("json")
                         .action(ArgAction::SetTrue)
                         .short('j')
@@ -298,11 +302,10 @@ pub fn add_subcommands(command: Command) -> Command {
                         "Force re-processing of packages (even if they already exist in the \
                          system)",
                     ),
-                    Arg::new("low-priority")
-                        .action(ArgAction::SetTrue)
-                        .short('L')
-                        .long("low-priority"),
-                    Arg::new("label").short('l').long("label"),
+                    Arg::new("label")
+                        .short('l')
+                        .long("label")
+                        .help("Label to use for analysis"),
                     Arg::new("project")
                         .short('p')
                         .long("project")

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -14,7 +14,7 @@ phylum analyze [OPTIONS] <lockfile>
 `-F`, `--force`
 &emsp; Force re-processing of packages (even if they already exist in the system)
 
-`--filter <filter>`
+`-f`, `--filter <filter>`
 &emsp; Provide a filter used to limit the issues displayed
 
 `-g`, `--group <group_name>`
@@ -23,7 +23,7 @@ phylum analyze [OPTIONS] <lockfile>
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`-l <label>`
+`-l`, `--label <label>`
 &emsp; Specify a label for a given analysis submission
 
 `-p`, `--project <project_name>`
@@ -42,7 +42,7 @@ $ phylum analyze package-lock.json
 $ phylum analyze --json --verbose effective-pom.xml
 
 # Analyze a PyPI lock file and apply a label
-$ phylum analyze -l test_branch requirements.txt
+$ phylum analyze --label test_branch requirements.txt
 
 # Analyze a Poetry lock file and return the results to the 'sample' project
 $ phylum analyze -p sample poetry.lock

--- a/docs/command_line_tool/phylum_history.md
+++ b/docs/command_line_tool/phylum_history.md
@@ -5,14 +5,16 @@ hidden: false
 ---
 
 Return information about historical scans
+
 ```sh
 phylum history [OPTIONS] [JOB_ID]
 ```
+
 `<JOB_ID>`
 &emsp; The job id to query
 
 ### Options
-`--filter <filter>`
+`-f`, `--filter <filter>`
 &emsp; Provide a filter used to limit the issues displayed
 
 `-j`, `--json`
@@ -25,6 +27,7 @@ phylum history [OPTIONS] [JOB_ID]
 &emsp; Increase verbosity of API response
 
 ### Examples
+
 ```sh
 # List the last 30 analysis runs
 $ phylum history

--- a/docs/command_line_tool/phylum_package.md
+++ b/docs/command_line_tool/phylum_package.md
@@ -5,13 +5,14 @@ hidden: false
 ---
 
 Retrieve the details of a specific package
+
 ```sh
 phylum package [OPTIONS] <name> <version>
 ```
 
 ### Options
 
-`--filter`
+`-f`, `--filter`
 &emsp; Provide a filter used to limit the issues displayed
 
 `-j`, `--json`


### PR DESCRIPTION
There are a few instances where a long option is provided without a short option and vice versa. This patch attempts to clean those up to be more consistent throughout the CLI interface.

* Add the short form `-f` to go with the long form option `--filter`
* Add the long form `--label` to go with the short form `-l`
* Remove the unused `--low-priority` option from the `batch` subcommand
* Update the docs to reflect the changes