### PR TITLE
`prettier` format checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       - run: npm i -g prettier
       - name: Extensions Style Check
         if: github.event_name != 'schedule'
-        run: prettier --check extensions cli/src/extension_api.ts
+        run: prettier --check .
 
   shellcheck:
     # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,19 @@ jobs:
           args: --all-features
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN_STAGING }}
+
+  prettier:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actionsx/setup-node@v2
+        with:
+          node-version: 18
+      - run: npm i -g prettier
+      - name: Extensions Style Check
+        if: github.event_name != 'schedule'
+        run: prettier --check extensions
+
   shellcheck:
     # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
     #       https://github.com/phylum-dev/cli/issues/467

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actionsx/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 18
       - run: npm i -g prettier

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       - run: npm i -g prettier
       - name: Extensions Style Check
         if: github.event_name != 'schedule'
-        run: prettier --check extensions
+        run: prettier --check extensions cli/src/extension_api.ts
 
   shellcheck:
     # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+*
+!(cli/src|extensions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,15 @@ cargo clippy --all-features
 #### Extensions
 
 First-party extensions are written in TypeScript. Extensions code must be
-formatted with [prettier](https://prettier.io/). Install it via `npm`:
+formatted with [Prettier](https://prettier.io/). 
+
+Prettier should be installed globally with a method of your choice. For example, via `npm`:
 
 ```sh
 npm install -g prettier
 ```
 
-`prettier` should be run from the top-level directory of the repository:
+Prettier should be run from the top-level directory of the repository:
 
 ```sh
 prettier --write .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ documentation available in the `docs/` directory.
 
 ### Style
 
+#### Rust
+
 General code format is maintained using `rustfmt`:
 
 ```sh
@@ -90,6 +92,23 @@ This should also pass for all pre-release features:
 ```sh
 cargo clippy --all-features
 ```
+
+#### Extensions
+
+First-party extensions are written in TypeScript. Extensions code must be
+formatted with [prettier](https://prettier.io/). Install it via `npm`:
+
+```sh
+npm install -g prettier
+```
+
+`prettier` should be run from the top-level directory of the repository:
+
+```sh
+prettier --write .
+```
+
+#### Shell scripts
 
 Additionally, there are a couple of script files that are part of the Phylum CLI
 project. These are linted by using [shellcheck]. The following command performs

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -1,380 +1,395 @@
 export class PhylumApi {
-    /// Analyze dependencies in a lockfile.
-    ///
-    /// This expects a `.phylum_project` file to be present if the `project`
-    /// parameter is undefined.
-    ///
-    /// # Parameters
-    ///
-    /// Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
-    ///
-    /// Packages are expected in the following format:
-    ///
-    /// ```
-    /// [
-    ///   { name: "accepts", version: "1.3.8" },
-    ///   { name: "ms", version: "2.0.0" },
-    ///   { name: "negotiator", version: "0.6.3" },
-    ///   { name: "ms", version: "2.1.3" }
-    /// ]
-    /// ```
-    ///
-    /// # Returns
-    ///
-    /// Analyze Job ID, which can later be queried with `getJobStatus`.
-    static async analyze(
-        package_type: string,
-        packages: [object],
-        project?: string,
-        group?: string,
-    ): string {
-        return await Deno.core.opAsync('analyze', package_type, packages, project, group);
-    }
+  /// Analyze dependencies in a lockfile.
+  ///
+  /// This expects a `.phylum_project` file to be present if the `project`
+  /// parameter is undefined.
+  ///
+  /// # Parameters
+  ///
+  /// Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
+  ///
+  /// Packages are expected in the following format:
+  ///
+  /// ```
+  /// [
+  ///   { name: "accepts", version: "1.3.8" },
+  ///   { name: "ms", version: "2.0.0" },
+  ///   { name: "negotiator", version: "0.6.3" },
+  ///   { name: "ms", version: "2.1.3" }
+  /// ]
+  /// ```
+  ///
+  /// # Returns
+  ///
+  /// Analyze Job ID, which can later be queried with `getJobStatus`.
+  static async analyze(
+    package_type: string,
+    packages: [object],
+    project?: string,
+    group?: string
+  ): string {
+    return await Deno.core.opAsync(
+      "analyze",
+      package_type,
+      packages,
+      project,
+      group
+    );
+  }
 
-    /// Get info about the logged in user.
-    ///
-    /// # Returns
-    ///
-    /// Object containing user information:
-    ///
-    /// ```
-    /// {
-    ///   email: "user@phylum.io",
-    ///   sub: "af8b5c32-9966-496a-e5ae-9ca9ceb43294",
-    ///   name: "John Doe",
-    ///   given_name: "John",
-    ///   family_name: "Doe",
-    ///   preferred_username: "JD",
-    ///   email_verified: true,
-    /// }
-    /// ```
-    static async getUserInfo(): object {
-        return await Deno.core.opAsync('get_user_info');
-    }
+  /// Get info about the logged in user.
+  ///
+  /// # Returns
+  ///
+  /// Object containing user information:
+  ///
+  /// ```
+  /// {
+  ///   email: "user@phylum.io",
+  ///   sub: "af8b5c32-9966-496a-e5ae-9ca9ceb43294",
+  ///   name: "John Doe",
+  ///   given_name: "John",
+  ///   family_name: "Doe",
+  ///   preferred_username: "JD",
+  ///   email_verified: true,
+  /// }
+  /// ```
+  static async getUserInfo(): object {
+    return await Deno.core.opAsync("get_user_info");
+  }
 
-    /// Get the current short-lived API access token.
-    static async getAccessToken(): string {
-        return await Deno.core.opAsync('get_access_token');
-    }
+  /// Get the current short-lived API access token.
+  static async getAccessToken(): string {
+    return await Deno.core.opAsync("get_access_token");
+  }
 
-    /// Get the long-lived user refresh token.
-    static async getRefreshToken(): string {
-        return await Deno.core.opAsync('get_refresh_token');
-    }
+  /// Get the long-lived user refresh token.
+  static async getRefreshToken(): string {
+    return await Deno.core.opAsync("get_refresh_token");
+  }
 
-    /// Get job results.
-    ///
-    /// # Returns
-    ///
-    /// Job analysis results:
-    ///
-    /// ```
-    /// {
-    ///   job_id: "de2d74b1-3925-4de9-9b8f-0c7b27f9b3c8",
-    ///   ecosystem: "npm",
-    ///   user_id: "0f2a8e3d-9f75-49fa-89c7-718c4f87fc93",
-    ///   user_email: "",
-    ///   created_at: 1657106760573,
-    ///   status: "complete",
-    ///   score: 1,
-    ///   pass: true,
-    ///   msg: "Project met threshold requirements",
-    ///   action: "none",
-    ///   num_incomplete: 0,
-    ///   last_updated: 1657106760573,
-    ///   project: "02a8dcdd-69bd-469f-8c39-be76c786fd2b",
-    ///   project_name: "api-docs",
-    ///   label: "uncategorized",
-    ///   thresholds: { author: 0, engineering: 0, license: 0, malicious: 0, total: 0, vulnerability: 0 },
-    ///   packages: [
-    ///     {
-    ///       name: "typescript",
-    ///       version: "4.7.4",
-    ///       status: "complete",
-    ///       last_updated: 1657106208802,
-    ///       license: "Apache-2.0",
-    ///       package_score: 1,
-    ///       num_dependencies: 0,
-    ///       num_vulnerabilities: 0,
-    ///       type: "npm",
-    ///       riskVectors: {
-    ///         author: 1,
-    ///         vulnerabilities: 1,
-    ///         total: 1,
-    ///         engineering: 1,
-    ///         malicious_code: 1,
-    ///         license: 1
-    ///       },
-    ///       dependencies: {},
-    ///       issues: []
-    ///     }
-    ///   ]
-    /// }
-    /// ```
-    static async getJobStatus(jobId: string): object {
-        return await Deno.core.opAsync('get_job_status', jobId);
-    }
+  /// Get job results.
+  ///
+  /// # Returns
+  ///
+  /// Job analysis results:
+  ///
+  /// ```
+  /// {
+  ///   job_id: "de2d74b1-3925-4de9-9b8f-0c7b27f9b3c8",
+  ///   ecosystem: "npm",
+  ///   user_id: "0f2a8e3d-9f75-49fa-89c7-718c4f87fc93",
+  ///   user_email: "",
+  ///   created_at: 1657106760573,
+  ///   status: "complete",
+  ///   score: 1,
+  ///   pass: true,
+  ///   msg: "Project met threshold requirements",
+  ///   action: "none",
+  ///   num_incomplete: 0,
+  ///   last_updated: 1657106760573,
+  ///   project: "02a8dcdd-69bd-469f-8c39-be76c786fd2b",
+  ///   project_name: "api-docs",
+  ///   label: "uncategorized",
+  ///   thresholds: { author: 0, engineering: 0, license: 0, malicious: 0, total: 0, vulnerability: 0 },
+  ///   packages: [
+  ///     {
+  ///       name: "typescript",
+  ///       version: "4.7.4",
+  ///       status: "complete",
+  ///       last_updated: 1657106208802,
+  ///       license: "Apache-2.0",
+  ///       package_score: 1,
+  ///       num_dependencies: 0,
+  ///       num_vulnerabilities: 0,
+  ///       type: "npm",
+  ///       riskVectors: {
+  ///         author: 1,
+  ///         vulnerabilities: 1,
+  ///         total: 1,
+  ///         engineering: 1,
+  ///         malicious_code: 1,
+  ///         license: 1
+  ///       },
+  ///       dependencies: {},
+  ///       issues: []
+  ///     }
+  ///   ]
+  /// }
+  /// ```
+  static async getJobStatus(jobId: string): object {
+    return await Deno.core.opAsync("get_job_status", jobId);
+  }
 
-    /// Get currently linked project.
-    ///
-    /// # Returns
-    ///
-    /// Project information:
-    ///
-    /// ```
-    /// {
-    ///   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
-    ///   name: "phylum",
-    ///   created_at: "2022-08-18T18:41:46.468054855+02:00",
-    ///   group_name: null
-    /// }
-    /// ```
-    ///
-    /// If no project is linked, this will return `null`.
-    static getCurrentProject(): object {
-        return Deno.core.opSync('get_current_project');
-    }
+  /// Get currently linked project.
+  ///
+  /// # Returns
+  ///
+  /// Project information:
+  ///
+  /// ```
+  /// {
+  ///   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
+  ///   name: "phylum",
+  ///   created_at: "2022-08-18T18:41:46.468054855+02:00",
+  ///   group_name: null
+  /// }
+  /// ```
+  ///
+  /// If no project is linked, this will return `null`.
+  static getCurrentProject(): object {
+    return Deno.core.opSync("get_current_project");
+  }
 
-    /// List the user's groups.
-    ///
-    /// # Returns
-    ///
-    /// Accessible groups:
-    ///
-    /// ```
-    /// {
-    ///   groups: [
-    ///     {
-    ///       created_at: "2022-05-02T14:25:24.184866508Z",
-    ///       last_modified: "2022-05-02T14:25:24.599950299Z",
-    ///       owner_email: "null@phylum.io",
-    ///       group_name: "phlock",
-    ///       is_admin: false,
-    ///       is_owner: true
-    ///     }
-    ///   ]
-    /// }
-    /// ```
-    static async getGroups(): object {
-        return Deno.core.opAsync('get_groups');
-    }
+  /// List the user's groups.
+  ///
+  /// # Returns
+  ///
+  /// Accessible groups:
+  ///
+  /// ```
+  /// {
+  ///   groups: [
+  ///     {
+  ///       created_at: "2022-05-02T14:25:24.184866508Z",
+  ///       last_modified: "2022-05-02T14:25:24.599950299Z",
+  ///       owner_email: "null@phylum.io",
+  ///       group_name: "phlock",
+  ///       is_admin: false,
+  ///       is_owner: true
+  ///     }
+  ///   ]
+  /// }
+  /// ```
+  static async getGroups(): object {
+    return Deno.core.opAsync("get_groups");
+  }
 
-    /// List the user's projects.
-    ///
-    /// # Returns
-    ///
-    /// Accessible projects:
-    ///
-    /// ```
-    /// [
-    ///   {
-    ///     name: "phylum",
-    ///     id: "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-    ///     updated_at: "2022-08-16T22:22:14.092474Z",
-    ///     created_at: "2022-06-24T22:45:47.054472Z",
-    ///     ecosystem: "npm",
-    ///     group_name: null
-    ///   }
-    /// ]
-    /// ```
-    static async getProjects(group?: string): object {
-        return Deno.core.opAsync('get_projects', group);
-    }
+  /// List the user's projects.
+  ///
+  /// # Returns
+  ///
+  /// Accessible projects:
+  ///
+  /// ```
+  /// [
+  ///   {
+  ///     name: "phylum",
+  ///     id: "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+  ///     updated_at: "2022-08-16T22:22:14.092474Z",
+  ///     created_at: "2022-06-24T22:45:47.054472Z",
+  ///     ecosystem: "npm",
+  ///     group_name: null
+  ///   }
+  /// ]
+  /// ```
+  static async getProjects(group?: string): object {
+    return Deno.core.opAsync("get_projects", group);
+  }
 
-    /// Create a project.
-    ///
-    /// # Returns
-    /// 
-    /// An object containing the id of the project, and an indication
-    /// stating whether the project was just created or already existing.
-    ///
-    /// ```
-    /// {
-    ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-    ///   "status": "created"
-    /// }
-    /// ```
-    ///
-    /// ```
-    /// {
-    ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-    ///   "status": "exists"
-    /// }
-    /// ```
-    static async createProject(name: string, group?: string): string {
-        return Deno.core.opAsync('create_project', name, group);
-    }
+  /// Create a project.
+  ///
+  /// # Returns
+  ///
+  /// An object containing the id of the project, and an indication
+  /// stating whether the project was just created or already existing.
+  ///
+  /// ```
+  /// {
+  ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+  ///   "status": "created"
+  /// }
+  /// ```
+  ///
+  /// ```
+  /// {
+  ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+  ///   "status": "exists"
+  /// }
+  /// ```
+  static async createProject(name: string, group?: string): string {
+    return Deno.core.opAsync("create_project", name, group);
+  }
 
-    /// Delete a project.
-    ///
-    /// # Returns
-    /// 
-    /// Nothing if successful; throws an error if unsuccessful.
-    static async deleteProject(name: string, group?: string): string {
-        return Deno.core.opAsync('delete_project', name, group);
-    }
+  /// Delete a project.
+  ///
+  /// # Returns
+  ///
+  /// Nothing if successful; throws an error if unsuccessful.
+  static async deleteProject(name: string, group?: string): string {
+    return Deno.core.opAsync("delete_project", name, group);
+  }
 
-    /// Get analysis results for a single package.
-    ///
-    /// This will not start a new package analysis, but only retrieve previous
-    /// analysis results.
-    ///
-    /// # Returns
-    ///
-    /// Package analysis results:
-    ///
-    /// ```
-    /// {
-    ///   id: "npm:typescript:4.7.4",
-    ///   name: "typescript",
-    ///   version: "4.7.4",
-    ///   registry: "npm",
-    ///   publishedDate: "2022-06-17T18:21:36+00:00",
-    ///   latestVersion: null,
-    ///   versions: [
-    ///     { version: "4.5.4", total_risk_score: 1 },
-    ///     { version: "3.9.7", total_risk_score: 1 },
-    ///     { version: "4.2.4", total_risk_score: 1 }
-    ///   ],
-    ///   description: "TypeScript is a language for application scale JavaScript development",
-    ///   license: "Apache-2.0",
-    ///   depSpecs: [],
-    ///   dependencies: [],
-    ///   downloadCount: 134637844,
-    ///   riskScores: {
-    ///     total: 1,
-    ///     vulnerability: 1,
-    ///     malicious_code: 1,
-    ///     author: 1,
-    ///     engineering: 1,
-    ///     license: 1
-    ///   },
-    ///   totalRiskScoreDynamics: null,
-    ///   issuesDetails: [],
-    ///   issues: [],
-    ///   authors: [],
-    ///   developerResponsiveness: {
-    ///     open_issue_count: 0,
-    ///     total_issue_count: 0,
-    ///     open_issue_avg_duration: null,
-    ///     open_pull_request_count: 0,
-    ///     total_pull_request_count: 0,
-    ///     open_pull_request_avg_duration: null
-    ///   },
-    ///   issueImpacts: { low: 0, medium: 0, high: 0, critical: 0 },
-    ///   complete: true
-    /// }
-    /// ```
-    static async getPackageDetails(name: string, version: string, packageType: string): object {
-        return await Deno.core.opAsync('get_package_details', name, version, packageType);
-    }
+  /// Get analysis results for a single package.
+  ///
+  /// This will not start a new package analysis, but only retrieve previous
+  /// analysis results.
+  ///
+  /// # Returns
+  ///
+  /// Package analysis results:
+  ///
+  /// ```
+  /// {
+  ///   id: "npm:typescript:4.7.4",
+  ///   name: "typescript",
+  ///   version: "4.7.4",
+  ///   registry: "npm",
+  ///   publishedDate: "2022-06-17T18:21:36+00:00",
+  ///   latestVersion: null,
+  ///   versions: [
+  ///     { version: "4.5.4", total_risk_score: 1 },
+  ///     { version: "3.9.7", total_risk_score: 1 },
+  ///     { version: "4.2.4", total_risk_score: 1 }
+  ///   ],
+  ///   description: "TypeScript is a language for application scale JavaScript development",
+  ///   license: "Apache-2.0",
+  ///   depSpecs: [],
+  ///   dependencies: [],
+  ///   downloadCount: 134637844,
+  ///   riskScores: {
+  ///     total: 1,
+  ///     vulnerability: 1,
+  ///     malicious_code: 1,
+  ///     author: 1,
+  ///     engineering: 1,
+  ///     license: 1
+  ///   },
+  ///   totalRiskScoreDynamics: null,
+  ///   issuesDetails: [],
+  ///   issues: [],
+  ///   authors: [],
+  ///   developerResponsiveness: {
+  ///     open_issue_count: 0,
+  ///     total_issue_count: 0,
+  ///     open_issue_avg_duration: null,
+  ///     open_pull_request_count: 0,
+  ///     total_pull_request_count: 0,
+  ///     open_pull_request_avg_duration: null
+  ///   },
+  ///   issueImpacts: { low: 0, medium: 0, high: 0, critical: 0 },
+  ///   complete: true
+  /// }
+  /// ```
+  static async getPackageDetails(
+    name: string,
+    version: string,
+    packageType: string
+  ): object {
+    return await Deno.core.opAsync(
+      "get_package_details",
+      name,
+      version,
+      packageType
+    );
+  }
 
-    /// Get dependencies inside a lockfile.
-    ///
-    /// # Returns
-    ///
-    /// List of dependencies:
-    ///
-    /// ```
-    /// {
-    ///   package_type: "npm",
-    ///   packages: [
-    ///     { name: "accepts", version: "1.3.8" },
-    ///     { name: "ms", version: "2.0.0" },
-    ///     { name: "negotiator", version: "0.6.3" },
-    ///     { name: "ms", version: "2.1.3" }
-    ///   ]
-    /// }
-    /// ```
-    static async parseLockfile(lockfile: string, lockfileType?: string): object {
-        return await Deno.core.opAsync('parse_lockfile', lockfile, lockfileType);
-    }
+  /// Get dependencies inside a lockfile.
+  ///
+  /// # Returns
+  ///
+  /// List of dependencies:
+  ///
+  /// ```
+  /// {
+  ///   package_type: "npm",
+  ///   packages: [
+  ///     { name: "accepts", version: "1.3.8" },
+  ///     { name: "ms", version: "2.0.0" },
+  ///     { name: "negotiator", version: "0.6.3" },
+  ///     { name: "ms", version: "2.1.3" }
+  ///   ]
+  /// }
+  /// ```
+  static async parseLockfile(lockfile: string, lockfileType?: string): object {
+    return await Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
+  }
 
-    /// Run a command inside a more restrictive sandbox.
-    ///
-    /// While all extensions are already sandboxed, it can be useful to further
-    /// restrict this execution environment when dealing with external commands
-    /// that could potentially misbehave. This API allows restricting
-    /// filesystem and network access for those processes.
-    ///
-    /// # Parameters
-    ///
-    /// The `process` parameter contains the command which shall be executed
-    /// and its restrictions:
-    ///
-    /// ```
-    /// {
-    ///   cmd: "ls",
-    ///   args: ["-lah"],
-    ///   stdin: "null",
-    ///   stdout: "piped",
-    ///   stderr: "inherit",
-    ///   exceptions: {
-    ///     read: ["~/"],
-    ///     write: false,
-    ///     run: ["ls"],
-    ///     net: false,
-    ///     strict: false,
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// The `read`/`write`/`run` permissions accept either an array of paths,
-    /// or a boolean. Paths must either be absolute or start with `~/`.
-    ///
-    /// For `run` the executables will be resolved from `$PATH` when they are
-    /// neither absolute nor start with `~/`.
-    ///
-    /// The `net` permission accepts only boolean values.
-    ///
-    /// Some exceptions are added by default, to simplify the extension creation
-    /// process. If you're looking for more granular control, you can set strict
-    /// to `true` and no exceptions will be added without explicitly specifying
-    /// them.
-    ///
-    /// # Returns
-    ///
-    /// Process status and output:
-    ///
-    /// ```
-    /// {
-    ///   stdout: "Hello, World!",
-    ///   stderr: "",
-    ///   success: true,
-    ///   code: 0,
-    /// }
-    /// ```
-    ///
-    /// If the process got killed by a signal, it will contain a `signal` field
-    /// instead of `code`:
-    ///
-    /// ```
-    /// {
-    ///   stdout: "",
-    ///   stderr: "Getting killed by signal...",
-    ///   success: false,
-    ///   signal: 31,
-    /// }
-    /// ```
-    static runSandboxed(process: object): object {
-        return Deno.core.opSync('run_sandboxed', process);
-    }
+  /// Run a command inside a more restrictive sandbox.
+  ///
+  /// While all extensions are already sandboxed, it can be useful to further
+  /// restrict this execution environment when dealing with external commands
+  /// that could potentially misbehave. This API allows restricting
+  /// filesystem and network access for those processes.
+  ///
+  /// # Parameters
+  ///
+  /// The `process` parameter contains the command which shall be executed
+  /// and its restrictions:
+  ///
+  /// ```
+  /// {
+  ///   cmd: "ls",
+  ///   args: ["-lah"],
+  ///   stdin: "null",
+  ///   stdout: "piped",
+  ///   stderr: "inherit",
+  ///   exceptions: {
+  ///     read: ["~/"],
+  ///     write: false,
+  ///     run: ["ls"],
+  ///     net: false,
+  ///     strict: false,
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The `read`/`write`/`run` permissions accept either an array of paths,
+  /// or a boolean. Paths must either be absolute or start with `~/`.
+  ///
+  /// For `run` the executables will be resolved from `$PATH` when they are
+  /// neither absolute nor start with `~/`.
+  ///
+  /// The `net` permission accepts only boolean values.
+  ///
+  /// Some exceptions are added by default, to simplify the extension creation
+  /// process. If you're looking for more granular control, you can set strict
+  /// to `true` and no exceptions will be added without explicitly specifying
+  /// them.
+  ///
+  /// # Returns
+  ///
+  /// Process status and output:
+  ///
+  /// ```
+  /// {
+  ///   stdout: "Hello, World!",
+  ///   stderr: "",
+  ///   success: true,
+  ///   code: 0,
+  /// }
+  /// ```
+  ///
+  /// If the process got killed by a signal, it will contain a `signal` field
+  /// instead of `code`:
+  ///
+  /// ```
+  /// {
+  ///   stdout: "",
+  ///   stderr: "Getting killed by signal...",
+  ///   success: false,
+  ///   signal: 31,
+  /// }
+  /// ```
+  static runSandboxed(process: object): object {
+    return Deno.core.opSync("run_sandboxed", process);
+  }
 
-    /// Get the extension's manifest permissions.
-    /// 
-    /// # Returns
-    /// 
-    /// The permissions object:
-    /// ```
-    /// {
-    ///   read: ["~/.npm"],
-    ///   write: ["/tmp"],
-    ///   run: ["ls", "echo", "npm"],
-    ///   env: ["HOME", "PATH"],
-    ///   net: false
-    /// }
-    /// ```
-    static permissions(): object {
-        return Deno.core.opSync('op_permissions');
-    }
+  /// Get the extension's manifest permissions.
+  ///
+  /// # Returns
+  ///
+  /// The permissions object:
+  /// ```
+  /// {
+  ///   read: ["~/.npm"],
+  ///   write: ["/tmp"],
+  ///   run: ["ls", "echo", "npm"],
+  ///   env: ["HOME", "PATH"],
+  ///   net: false
+  /// }
+  /// ```
+  static permissions(): object {
+    return Deno.core.opSync("op_permissions");
+  }
 }

--- a/extensions/duplicates/main.ts
+++ b/extensions/duplicates/main.ts
@@ -6,25 +6,27 @@ import { PhylumApi } from "phylum";
 
 // Ensure lockfile argument is present.
 if (Deno.args.length != 1) {
-    console.error("Usage: phylum duplicates <LOCKFILE>");
-    Deno.exit(1);
+  console.error("Usage: phylum duplicates <LOCKFILE>");
+  Deno.exit(1);
 }
 
 // Parse lockfile using Phylum's API.
 const lockfile = await PhylumApi.parseLockfile(Deno.args[0]);
 
 // Group all versions for the same dependency together.
-const groupedDeps = groupBy(lockfile.packages, dep => dep.name);
+const groupedDeps = groupBy(lockfile.packages, (dep) => dep.name);
 
 // Reduce each dependency to a list of its versions.
-const reducedDeps = mapValues(groupedDeps, deps => deps.map(dep => dep.version));
+const reducedDeps = mapValues(groupedDeps, (deps) =>
+  deps.map((dep) => dep.version)
+);
 
 for (const [dep, versions] of Object.entries(reducedDeps)) {
-    // Deduplicate identical versions.
-    const distinctVersions = distinct(versions);
+  // Deduplicate identical versions.
+  const distinctVersions = distinct(versions);
 
-    // Print all dependencies with more than one version.
-    if (distinctVersions.length > 1) {
-        console.log(`${dep}:`, distinctVersions);
-    }
+  // Print all dependencies with more than one version.
+  if (distinctVersions.length > 1) {
+    console.log(`${dep}:`, distinctVersions);
+  }
 }

--- a/extensions/find-permissions/main.ts
+++ b/extensions/find-permissions/main.ts
@@ -1,229 +1,251 @@
-import { red, green, blue, yellow } from 'https://deno.land/std@0.150.0/fmt/colors.ts';
-import { PhylumApi } from 'phylum';
+import {
+  red,
+  green,
+  blue,
+  yellow,
+} from "https://deno.land/std@0.150.0/fmt/colors.ts";
+import { PhylumApi } from "phylum";
 
 // Print help.
-if (Deno.args.includes('-h')
-    || Deno.args.includes('help')
-    || Deno.args.includes('--help'))
-{
-    console.log('find-permissions');
-    console.log('CLI extension to help find required sandboxing permissions.');
-    console.log();
-    console.log('USAGE:');
-    console.log('    phylum find-permissions [OPTIONS] --bin <PATH>');
-    console.log();
-    console.log('OPTIONS:');
-    console.log('    --read               Check if tested paths need to be readable or executable');
-    console.log('    --write              Check if tested paths need to be writable');
-    console.log('    --pre-bin <PATH>     Executable to be run before test execution');
-    console.log('    --bin <PATH>         Executable to be run to test path necessity');
-    console.log('    --post-bin <PATH>    Executable to be run after test execution');
-    console.log('    --skip-files         Only check directories, speeding up the process');
-    console.log('    --strict             Use strict sandboxing mode');
-    Deno.exit(0);
+if (
+  Deno.args.includes("-h") ||
+  Deno.args.includes("help") ||
+  Deno.args.includes("--help")
+) {
+  console.log("find-permissions");
+  console.log("CLI extension to help find required sandboxing permissions.");
+  console.log();
+  console.log("USAGE:");
+  console.log("    phylum find-permissions [OPTIONS] --bin <PATH>");
+  console.log();
+  console.log("OPTIONS:");
+  console.log(
+    "    --read               Check if tested paths need to be readable or executable"
+  );
+  console.log(
+    "    --write              Check if tested paths need to be writable"
+  );
+  console.log(
+    "    --pre-bin <PATH>     Executable to be run before test execution"
+  );
+  console.log(
+    "    --bin <PATH>         Executable to be run to test path necessity"
+  );
+  console.log(
+    "    --post-bin <PATH>    Executable to be run after test execution"
+  );
+  console.log(
+    "    --skip-files         Only check directories, speeding up the process"
+  );
+  console.log("    --strict             Use strict sandboxing mode");
+  Deno.exit(0);
 }
 
 // Permissions types to be checked.
-let check_write = Deno.args.includes('--write');
-let check_read = Deno.args.includes('--read');
+let check_write = Deno.args.includes("--write");
+let check_read = Deno.args.includes("--read");
 
 // Ensure at least one type of permission is specified.
 if (!check_write && !check_read) {
-    console.error('Expected at least one of `--read`, `--write`');
-    Deno.exit(111);
+  console.error("Expected at least one of `--read`, `--write`");
+  Deno.exit(111);
 }
 
 // Ensure test executable was passed.
-const test_bin_path = getArgOption('--bin');
+const test_bin_path = getArgOption("--bin");
 if (!test_bin_path) {
-    console.error('Missing required `--bin <PATH>`');
-    Deno.exit(222);
+  console.error("Missing required `--bin <PATH>`");
+  Deno.exit(222);
 }
 
 // Get absolute test executable path.
 let test_bin;
 try {
-    test_bin = await Deno.realPath(test_bin_path);
+  test_bin = await Deno.realPath(test_bin_path);
 } catch (e) {
-    console.error(`Invalid executable path: ${test_bin_path}`);
-    Deno.exit(333);
+  console.error(`Invalid executable path: ${test_bin_path}`);
+  Deno.exit(333);
 }
 
 // Get setup/teardown executables.
-const pre_test_bin = getArgOption('--pre-bin');
-const post_test_bin = getArgOption('--post-bin');
+const pre_test_bin = getArgOption("--pre-bin");
+const post_test_bin = getArgOption("--post-bin");
 
 // Check if files should be ignored.
-const skipFiles = Deno.args.includes('--skip-files');
+const skipFiles = Deno.args.includes("--skip-files");
 
 // Check if sandboxing should be strict.
-const strict = Deno.args.includes('--strict');
+const strict = Deno.args.includes("--strict");
 
 // Required sandboxing exceptions.
 const requiredPaths = [];
 
 // Run analysis and report results.
-await checkPath([], '/');
-console.log('\nRequired paths: [');
+await checkPath([], "/");
+console.log("\nRequired paths: [");
 for (const path of requiredPaths) {
-    console.log(`    ${yellow(`"${path}"`)},`);
+  console.log(`    ${yellow(`"${path}"`)},`);
 }
-console.log(']');
+console.log("]");
 
 // Recursively check the path for required sandboxing exceptions.
 async function checkPath(allowed: [string], path: string) {
-    console.log(`${blue(`Scanning "${path}"...`)}`);
+  console.log(`${blue(`Scanning "${path}"...`)}`);
 
-    // Return immediately if it works without the path.
-    if (await test(allowed)) {
-        console.log(`${green(`${path}: Unnecessary directory`)}`);
-        return;
+  // Return immediately if it works without the path.
+  if (await test(allowed)) {
+    console.log(`${green(`${path}: Unnecessary directory`)}`);
+    return;
+  }
+
+  // Ensure path has trailing slash.
+  if (!path.endsWith("/")) {
+    path += "/";
+  }
+
+  // Get all files and directories in this folder.
+  const directories = [];
+  const files = [];
+  for await (const entry of Deno.readDir(path)) {
+    if (entry.isDirectory) {
+      directories.push(path + entry.name);
+    } else if (entry.isFile) {
+      files.push(path + entry.name);
     }
+  }
 
-    // Ensure path has trailing slash.
-    if (!path.endsWith('/')) {
-        path += '/';
-    }
+  // Add path if it doesn't work with all directories and files.
+  const allowedAndChildren = allowed.concat(files).concat(directories);
+  if (!(await test(allowedAndChildren))) {
+    console.log(`${red(`${path}: Required directory`)}`);
+    requiredPaths.push(path);
+    return;
+  }
 
-    // Get all files and directories in this folder.
-    const directories = [];
-    const files = [];
-    for await (const entry of Deno.readDir(path)) {
-        if (entry.isDirectory) {
-            directories.push(path + entry.name);
-        } else if (entry.isFile) {
-            files.push(path + entry.name);
-        }
-    }
-
-    // Add path if it doesn't work with all directories and files.
-    const allowedAndChildren = allowed.concat(files).concat(directories);
-    if (!(await test(allowedAndChildren))) {
-        console.log(`${red(`${path}: Required directory`)}`);
-        requiredPaths.push(path);
-        return;
-    }
-
-    // Check if any file is required.
-    const allowedAndDirectories = allowed.concat(directories);
-    if (!(await test(allowedAndDirectories))) {
-        if (skipFiles) {
-            // Add entire directory if any file is required and we're skipping file checks.
-            console.log(`${red(`${path}: Required directory due to skipping files`)}`);
-            requiredPaths.push(path);
-            return;
+  // Check if any file is required.
+  const allowedAndDirectories = allowed.concat(directories);
+  if (!(await test(allowedAndDirectories))) {
+    if (skipFiles) {
+      // Add entire directory if any file is required and we're skipping file checks.
+      console.log(
+        `${red(`${path}: Required directory due to skipping files`)}`
+      );
+      requiredPaths.push(path);
+      return;
+    } else {
+      // Add all required files.
+      for (const file of files) {
+        const withoutFile = allowedAndChildren.filter((entry) => entry != file);
+        if (!(await test(withoutFile))) {
+          console.log(`${red(`${file}: Required file`)}`);
+          requiredPaths.push(file);
         } else {
-            // Add all required files.
-            for (const file of files) {
-                const withoutFile = allowedAndChildren.filter(entry => entry != file);
-                if (!(await test(withoutFile))) {
-                    console.log(`${red(`${file}: Required file`)}`);
-                    requiredPaths.push(file);
-                } else {
-                    console.log(`${green(`${file}: Unnecessary file`)}`);
-                }
-            }
+          console.log(`${green(`${file}: Unnecessary file`)}`);
         }
+      }
     }
+  }
 
-    // Check if any directory is required.
-    const allowedAndFiles = allowed.concat(files);
-    if (!(await test(allowedAndFiles))) {
-        // Check all child directories.
-        for (const directory of directories) {
-            const withoutDirectory = allowedAndChildren.filter(entry => entry != directory);
-            await checkPath(withoutDirectory, directory);
-        }
+  // Check if any directory is required.
+  const allowedAndFiles = allowed.concat(files);
+  if (!(await test(allowedAndFiles))) {
+    // Check all child directories.
+    for (const directory of directories) {
+      const withoutDirectory = allowedAndChildren.filter(
+        (entry) => entry != directory
+      );
+      await checkPath(withoutDirectory, directory);
     }
+  }
 }
 
 // Check if execution with the specified directories works.
 async function test(directories: [string]): bool {
-    // Use directories for enabled permission types, allow everything otherwise.
-    let write = ['/'];
-    let read = ['/'];
-    if (check_write) {
-        write = directories;
+  // Use directories for enabled permission types, allow everything otherwise.
+  let write = ["/"];
+  let read = ["/"];
+  if (check_write) {
+    write = directories;
+  }
+  if (check_read) {
+    read = directories;
+  }
+
+  // Run pre-test setup executable.
+  if (pre_test_bin) {
+    let pre_status = PhylumApi.runSandboxed({
+      cmd: pre_test_bin,
+      stdout: "null",
+      stderr: "null",
+      exceptions: {
+        write: true,
+        read: true,
+        execute: true,
+        net: true,
+      },
+    });
+
+    if (!pre_status.success) {
+      console.error(`${red("Pre-test executable failed")}`);
+
+      // Assume test would fail if setup didn't even run.
+      return false;
     }
-    if (check_read) {
-        read = directories;
+  }
+
+  // Add `test_bin` path to run permissions.
+  read.push(test_bin);
+
+  // Run test against test executable.
+  let output = undefined;
+  try {
+    output = PhylumApi.runSandboxed({
+      cmd: test_bin,
+      exceptions: {
+        strict,
+        write,
+        read,
+        run: read,
+        net: true,
+      },
+      stdout: "null",
+      stderr: "null",
+    });
+  } catch (_e) {
+    return false;
+  }
+
+  // Run post-test cleanup executable.
+  if (post_test_bin) {
+    let post_status = PhylumApi.runSandboxed({
+      cmd: post_test_bin,
+      stdout: "null",
+      stderr: "null",
+      exceptions: {
+        write: true,
+        read: true,
+        execute: true,
+        net: true,
+      },
+    });
+
+    if (!post_status.success) {
+      console.error(`${red("Post-test executable failed")}`);
+
+      // Mark test as failed to exit as quickly as possible.
+      return false;
     }
+  }
 
-    // Run pre-test setup executable.
-    if (pre_test_bin) {
-        let pre_status = PhylumApi.runSandboxed({
-            cmd: pre_test_bin,
-            stdout: 'null',
-            stderr: 'null',
-            exceptions: {
-                write: true,
-                read: true,
-                execute: true,
-                net: true
-            }
-        })
-
-        if (!pre_status.success) {
-            console.error(`${red('Pre-test executable failed')}`);
-
-            // Assume test would fail if setup didn't even run.
-            return false;
-        }
-    }
-
-    // Add `test_bin` path to run permissions.
-    read.push(test_bin);
-
-    // Run test against test executable.
-    let output = undefined;
-    try {
-        output = PhylumApi.runSandboxed({
-            cmd: test_bin,
-            exceptions: {
-                strict,
-                write,
-                read,
-                run: read,
-                net: true,
-            },
-            stdout: 'null',
-            stderr: 'null',
-        });
-    } catch (_e) {
-        return false;
-    }
-
-    // Run post-test cleanup executable.
-    if (post_test_bin) {
-        let post_status = PhylumApi.runSandboxed({
-            cmd: post_test_bin,
-            stdout: 'null',
-            stderr: 'null',
-            exceptions: {
-                write: true,
-                read: true,
-                execute: true,
-                net: true
-            }
-        })
-
-        if (!post_status.success) {
-            console.error(`${red('Post-test executable failed')}`);
-
-            // Mark test as failed to exit as quickly as possible.
-            return false;
-        }
-    }
-
-    return output.success;
+  return output.success;
 }
 
 // Get the value of a CLI argument.
 function getArgOption(option: string): string | undefined {
-    let option_index = Deno.args.findIndex(arg => arg === option);
-    if (option_index !== -1) {
-        return Deno.args[option_index + 1];
-    } else {
-        return undefined;
-    }
+  let option_index = Deno.args.findIndex((arg) => arg === option);
+  if (option_index !== -1) {
+    return Deno.args[option_index + 1];
+  } else {
+    return undefined;
+  }
 }

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -1,5 +1,9 @@
-import { red, green, yellow } from 'https://deno.land/std@0.150.0/fmt/colors.ts';
-import { PhylumApi } from 'phylum';
+import {
+  red,
+  green,
+  yellow,
+} from "https://deno.land/std@0.150.0/fmt/colors.ts";
+import { PhylumApi } from "phylum";
 
 class FileBackup {
   readonly fileName: string;
@@ -29,134 +33,157 @@ class FileBackup {
 
 // Ensure we're in an npm root directory.
 try {
-    await Deno.stat('package.json');
+  await Deno.stat("package.json");
 } catch (e) {
-    console.error(`[${red("phylum")}] \`package.json\` was not found in the current directory.`);
-    console.error(`[${red("phylum")}] Please move to the npm project's top level directory and try again.`);
-    Deno.exit(125);
+  console.error(
+    `[${red(
+      "phylum"
+    )}] \`package.json\` was not found in the current directory.`
+  );
+  console.error(
+    `[${red(
+      "phylum"
+    )}] Please move to the npm project's top level directory and try again.`
+  );
+  Deno.exit(125);
 }
 
 // Store initial package manager file state.
-const packageLockBackup = new FileBackup('./package-lock.json');
+const packageLockBackup = new FileBackup("./package-lock.json");
 await packageLockBackup.backup();
-const manifestBackup = new FileBackup('./package.json');
+const manifestBackup = new FileBackup("./package.json");
 await manifestBackup.backup();
 
-
 // Analyze new dependencies with phylum before install/update.
-if (Deno.args.length >= 1
-    && (
-        'install'.startsWith(Deno.args[0])
-        || 'isntall'.startsWith(Deno.args[0])
-        || 'update'.startsWith(Deno.args[0])
-        || 'udpate'.startsWith(Deno.args[0])
-    )) {
-    await checkDryRun(Deno.args[0], Deno.args.slice(1));
+if (
+  Deno.args.length >= 1 &&
+  ("install".startsWith(Deno.args[0]) ||
+    "isntall".startsWith(Deno.args[0]) ||
+    "update".startsWith(Deno.args[0]) ||
+    "udpate".startsWith(Deno.args[0]))
+) {
+  await checkDryRun(Deno.args[0], Deno.args.slice(1));
 
-    console.log(`[${green("phylum")}] Installing without build scripts…`);
+  console.log(`[${green("phylum")}] Installing without build scripts…`);
 
-    // Install packages without executing build scripts.
-    let cmd = await Deno.run({
-        cmd: ['npm', ...Deno.args, '--ignore-scripts'],
-        stdout: 'inherit',
-        stderr: 'inherit',
-        stdin: 'inherit',
-    })
-    let status = await cmd.status();
+  // Install packages without executing build scripts.
+  let cmd = await Deno.run({
+    cmd: ["npm", ...Deno.args, "--ignore-scripts"],
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+  let status = await cmd.status();
 
-    // Ensure install worked. Failure is still "safe" for the user.
-    if (!status.success) {
-        console.error(`[${red("phylum")}] Installing packges failed.\n`);
-        abort(status.code);
-    } else {
-        console.log(`[${green("phylum")}] Packages installed successfully.\n`);
-    }
+  // Ensure install worked. Failure is still "safe" for the user.
+  if (!status.success) {
+    console.error(`[${red("phylum")}] Installing packges failed.\n`);
+    abort(status.code);
+  } else {
+    console.log(`[${green("phylum")}] Packages installed successfully.\n`);
+  }
 
-    console.log(`[${green("phylum")}] Running build scripts inside sandbox…`);
+  console.log(`[${green("phylum")}] Running build scripts inside sandbox…`);
 
-    // Run build scripts inside a sandbox.
-    const output = PhylumApi.runSandboxed({
-        cmd: 'npm',
-        args: ['install'],
-        exceptions: {
-            write: ['~/.npm/_logs', './package-lock.json', './node_modules'],
-            run: ['npm'],
-            read: true,
-            net: false,
-        },
-    });
+  // Run build scripts inside a sandbox.
+  const output = PhylumApi.runSandboxed({
+    cmd: "npm",
+    args: ["install"],
+    exceptions: {
+      write: ["~/.npm/_logs", "./package-lock.json", "./node_modules"],
+      run: ["npm"],
+      read: true,
+      net: false,
+    },
+  });
 
-    // Failure here could indicate vulnerabilities; report to the user.
-    if (!output.success) {
-        console.log(`[${red("phylum")}] Sandboxed build failed.`);
-        console.log(`[${red("phylum")}]`);
-        console.log(`[${red("phylum")}] This could mean one of your packages attempted to access a restricted resource.`);
-        console.log(`[${red("phylum")}] Do not retry installation without Phylum's extension.`);
-        console.log(`[${red("phylum")}]`);
-        console.log(`[${red("phylum")}] Please submit your lockfile to Phylum should this error persist.`);
+  // Failure here could indicate vulnerabilities; report to the user.
+  if (!output.success) {
+    console.log(`[${red("phylum")}] Sandboxed build failed.`);
+    console.log(`[${red("phylum")}]`);
+    console.log(
+      `[${red(
+        "phylum"
+      )}] This could mean one of your packages attempted to access a restricted resource.`
+    );
+    console.log(
+      `[${red("phylum")}] Do not retry installation without Phylum's extension.`
+    );
+    console.log(`[${red("phylum")}]`);
+    console.log(
+      `[${red(
+        "phylum"
+      )}] Please submit your lockfile to Phylum should this error persist.`
+    );
 
-        abort(output.code);
-    } else {
-        console.log(`[${green("phylum")}] Packages built successfully.`);
-    }
+    abort(output.code);
+  } else {
+    console.log(`[${green("phylum")}] Packages built successfully.`);
+  }
 } else {
-    let status = PhylumApi.runSandboxed({
-        cmd: 'npm', 
-        args: Deno.args,
-        exceptions: {
-            write: ['~/.npm', './'],
-            read: true,
-            run: ['npm'],
-            net: true,
-        }
-    });
-    Deno.exit(status.code);
+  let status = PhylumApi.runSandboxed({
+    cmd: "npm",
+    args: Deno.args,
+    exceptions: {
+      write: ["~/.npm", "./"],
+      read: true,
+      run: ["npm"],
+      net: true,
+    },
+  });
+  Deno.exit(status.code);
 }
 
 // Analyze new packages.
 async function checkDryRun(subcommand: string, args: string[]) {
-    console.log(`[${green("phylum")}] Updating lockfile…`);
+  console.log(`[${green("phylum")}] Updating lockfile…`);
 
-    let cmd = await Deno.run({
-        cmd: ['npm', subcommand, '--package-lock-only', ...args],
-        stdout: 'inherit',
-        stderr: 'inherit',
-        stdin: 'inherit',
-    })
-    let status = await cmd.status();
+  let cmd = await Deno.run({
+    cmd: ["npm", subcommand, "--package-lock-only", ...args],
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+  let status = await cmd.status();
 
-    // Ensure lockfile update was successful.
-    if (!status.success) {
-        console.error(`[${red("phylum")}] Lockfile update failed.\n`);
-        abort(status.code);
-    }
+  // Ensure lockfile update was successful.
+  if (!status.success) {
+    console.error(`[${red("phylum")}] Lockfile update failed.\n`);
+    abort(status.code);
+  }
 
-    const lockfile = await PhylumApi.parseLockfile('./package-lock.json', 'npm');
+  const lockfile = await PhylumApi.parseLockfile("./package-lock.json", "npm");
 
-    // Ensure `checkDryRun` never modifies package manager files,
-    // regardless of success.
-    await restoreBackup();
+  // Ensure `checkDryRun` never modifies package manager files,
+  // regardless of success.
+  await restoreBackup();
 
-    console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
-    console.log(`[${green("phylum")}] Analyzing packages…`);
+  console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
+  console.log(`[${green("phylum")}] Analyzing packages…`);
 
-    if (lockfile.packages.length === 0) {
-        console.log(`[${green("phylum")}] No packages found in lockfile.\n`)
-        return;
-    }
+  if (lockfile.packages.length === 0) {
+    console.log(`[${green("phylum")}] No packages found in lockfile.\n`);
+    return;
+  }
 
-    const jobId = await PhylumApi.analyze('npm', lockfile.packages);
-    const jobStatus = await PhylumApi.getJobStatus(jobId);
+  const jobId = await PhylumApi.analyze("npm", lockfile.packages);
+  const jobStatus = await PhylumApi.getJobStatus(jobId);
 
-    if (jobStatus.pass && jobStatus.status === 'complete') {
-        console.log(`[${green("phylum")}] All packages pass project thresholds.\n`)
-    } else if (jobStatus.pass) {
-        console.warn(`[${yellow("phylum")}] Unknown packages were submitted for analysis, please check again later.\n`);
-        Deno.exit(126);
-    } else {
-        console.error(`[${red("phylum")}] The operation caused a threshold failure.\n`);
-        Deno.exit(127);
-    }
+  if (jobStatus.pass && jobStatus.status === "complete") {
+    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
+  } else if (jobStatus.pass) {
+    console.warn(
+      `[${yellow(
+        "phylum"
+      )}] Unknown packages were submitted for analysis, please check again later.\n`
+    );
+    Deno.exit(126);
+  } else {
+    console.error(
+      `[${red("phylum")}] The operation caused a threshold failure.\n`
+    );
+    Deno.exit(127);
+  }
 }
 
 // Abort with specified exit code.
@@ -164,12 +191,12 @@ async function checkDryRun(subcommand: string, args: string[]) {
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
 async function abort(code) {
-    await restoreBackup();
-    Deno.exit(code);
+  await restoreBackup();
+  Deno.exit(code);
 }
 
 // Restore package manager files.
 async function restoreBackup() {
-    await packageLockBackup.restoreOrDelete();
-    await manifestBackup.restoreOrDelete();
+  await packageLockBackup.restoreOrDelete();
+  await manifestBackup.restoreOrDelete();
 }

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -1,5 +1,9 @@
-import { PhylumApi } from "phylum"
-import { red, green, yellow } from "https://deno.land/std@0.150.0/fmt/colors.ts";
+import { PhylumApi } from "phylum";
+import {
+  red,
+  green,
+  yellow,
+} from "https://deno.land/std@0.150.0/fmt/colors.ts";
 
 class FileBackup {
   readonly fileName: string;
@@ -13,7 +17,7 @@ class FileBackup {
   async backup() {
     try {
       this.fileContent = await Deno.readTextFile(this.fileName);
-    } catch (e) { }
+    } catch (e) {}
   }
 
   async restoreOrDelete() {
@@ -23,28 +27,42 @@ class FileBackup {
       } else {
         await Deno.remove(this.fileName);
       }
-    } catch (e) { }
+    } catch (e) {}
   }
 }
 
 // Ensure we're in a poetry root directory.
 try {
-  await Deno.stat('pyproject.toml');
+  await Deno.stat("pyproject.toml");
 } catch (e) {
-  console.error(`[${red("phylum")}] \`pyproject.toml\` was not found in the current directory.`);
-  console.error(`[${red("phylum")}] Please move to the Poetry project's top level directory and try again.`);
+  console.error(
+    `[${red(
+      "phylum"
+    )}] \`pyproject.toml\` was not found in the current directory.`
+  );
+  console.error(
+    `[${red(
+      "phylum"
+    )}] Please move to the Poetry project's top level directory and try again.`
+  );
   Deno.exit(125);
 }
 
 // Store initial package manager file state.
-const packageLockBackup = new FileBackup('poetry.lock');
+const packageLockBackup = new FileBackup("poetry.lock");
 await packageLockBackup.backup();
-const manifestBackup = new FileBackup('pyproject.toml');
+const manifestBackup = new FileBackup("pyproject.toml");
 await manifestBackup.backup();
 
 // If the subcommand modifies the lockfile, process it through Phylum.
-if (Deno.args.length >= 1 && ['add', 'update', 'install'].includes(Deno.args[0])) {
-  const analysisOutcome = await poetryCheckDryRun(Deno.args[0], Deno.args.slice(1));
+if (
+  Deno.args.length >= 1 &&
+  ["add", "update", "install"].includes(Deno.args[0])
+) {
+  const analysisOutcome = await poetryCheckDryRun(
+    Deno.args[0],
+    Deno.args.slice(1)
+  );
 
   // If the analysis failed, exit with an error.
   if (analysisOutcome !== 0) {
@@ -52,15 +70,15 @@ if (Deno.args.length >= 1 && ['add', 'update', 'install'].includes(Deno.args[0])
   }
 } else {
   let status = PhylumApi.runSandboxed({
-    cmd: 'poetry',
+    cmd: "poetry",
     args: Deno.args,
     exceptions: {
       read: true,
-      write: ['~/.cache/pypoetry', './'],
+      write: ["~/.cache/pypoetry", "./"],
       run: false,
       net: true,
-    }
-  })
+    },
+  });
   Deno.exit(status.code);
 }
 
@@ -69,15 +87,15 @@ async function poetryCheckDryRun(subcommand: string, args: string[]): number {
   console.log(`[${green("phylum")}] Updating lockfile…`);
 
   let status = PhylumApi.runSandboxed({
-    cmd: 'poetry',
-    args: [subcommand, '-n', '--lock', ...args.map(s => s.toString())],
+    cmd: "poetry",
+    args: [subcommand, "-n", "--lock", ...args.map((s) => s.toString())],
     exceptions: {
       read: true,
-      write: ['~/.cache/pypoetry', './'],
+      write: ["~/.cache/pypoetry", "./"],
       run: false,
       net: true,
-    }
-  })
+    },
+  });
 
   // Ensure dry-run update was successful.
   if (!status.success) {
@@ -85,7 +103,7 @@ async function poetryCheckDryRun(subcommand: string, args: string[]): number {
     abort(status.code);
   }
 
-  const lockfileData = await PhylumApi.parseLockfile('./poetry.lock', 'poetry');
+  const lockfileData = await PhylumApi.parseLockfile("./poetry.lock", "poetry");
 
   // Ensure `checkDryRun` never modifies package manager files,
   // regardless of success.
@@ -95,21 +113,30 @@ async function poetryCheckDryRun(subcommand: string, args: string[]): number {
   console.log(`[${green("phylum")}] Analyzing packages…`);
 
   if (lockfileData.packages.length === 0) {
-    console.log(`[${green("phylum")}] No packages found in lockfile.\n`)
+    console.log(`[${green("phylum")}] No packages found in lockfile.\n`);
     return;
   }
 
-  const jobId = await PhylumApi.analyze(lockfileData['package_type'], lockfileData['packages']);
+  const jobId = await PhylumApi.analyze(
+    lockfileData["package_type"],
+    lockfileData["packages"]
+  );
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
   if (jobStatus.pass && jobStatus.status === "complete") {
     console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
     return 0;
   } else if (jobStatus.pass) {
-    console.warn(`[${yellow("phylum")}] Unknown packages were submitted for analysis, please check again later.\n`);
+    console.warn(
+      `[${yellow(
+        "phylum"
+      )}] Unknown packages were submitted for analysis, please check again later.\n`
+    );
     return 126;
   } else {
-    console.error(`[${red("phylum")}] The operation caused a threshold failure.\n`);
+    console.error(
+      `[${red("phylum")}] The operation caused a threshold failure.\n`
+    );
     return 127;
   }
 }
@@ -119,12 +146,12 @@ async function poetryCheckDryRun(subcommand: string, args: string[]): number {
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
 async function abort(code) {
-    await restoreBackup();
-    Deno.exit(code);
+  await restoreBackup();
+  Deno.exit(code);
 }
 
 // Restore package manager files.
 async function restoreBackup() {
-    await packageLockBackup.restoreOrDelete();
-    await manifestBackup.restoreOrDelete();
+  await packageLockBackup.restoreOrDelete();
+  await manifestBackup.restoreOrDelete();
 }

--- a/extensions/poetry/tests.ts
+++ b/extensions/poetry/tests.ts
@@ -9,95 +9,115 @@
 // temporary directory, run the extension there, and subsequently clean up.
 //
 
-import { describe, afterAll, beforeAll, it, } from "https://deno.land/std@0.148.0/testing/bdd.ts"
-import { copy } from "https://deno.land/std@0.148.0/fs/mod.ts"
-import { assert } from "https://deno.land/std@0.148.0/testing/asserts.ts"
+import {
+  describe,
+  afterAll,
+  beforeAll,
+  it,
+} from "https://deno.land/std@0.148.0/testing/bdd.ts";
+import { copy } from "https://deno.land/std@0.148.0/fs/mod.ts";
+import { assert } from "https://deno.land/std@0.148.0/testing/asserts.ts";
 
 class Phylum {
-  readonly tempDir: string
-  readonly fixturesDir: string
-  readonly extDir: string
+  readonly tempDir: string;
+  readonly fixturesDir: string;
+  readonly extDir: string;
 
-  constructor (tempDir: string, extDir: string) {
-    this.tempDir = tempDir
-    this.fixturesDir = tempDir + '/fixtures'
-    this.extDir = extDir
+  constructor(tempDir: string, extDir: string) {
+    this.tempDir = tempDir;
+    this.fixturesDir = tempDir + "/fixtures";
+    this.extDir = extDir;
   }
 
-  async run (args: string[], cwd?: string) {
+  async run(args: string[], cwd?: string) {
     let process = Deno.run({
-      cmd: ['phylum', ...args],
-      env: { 'XDG_DATA_HOME': await this.tempDir },
+      cmd: ["phylum", ...args],
+      env: { XDG_DATA_HOME: await this.tempDir },
       cwd,
-      stdout: 'inherit',
-      stderr: 'inherit',
-    })
+      stdout: "inherit",
+      stderr: "inherit",
+    });
 
-    const status = await process.status()
-    await process.close()
+    const status = await process.status();
+    await process.close();
 
-    return status
+    return status;
   }
 
-  async runExt (args: string[], cwd?: string) {
-    return await this.run(['extension', 'run', '-y', this.extDir, ...args], cwd)
+  async runExt(args: string[], cwd?: string) {
+    return await this.run(
+      ["extension", "run", "-y", this.extDir, ...args],
+      cwd
+    );
   }
 
-  async cleanup () {
-    await Deno.remove(this.tempDir, { recursive: true })
+  async cleanup() {
+    await Deno.remove(this.tempDir, { recursive: true });
   }
 }
 
-const phylum = new Phylum(await Deno.makeTempDir(), Deno.cwd())
+const phylum = new Phylum(await Deno.makeTempDir(), Deno.cwd());
 
 beforeAll(async () => {
-  await copy('./fixtures',  phylum.fixturesDir)
+  await copy("./fixtures", phylum.fixturesDir);
   // The `poetry_test` project should be pre-existing.
-  await phylum.run(['project', 'link', 'poetry_test'], phylum.fixturesDir)
-})
+  await phylum.run(["project", "link", "poetry_test"], phylum.fixturesDir);
+});
 
 afterAll(async () => {
-  await phylum.cleanup()
-})
+  await phylum.cleanup();
+});
 
 describe("Poetry extension", async () => {
   // These tests may fail if the packages aren't processed on staging.
 
   it("correctly handles the `--dry-run` argument", async () => {
-    let status = await phylum.runExt(['add', '--dry-run', 'numpy'], phylum.fixturesDir)
-    assert(status.code === 0)
-  })
+    let status = await phylum.runExt(
+      ["add", "--dry-run", "numpy"],
+      phylum.fixturesDir
+    );
+    assert(status.code === 0);
+  });
 
   it("correctly allows a valid package", async () => {
-    let status = await phylum.runExt(['add', 'numpy'], phylum.fixturesDir)
-    assert(status.code === 0)
-  })
+    let status = await phylum.runExt(["add", "numpy"], phylum.fixturesDir);
+    assert(status.code === 0);
+  });
 
   it("correctly denies a known bad package", async () => {
-    let status = await phylum.runExt(['add', 'cffi==1.15.0'], phylum.fixturesDir)
-    assert(status.code !== 0)
-  })
+    let status = await phylum.runExt(
+      ["add", "cffi==1.15.0"],
+      phylum.fixturesDir
+    );
+    assert(status.code !== 0);
+  });
 
   it("allows duplicating the `--dry-run` flag", async () => {
-    let status = await phylum.runExt(['add', '--dry-run', 'numpy'], phylum.fixturesDir)
-    assert(status.code === 0)
-  })
+    let status = await phylum.runExt(
+      ["add", "--dry-run", "numpy"],
+      phylum.fixturesDir
+    );
+    assert(status.code === 0);
+  });
 
   it("allows duplicating the `--lock` flag", async () => {
-    let status = await phylum.runExt(['add', '--lock', 'numpy'], phylum.fixturesDir)
-    assert(status.code === 0)
-  })
+    let status = await phylum.runExt(
+      ["add", "--lock", "numpy"],
+      phylum.fixturesDir
+    );
+    assert(status.code === 0);
+  });
 
   it("correctly passes through other commands", async () => {
-    let status
+    let status;
 
-    status = await phylum.runExt(['check'], phylum.fixturesDir)
-    assert(status.code === 0)
+    status = await phylum.runExt(["check"], phylum.fixturesDir);
+    assert(status.code === 0);
 
-    status = await phylum.runExt(['help'], phylum.fixturesDir)
-    assert(status.code === 0)
+    status = await phylum.runExt(["help"], phylum.fixturesDir);
+    assert(status.code === 0);
 
-    status = await phylum.runExt(['version'], phylum.fixturesDir)
-    assert(status.code === 0)
-  })
-})
+    status = await phylum.runExt(["version"], phylum.fixturesDir);
+    assert(status.code === 0);
+  });
+});

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -1,5 +1,9 @@
-import { red, green, yellow } from 'https://deno.land/std@0.150.0/fmt/colors.ts';
-import { PhylumApi } from 'phylum';
+import {
+  red,
+  green,
+  yellow,
+} from "https://deno.land/std@0.150.0/fmt/colors.ts";
+import { PhylumApi } from "phylum";
 
 class FileBackup {
   readonly fileName: string;
@@ -29,139 +33,162 @@ class FileBackup {
 
 // Ensure we're in a yarn root directory.
 try {
-    await Deno.stat('package.json');
+  await Deno.stat("package.json");
 } catch (e) {
-    console.error(`[${red("phylum")}] \`package.json\` was not found in the current directory.`);
-    console.error(`[${red("phylum")}] Please move to the yarn project's top level directory and try again.`);
-    Deno.exit(125);
+  console.error(
+    `[${red(
+      "phylum"
+    )}] \`package.json\` was not found in the current directory.`
+  );
+  console.error(
+    `[${red(
+      "phylum"
+    )}] Please move to the yarn project's top level directory and try again.`
+  );
+  Deno.exit(125);
 }
 
 // Store initial package manager file state.
-const packageLockBackup = new FileBackup('./yarn.lock');
+const packageLockBackup = new FileBackup("./yarn.lock");
 await packageLockBackup.backup();
-const manifestBackup = new FileBackup('./package.json');
+const manifestBackup = new FileBackup("./package.json");
 await manifestBackup.backup();
 
 // Analyze new dependencies with phylum before install/update.
-if (Deno.args.length >= 1
-    && (
-        Deno.args[0] === 'add')
-        || Deno.args[0] === 'install'
-        || Deno.args[0] === 'up'
-        || Deno.args[0] === 'dedupe'
-   ) {
-    await checkDryRun(Deno.args[0], Deno.args.slice(1));
+if (
+  (Deno.args.length >= 1 && Deno.args[0] === "add") ||
+  Deno.args[0] === "install" ||
+  Deno.args[0] === "up" ||
+  Deno.args[0] === "dedupe"
+) {
+  await checkDryRun(Deno.args[0], Deno.args.slice(1));
 
-    console.log(`[${green("phylum")}] Downloading packages to cache…`);
+  console.log(`[${green("phylum")}] Downloading packages to cache…`);
 
-    // Download packages to cache without sandbox.
-    let status = PhylumApi.runSandboxed({
-        cmd: 'yarn',
-        args: [...Deno.args, '--mode=skip-build'],
-        exceptions: {
-            read: true,
-            write: ['~/.cache/node', '~/.cache/yarn', '~/.yarn', './'],
-            run: false,
-            net: true,
-        }
-    })
+  // Download packages to cache without sandbox.
+  let status = PhylumApi.runSandboxed({
+    cmd: "yarn",
+    args: [...Deno.args, "--mode=skip-build"],
+    exceptions: {
+      read: true,
+      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./"],
+      run: false,
+      net: true,
+    },
+  });
 
-    // Ensure download worked. Failure is still "safe" for the user.
-    if (!status.success) {
-        console.error(`[${red("phylum")}] Downloading packages to cache failed.\n`);
-        abort(status.code);
-    } else {
-        console.log(`[${green("phylum")}] Cache updated successfully.\n`);
-    }
+  // Ensure download worked. Failure is still "safe" for the user.
+  if (!status.success) {
+    console.error(`[${red("phylum")}] Downloading packages to cache failed.\n`);
+    abort(status.code);
+  } else {
+    console.log(`[${green("phylum")}] Cache updated successfully.\n`);
+  }
 
-    console.log(`[${green("phylum")}] Building packages inside sandbox…`);
+  console.log(`[${green("phylum")}] Building packages inside sandbox…`);
 
-    // Run build inside a sandbox.
-    const output = PhylumApi.runSandboxed({
-        cmd: 'yarn',
-        args: ['install', '--immutable', '--immutable-cache'],
-        exceptions: {
-            write: ['/tmp', './.yarn'],
-            run: ['yarn', '/tmp'],
-            read: true,
-            net: false,
-        },
-    });
+  // Run build inside a sandbox.
+  const output = PhylumApi.runSandboxed({
+    cmd: "yarn",
+    args: ["install", "--immutable", "--immutable-cache"],
+    exceptions: {
+      write: ["/tmp", "./.yarn"],
+      run: ["yarn", "/tmp"],
+      read: true,
+      net: false,
+    },
+  });
 
-    // Failure here could indicate vulnerabilities; report to the user.
-    if (!output.success) {
-        console.log(`[${red("phylum")}] Sandboxed build failed.`);
-        console.log(`[${red("phylum")}]`);
-        console.log(`[${red("phylum")}] This could mean one of your packages attempted to access a restricted resource.`);
-        console.log(`[${red("phylum")}] Do not retry installation without Phylum's extension.`);
-        console.log(`[${red("phylum")}]`);
-        console.log(`[${red("phylum")}] Please submit your lockfile to Phylum should this error persist.`);
+  // Failure here could indicate vulnerabilities; report to the user.
+  if (!output.success) {
+    console.log(`[${red("phylum")}] Sandboxed build failed.`);
+    console.log(`[${red("phylum")}]`);
+    console.log(
+      `[${red(
+        "phylum"
+      )}] This could mean one of your packages attempted to access a restricted resource.`
+    );
+    console.log(
+      `[${red("phylum")}] Do not retry installation without Phylum's extension.`
+    );
+    console.log(`[${red("phylum")}]`);
+    console.log(
+      `[${red(
+        "phylum"
+      )}] Please submit your lockfile to Phylum should this error persist.`
+    );
 
-        abort(output.code);
-    } else {
-        console.log(`[${green("phylum")}] Packages built successfully.`);
-    }
+    abort(output.code);
+  } else {
+    console.log(`[${green("phylum")}] Packages built successfully.`);
+  }
 } else {
-    let status = PhylumApi.runSandboxed({
-        cmd: 'yarn',
-        args: [...Deno.args],
-        exceptions: {
-            read: true,
-            write: ['~/.cache/node', '~/.cache/yarn', '~/.yarn', './'],
-            run: false,
-            net: true,
-        }
-    })
-    Deno.exit(status.code);
+  let status = PhylumApi.runSandboxed({
+    cmd: "yarn",
+    args: [...Deno.args],
+    exceptions: {
+      read: true,
+      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./"],
+      run: false,
+      net: true,
+    },
+  });
+  Deno.exit(status.code);
 }
 
 // Analyze new packages.
 async function checkDryRun(subcommand: string, args: string[]) {
-    console.log(`[${green("phylum")}] Updating lockfile…`);
+  console.log(`[${green("phylum")}] Updating lockfile…`);
 
-    let status = PhylumApi.runSandboxed({
-        cmd: 'yarn',
-        args: [...Deno.args, '--mode=update-lockfile'],
-        exceptions: {
-            read: true,
-            write: ['~/.cache/node', '~/.cache/yarn', '~/.yarn', './'],
-            run: false,
-            net: true,
-        }
-    })
+  let status = PhylumApi.runSandboxed({
+    cmd: "yarn",
+    args: [...Deno.args, "--mode=update-lockfile"],
+    exceptions: {
+      read: true,
+      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./"],
+      run: false,
+      net: true,
+    },
+  });
 
-    // Ensure lockfile update was successful.
-    if (!status.success) {
-        console.error(`[${red("phylum")}] Lockfile update failed.\n`);
-        abort(status.code);
-    }
+  // Ensure lockfile update was successful.
+  if (!status.success) {
+    console.error(`[${red("phylum")}] Lockfile update failed.\n`);
+    abort(status.code);
+  }
 
-    const lockfile = await PhylumApi.parseLockfile('./yarn.lock', 'yarn');
+  const lockfile = await PhylumApi.parseLockfile("./yarn.lock", "yarn");
 
-    // Ensure `checkDryRun` never modifies package manager files,
-    // regardless of success.
-    await restoreBackup();
+  // Ensure `checkDryRun` never modifies package manager files,
+  // regardless of success.
+  await restoreBackup();
 
-    console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
-    console.log(`[${green("phylum")}] Analyzing packages…`);
+  console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
+  console.log(`[${green("phylum")}] Analyzing packages…`);
 
-    if (lockfile.packages.length === 0) {
-        console.log(`[${green("phylum")}] No packages found in lockfile.\n`)
-        return;
-    }
+  if (lockfile.packages.length === 0) {
+    console.log(`[${green("phylum")}] No packages found in lockfile.\n`);
+    return;
+  }
 
-    const jobId = await PhylumApi.analyze('npm', lockfile.packages);
-    const jobStatus = await PhylumApi.getJobStatus(jobId);
+  const jobId = await PhylumApi.analyze("npm", lockfile.packages);
+  const jobStatus = await PhylumApi.getJobStatus(jobId);
 
-    if (jobStatus.pass && jobStatus.status === 'complete') {
-        console.log(`[${green("phylum")}] All packages pass project thresholds.\n`)
-    } else if (jobStatus.pass) {
-        console.warn(`[${yellow("phylum")}] Unknown packages were submitted for analysis, please check again later.\n`);
-        Deno.exit(126);
-    } else {
-        console.error(`[${red("phylum")}] The operation caused a threshold failure.\n`);
-        Deno.exit(127);
-    }
+  if (jobStatus.pass && jobStatus.status === "complete") {
+    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
+  } else if (jobStatus.pass) {
+    console.warn(
+      `[${yellow(
+        "phylum"
+      )}] Unknown packages were submitted for analysis, please check again later.\n`
+    );
+    Deno.exit(126);
+  } else {
+    console.error(
+      `[${red("phylum")}] The operation caused a threshold failure.\n`
+    );
+    Deno.exit(127);
+  }
 }
 
 // Abort with specified exit code.
@@ -169,12 +196,12 @@ async function checkDryRun(subcommand: string, args: string[]) {
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
 async function abort(code) {
-    await restoreBackup();
-    Deno.exit(code);
+  await restoreBackup();
+  Deno.exit(code);
 }
 
 // Restore package manager files.
 async function restoreBackup() {
-    await packageLockBackup.restoreOrDelete();
-    await manifestBackup.restoreOrDelete();
+  await packageLockBackup.restoreOrDelete();
+  await manifestBackup.restoreOrDelete();
 }


### PR DESCRIPTION
Closes #704.

This PR adds a job for checking extensions' formatting with [prettier](https://prettier.io/).
`prettier` is opinionated and requires no configuration to be run.

In this PR, the only manual modifications are in the `test.yml` workflow; the remainder of the diffs derive from applying the formatting.