### PR TITLE
Improve strictness of Gradle parser

### DIFF
--- a/lockfile/src/parsers/gradle_dep.rs
+++ b/lockfile/src/parsers/gradle_dep.rs
@@ -22,7 +22,7 @@ fn filter_line(line: &&str) -> bool {
 }
 
 // Take all non-white characters until encountering whitespace or `until`.
-fn not_space_until<'a>(input: &'a str, until: char) -> Result<&'a str, &'a str> {
+fn not_space_until(input: &str, until: char) -> Result<&str, &str> {
     take_till(|c: char| c == until || c.is_whitespace())(input)
 }
 

--- a/lockfile/src/parsers/mod.rs
+++ b/lockfile/src/parsers/mod.rs
@@ -1,5 +1,5 @@
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take, take_till, take_until};
+use nom::bytes::complete::{tag, take, take_until};
 use nom::character::complete::{line_ending, multispace0, none_of, space0};
 use nom::combinator::{eof, opt, recognize};
 use nom::error::{context, ParseError, VerboseError};

--- a/tests/fixtures/gradle.lockfile
+++ b/tests/fixtures/gradle.lockfile
@@ -4,6 +4,7 @@
 com.google.code.findbugs:jsr305:1.3.9=classpath
 com.google.errorprone:error_prone_annotations:2.0.18=classpath
 com.google.guava:guava:23.3-jre=classpath
+
 com.google.j2objc:j2objc-annotations:1.1=classpath
 org.codehaus.mojo:animal-sniffer-annotations:1.14=classpath
 org.springframework:spring-core:5.2.15.RELEASE


### PR DESCRIPTION
Previously the Gradle parser was **very** permissive, so much so that
some of our non-Gradle test lockfiles were accepted as valid Gradle
lockfiles.

This patch rewrites the Gradle parser while attempting to be as strict
as possible. Running against our lockfiles in tests/fixtures now shows
that all parsers can only parse the lockfiles in their specific format.

Closes #754.