### PR TITLE
Add default sandbox exception for $PATH

### DIFF
--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -300,6 +300,9 @@ pub fn default_sandbox() -> SandboxResult<Birdcage> {
         add_exception(&mut birdcage, Exception::ExecuteAndRead(path.into()))?;
     }
 
+    // Allow applications to read from `$PATH`.
+    birdcage.add_exception(Exception::Environment("PATH".into()))?;
+
     Ok(birdcage)
 }
 


### PR DESCRIPTION
Since users might rely on executables in their $PATH being accessible for extensions, an exception was added to the default sandbox allowing for access to $PATH by default.

The $PATH is still cleared when using the strict sandboxing mode.
