### PR TITLE
Avoid stdout when run with `--json`

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -420,10 +420,10 @@ async fn parse_lockfile(
     let lockfile_type = match lockfile_type {
         Some(lockfile_type) => lockfile_type,
         None => {
-            let (packages, package_type) = parse::get_packages_from_lockfile(Path::new(&lockfile))?;
+            let parsed = parse::get_packages_from_lockfile(Path::new(&lockfile))?;
             return Ok(PackageLock {
-                package_type,
-                packages: packages.into_iter().map(PackageSpecifier::from).collect(),
+                package_type: parsed.package_type,
+                packages: parsed.packages.into_iter().map(PackageSpecifier::from).collect(),
             });
         },
     };

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -202,9 +202,11 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
             group.map(String::from),
         )
         .await?;
-
     log::debug!("Response => {:?}", job_id);
-    print_user_success!("Job ID: {}", job_id);
+
+    if pretty_print {
+        print_user_success!("Job ID: {}", job_id);
+    }
 
     if synch {
         log::debug!("Requesting status...");

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -9,7 +9,12 @@ use phylum_lockfile::{get_path_format, LockfileFormat};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use crate::commands::{CommandResult, ExitCode};
-use crate::{print_user_success, print_user_warning};
+
+pub struct ParsedLockfile {
+    pub format: LockfileFormat,
+    pub packages: Vec<PackageDescriptor>,
+    pub package_type: PackageType,
+}
 
 pub fn lockfile_types() -> Vec<&'static str> {
     LockfileFormat::iter().map(|format| format.name()).chain(["auto"]).collect()
@@ -22,8 +27,8 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
     let lockfile = matches.get_one::<String>("LOCKFILE").unwrap();
 
     let pkgs = if lockfile_type == &auto_type {
-        let (pkgs, _) = try_get_packages(Path::new(lockfile))?;
-        pkgs
+        let parsed = try_get_packages(Path::new(lockfile))?;
+        parsed.packages
     } else {
         let parser = lockfile_type.parse::<LockfileFormat>().unwrap().parser();
 
@@ -36,20 +41,19 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
     Ok(ExitCode::Ok.into())
 }
 /// Attempt to get packages from an unknown lockfile type
-pub fn try_get_packages(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
-    print_user_warning!(
-        "Attempting to obtain packages from unrecognized lockfile type: {}",
-        path.to_string_lossy()
-    );
-
+fn try_get_packages(path: &Path) -> Result<ParsedLockfile> {
     let data = read_to_string(path)?;
 
     for format in LockfileFormat::iter() {
         let parser = format.parser();
-        if let Ok(pkgs) = parser.parse(data.as_str()) {
-            if !pkgs.is_empty() {
-                print_user_success!("Identified lockfile type: {}", format);
-                return Ok((pkgs, parser.package_type()));
+        if let Ok(packages) = parser.parse(data.as_str()) {
+            if !packages.is_empty() {
+                log::info!("Identified lockfile type: {}", format);
+                return Ok(ParsedLockfile {
+                    format,
+                    packages,
+                    package_type: parser.package_type(),
+                });
             }
         }
     }
@@ -59,17 +63,27 @@ pub fn try_get_packages(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageT
 
 /// Determine the lockfile type based on its name and parse
 /// accordingly to obtain the packages from it
-pub fn get_packages_from_lockfile(path: &Path) -> Result<(Vec<PackageDescriptor>, PackageType)> {
+pub fn get_packages_from_lockfile(path: &Path) -> Result<ParsedLockfile> {
     let res = match get_path_format(path) {
         Some(format) => {
             let data = read_to_string(path)?;
             let parser = format.parser();
-            (parser.parse(&data)?, parser.package_type())
+            ParsedLockfile {
+                format,
+                packages: parser.parse(&data)?,
+                package_type: parser.package_type(),
+            }
         },
-        None => try_get_packages(path)?,
+        None => {
+            log::warn!(
+                "Attempting to obtain packages from unrecognized lockfile type: {}",
+                path.display()
+            );
+            try_get_packages(path)?
+        },
     };
 
-    log::debug!("Read {} packages from file `{}`", res.0.len(), path.display());
+    log::debug!("Read {} packages from file `{}`", res.packages.len(), path.display());
 
     Ok(res)
 }
@@ -81,25 +95,30 @@ mod tests {
     #[test]
     fn it_can_identify_lock_file_types() {
         let test_cases = [
-            ("../tests/fixtures/Gemfile.lock", PackageType::RubyGems),
-            ("../tests/fixtures/yarn-v1.lock", PackageType::Npm),
-            ("../tests/fixtures/yarn.lock", PackageType::Npm),
-            ("../tests/fixtures/package-lock.json", PackageType::Npm),
-            ("../tests/fixtures/sample.csproj", PackageType::Nuget),
-            ("../tests/fixtures/gradle.lockfile", PackageType::Maven),
-            ("../tests/fixtures/effective-pom.xml", PackageType::Maven),
-            ("../tests/fixtures/workspace-effective-pom.xml", PackageType::Maven),
-            ("../tests/fixtures/requirements.txt", PackageType::PyPi),
-            ("../tests/fixtures/Pipfile", PackageType::PyPi),
-            ("../tests/fixtures/Pipfile.lock", PackageType::PyPi),
-            ("../tests/fixtures/poetry.lock", PackageType::PyPi),
-            ("../tests/fixtures/go.sum", PackageType::Golang),
-            ("../tests/fixtures/Cargo_v3.lock", PackageType::Cargo),
+            ("../tests/fixtures/Gemfile.lock", PackageType::RubyGems, LockfileFormat::Gem),
+            ("../tests/fixtures/yarn-v1.lock", PackageType::Npm, LockfileFormat::Yarn),
+            ("../tests/fixtures/yarn.lock", PackageType::Npm, LockfileFormat::Yarn),
+            ("../tests/fixtures/package-lock.json", PackageType::Npm, LockfileFormat::Npm),
+            ("../tests/fixtures/sample.csproj", PackageType::Nuget, LockfileFormat::Msbuild),
+            ("../tests/fixtures/gradle.lockfile", PackageType::Maven, LockfileFormat::Gradle),
+            ("../tests/fixtures/effective-pom.xml", PackageType::Maven, LockfileFormat::Maven),
+            (
+                "../tests/fixtures/workspace-effective-pom.xml",
+                PackageType::Maven,
+                LockfileFormat::Maven,
+            ),
+            ("../tests/fixtures/requirements.txt", PackageType::PyPi, LockfileFormat::Pip),
+            ("../tests/fixtures/Pipfile", PackageType::PyPi, LockfileFormat::Pipenv),
+            ("../tests/fixtures/Pipfile.lock", PackageType::PyPi, LockfileFormat::Pipenv),
+            ("../tests/fixtures/poetry.lock", PackageType::PyPi, LockfileFormat::Poetry),
+            ("../tests/fixtures/go.sum", PackageType::Golang, LockfileFormat::Go),
+            ("../tests/fixtures/Cargo_v3.lock", PackageType::Cargo, LockfileFormat::Cargo),
         ];
 
-        for (file, expected_type) in &test_cases {
-            let (_, pkg_type) = try_get_packages(Path::new(file)).unwrap();
-            assert_eq!(pkg_type, *expected_type, "{}", file);
+        for (file, expected_type, expected_format) in test_cases {
+            let parsed = try_get_packages(Path::new(file)).unwrap();
+            assert_eq!(parsed.package_type, expected_type, "{}", file);
+            assert_eq!(parsed.format, expected_format, "{}", file);
         }
     }
 }


### PR DESCRIPTION
There were two places where we might print to stdout when running `phylum analyze --json`. One of them is printing the Job ID. This patch avoids printing in that case. The other is identifying a previously unknown lockfile. This patch sends that output to stderr.

Closes #769