### PR TITLE
Fix --package-type option

### DIFF
--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -21,7 +21,7 @@ fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<Pack
     // to the global setting
     let package_type = match matches.get_one::<String>("package-type") {
         Some(pt) => {
-            PackageType::from_str(pt).map_err(|()| anyhow!("invalid package type: {}", pt))?
+            PackageType::from_str(pt).map_err(|_| anyhow!("invalid package type: {}", pt))?
         },
         None => request_type,
     };

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anyhow::{anyhow, Result};
 use clap::ArgMatches;
 use console::style;
 use phylum_types::types::package::{PackageDescriptor, PackageType};
@@ -11,28 +12,28 @@ use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;
 use crate::print_user_warning;
 
-fn parse_package(options: &ArgMatches, request_type: &PackageType) -> PackageDescriptor {
+fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<PackageDescriptor> {
     // Read required options.
-    let name = options.get_one::<String>("name").unwrap().to_string();
-    let version = options.get_one::<String>("version").unwrap().to_string();
-
-    let mut package_type = request_type.to_owned();
+    let name = matches.get_one::<String>("name").unwrap().to_string();
+    let version = matches.get_one::<String>("version").unwrap().to_string();
 
     // If a package type was provided on the command line, prefer that
-    //  to the global setting
-    if options.get_flag("package-type") {
-        package_type = PackageType::from_str(options.get_one::<String>("package-type").unwrap())
-            .unwrap_or(package_type);
-    }
+    // to the global setting
+    let package_type = match matches.get_one::<String>("package-type") {
+        Some(pt) => {
+            PackageType::from_str(pt).map_err(|()| anyhow!("invalid package type: {}", pt))?
+        },
+        None => request_type,
+    };
 
-    PackageDescriptor { name, version, package_type }
+    Ok(PackageDescriptor { name, version, package_type })
 }
 
 /// Handle the subcommands for the `package` subcommand.
 pub async fn handle_get_package(api: &mut PhylumApi, matches: &clap::ArgMatches) -> CommandResult {
     let pretty_print = !matches.get_flag("json");
 
-    let pkg = parse_package(matches, &api.config().request_type);
+    let pkg = parse_package(matches, api.config().request_type)?;
     let mut resp = match api.get_package_details(&pkg).await {
         Ok(resp) => resp,
         Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => {


### PR DESCRIPTION
Fix the `--package-type` option by avoiding the call to `get_flag` (since this option is not a flag).