### PR TITLE
Validate `run` permissions in `runSandboxed`

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -401,6 +401,9 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
     let resolved_permissions =
         permissions::Permissions::from(exceptions).subset_of(&state.extension().permissions())?;
 
+    // Ensure access to the executable was explicitly granted.
+    resolved_permissions.run.validate(&cmd, "executable")?;
+
     // Add sandbox subcommand argument.
     let mut sandbox_args = Vec::with_capacity(args.len());
     sandbox_args.push("sandbox".into());

--- a/cli/tests/fixtures/extensions/permissions/correct-run-perms/main.ts
+++ b/cli/tests/fixtures/extensions/permissions/correct-run-perms/main.ts
@@ -5,6 +5,7 @@ let cmd = PhylumApi.runSandboxed({
   args: ['hello'],
   stdout: 'piped',
   stderr: 'piped',
+  exceptions: { run: ['echo'] },
 });
 
 await Deno.stdout.write(new TextEncoder().encode(cmd.stdout));


### PR DESCRIPTION
This patch adds a permission check to the `runSandboxed` extension API, validating that any command executed is present in the requested permissions of the manifest and the `runSandboxed` exceptions.

This should help with consistency between `runSandboxed` and `Deno.run`, since the sandbox was by default adding every executable in `$PATH` to the allowed executables, making it difficult to identify why things weren't failing despite not specifying any `run` permissions.

While this does ensure that a command is present in the exceptions before it can be executed by `runSandboxed`, nothing is done to the sandbox itself. So the executed command can keep freely creating new processes as long as they're permitted by the sandbox.

Currently the exception needs to match the `cmd` passed to `runSandboxed` **exactly**, to ensure the API is consistent with Deno's `Deno.run`. It would be possible to relax this in the future and allow executing child paths of anything requested.
