### PR TITLE
`phylum auth set-token`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -106,7 +106,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_name("group_name")
                         .help("Group to list projects for"),
                 ])
-                .aliases(&["projects"])
+                .aliases(["projects"])
                 .subcommand(
                     Command::new("create").about("Create a new project").args(&[
                         Arg::new("name")
@@ -121,7 +121,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     ]),
                 )
                 .subcommand(
-                    Command::new("delete").about("Delete a project").aliases(&["rm"]).args(&[
+                    Command::new("delete").about("Delete a project").aliases(["rm"]).args(&[
                         Arg::new("name")
                             .value_name("name")
                             .help("Name of the project")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -216,6 +216,13 @@ pub fn add_subcommands(command: Command) -> Command {
                 .subcommand(
                     Command::new("status").about("Return the current authentication status"),
                 )
+                .subcommand(Command::new("set-token").about("Set the current authentication token").arg(
+                    Arg::new("token")
+                        .action(ArgAction::Set)
+                        .required(false)
+                        .help("Authentication token to store (read from stdin if omitted)")
+                    ),
+                )
                 .subcommand(
                     Command::new("token").about("Return the current authentication token").arg(
                         Arg::new("bearer")

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -64,7 +64,7 @@ impl CodeVerifier {
         let mut hasher = Sha256::new();
         hasher.update(&code_verifier);
         let hash = hasher.finalize();
-        let base_64_url_safe = base64::encode_config(&hash, base64::URL_SAFE_NO_PAD);
+        let base_64_url_safe = base64::encode_config(hash, base64::URL_SAFE_NO_PAD);
         Ok((CodeVerifier(code_verifier), ChallengeCode(base_64_url_safe)))
     }
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -88,28 +88,26 @@ pub async fn handle_auth(
     app_helper: &mut Command,
     timeout: Option<u64>,
 ) -> CommandResult {
-    if matches.subcommand_matches("register").is_some() {
-        match handle_auth_register(config, config_path).await {
+    match matches.subcommand() {
+        Some(("register", _)) => match handle_auth_register(config, config_path).await {
             Ok(_) => {
                 print_user_success!("{}", "User successfuly regsistered");
                 Ok(ExitCode::Ok.into())
             },
             Err(error) => Err(error).context("User registration failed"),
-        }
-    } else if matches.subcommand_matches("login").is_some() {
-        match handle_auth_login(config, config_path).await {
+        },
+        Some(("login", _)) => match handle_auth_login(config, config_path).await {
             Ok(_) => {
                 print_user_success!("{}", "User login successful");
                 Ok(ExitCode::Ok.into())
             },
             Err(error) => Err(error).context("User login failed"),
-        }
-    } else if matches.subcommand_matches("status").is_some() {
-        handle_auth_status(config, timeout).await
-    } else if let Some(matches) = matches.subcommand_matches("token") {
-        handle_auth_token(&config, matches).await
-    } else {
-        print_sc_help(app_helper, &["auth"])?;
-        Ok(ExitCode::Ok.into())
+        },
+        Some(("status", _)) => handle_auth_status(config, timeout).await,
+        Some(("token", matches)) => handle_auth_token(&config, matches).await,
+        _ => {
+            print_sc_help(app_helper, &["auth"])?;
+            Ok(ExitCode::Ok.into())
+        },
     }
 }

--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -334,7 +334,7 @@ pub fn resolve_bin_path<P: AsRef<Path>>(bin: P) -> PathBuf {
 
     // Return first path in `$PATH` that contains `bin`.
     for path in path.split(':') {
-        let combined = PathBuf::from(path).join(&bin);
+        let combined = PathBuf::from(path).join(bin);
         if combined.exists() {
             return combined;
         }

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -38,7 +38,7 @@ fn allow_fs() {
         .run(&[
             "sandbox",
             "--allow-write",
-            &test_file_path,
+            test_file_path,
             "bash",
             "-c",
             &format!("echo x > {test_file_path}"),
@@ -46,7 +46,7 @@ fn allow_fs() {
         .success();
 
     // Test read access.
-    test_cli.run(&["sandbox", "--allow-read", &test_file_path, "cat", &test_file_path]).success();
+    test_cli.run(&["sandbox", "--allow-read", test_file_path, "cat", test_file_path]).success();
 }
 
 #[test]

--- a/docs/command_line_tool/phylum_auth.md
+++ b/docs/command_line_tool/phylum_auth.md
@@ -9,5 +9,6 @@ Manage authentication, registration, and API keys
 ### Commands
 * [phylum auth login](https://docs.phylum.io/docs/phylum_auth_login)
 * [phylum auth register](https://docs.phylum.io/docs/phylum_auth_register)
+* [phylum auth set-token](https://docs.phylum.io/docs/phylum_auth_set-token)
 * [phylum auth status](https://docs.phylum.io/docs/phylum_auth_status)
 * [phylum auth token](https://docs.phylum.io/docs/phylum_auth_token)

--- a/docs/command_line_tool/phylum_auth.md
+++ b/docs/command_line_tool/phylum_auth.md
@@ -9,6 +9,6 @@ Manage authentication, registration, and API keys
 ### Commands
 * [phylum auth login](https://docs.phylum.io/docs/phylum_auth_login)
 * [phylum auth register](https://docs.phylum.io/docs/phylum_auth_register)
-* [phylum auth set-token](https://docs.phylum.io/docs/phylum_auth_set-token)
+* [phylum auth set-token](https://docs.phylum.io/docs/phylum_auth_set_token)
 * [phylum auth status](https://docs.phylum.io/docs/phylum_auth_status)
 * [phylum auth token](https://docs.phylum.io/docs/phylum_auth_token)

--- a/docs/command_line_tool/phylum_auth_set_token.md
+++ b/docs/command_line_tool/phylum_auth_set_token.md
@@ -1,0 +1,21 @@
+---
+title: phylum auth set-token
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Set the current authentication token
+
+```sh
+phylum auth set-token [TOKEN]
+```
+
+### Examples
+```sh
+# Supply the token directly on the command line
+$ phylum auth set-token eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjB9.49jV8bS3WGLP20VBpCDane-kjxfGmO8L6LHgE7mLO9I
+
+# Supply the token on stdin
+$ phylum auth set-token
+eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjB9.49jV8bS3WGLP20VBpCDane-kjxfGmO8L6LHgE7mLO9I
+```

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -278,7 +278,7 @@ mod tests {
                     Err(_) => continue,
                 };
 
-                if packages.len() > 0 {
+                if !packages.is_empty() {
                     parsed_lockfiles.push(lockfile_path.display().to_string());
                 }
             }


### PR DESCRIPTION
This patch adds a command to set the token in the config file. This provides an alternative to `phylum auth login` provided you can get the token from some other place. The other place may be `phylum auth token` from another machine or, in the future, we may support copying the token directly from the web UI.