### PR TITLE
fix: avoid stdout when run with --json

### DIFF
--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -136,7 +136,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         let res = get_packages_from_lockfile(Path::new(lockfile))
             .context("Unable to locate any valid package in package lockfile")?;
 
-        if !pretty_print {
+        if pretty_print {
             print_user_success!("Succesfully parsed lockfile as type: {}", res.format.name());
         }
 


### PR DESCRIPTION
This is a continuation of #773, to resolve #769

## Screenshots

Behavior before this change:

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/18729796/198413939-8f88f711-305e-4ea4-8546-c67811619365.png">

---

Behavior after this change:

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/18729796/198413799-241946d4-ff08-4afa-9947-31eb9c3d1fc2.png">
