### PR TITLE
Bump to v3.12.1 - Fix to avoid stdout when run with `--json`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 3.12.1 - Fix to avoid stdout when run with --json
 * 3.12.0 - Permissions extension API
 * 3.11.0 - Extensions API improvements: sandboxing API, environment variables permissions, create and delete projects
 * 3.10.0 - Support legacy poetry dependency source type, remove XDG migration code, send better UA header, and bugfixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "3.12.0"
+version = "3.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "3.12.0"
+version = "3.12.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release-Version: v3.12.1
Release-Summary: Fix to avoid stdout when run with `--json`

