### PR TITLE
Add ignore scripts when updating package-lock.json

### DIFF
--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -139,7 +139,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
   console.log(`[${green("phylum")}] Updating lockfile…`);
 
   let cmd = await Deno.run({
-    cmd: ["npm", subcommand, "--package-lock-only", ...args],
+    cmd: ["npm", subcommand, "--package-lock-only", "--ignore-scripts", ...args],
     stdout: "inherit",
     stderr: "inherit",
     stdin: "inherit",


### PR DESCRIPTION
Updates the read permissions to limit access to disk from the npm extension. Also adds the `--ignore-scripts` to the lock file generation.
