### PR TITLE
Sandbox outer error management implementation with IPC file

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -354,6 +354,12 @@ pub fn add_subcommands(command: Command) -> Command {
     {
         app = app.subcommand(
             Command::new("sandbox").hide(true).about("Run an application in a sandbox").args(&[
+                Arg::new("ipc-path")
+                    .help("Set directory to store IPC messages in")
+                    .long("ipc-path")
+                    .value_name("PATH")
+                    .value_hint(ValueHint::FilePath)
+                    .action(ArgAction::Set),
                 Arg::new("allow-read")
                     .help("Add filesystem read sandbox exception")
                     .long("allow-read")

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -27,6 +27,7 @@ use phylum_types::types::package::{
 use phylum_types::types::project::ProjectSummaryResponse;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
 use tempfile::TempDir;
 use tokio::fs;
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -433,8 +433,9 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
         .stderr(stderr)
         .output()?;
 
-    if !output.status.success() && ipc_path_error.exists() {
-        let error_msg = std::fs::read_to_string(ipc_path_error)?;
+    let error_msg = std::fs::read_to_string(ipc_path_error)?;
+
+    if !output.status.success() && !error_msg.is_empty() {
         return Err(anyhow!(error_msg));
     }
 

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -1,6 +1,9 @@
 //! Sandbox subcommand handling.
 
+use std::fs::File;
+use std::io::Write;
 use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
@@ -12,13 +15,33 @@ use crate::commands::{CommandResult, CommandValue, ExitCode};
 
 /// Entry point for the `sandbox` subcommand.
 pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
+    // Create the IPC error message file before locking the sandbox, so we are still
+    // able to access it via this file descriptor.
+    let ipc_file = if let Some(path) = matches.get_one::<String>("ipc-path").map(PathBuf::from) {
+        Some(File::create(path.join("error"))?)
+    } else {
+        None
+    };
+
     // Setup sandbox.
     lock_process(matches)?;
 
     // Start subprocess.
     let cmd = matches.get_one::<String>("cmd").unwrap();
     let args: Vec<&String> = matches.get_many("args").unwrap_or_default().collect();
-    let status = Command::new(cmd).args(&args).status()?;
+    let status = Command::new(cmd).args(&args).status().map_err(|e| {
+        let error_msg = format!("Sandbox process not started: {cmd}: {e}");
+
+        // If the parent is expecting an error report in `--ipc-path`, provide it.
+        if let Some(mut ipc_file) = ipc_file {
+            // Filesystem errors will be propagated upwards. There is no non-fallible way of
+            // communicating with the parent process in this way.
+            if let Err(e) = ipc_file.write_all(error_msg.as_bytes()) {
+                return anyhow!(e);
+            }
+        }
+        anyhow!(error_msg)
+    })?;
 
     if let Some(code) = status.code() {
         Ok(CommandValue::Code(ExitCode::Custom(code)))

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -1,5 +1,5 @@
 use predicates::prelude::*;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 use crate::common::TestCli;
 
@@ -90,4 +90,19 @@ fn allow_net() {
     let test_cli = TestCli::builder().build();
 
     test_cli.run(&["sandbox", "--allow-env", "--allow-net", "curl", "http://phylum.io"]).success();
+}
+
+#[test]
+fn error_exit() {
+    let test_cli = TestCli::builder().build();
+    let ipc_path = TempDir::new().unwrap();
+    let ipc_path_error = ipc_path.path().join("error");
+
+    test_cli
+        .run(&["sandbox", "--ipc-path", ipc_path.path().to_str().unwrap(), "blargle"])
+        .failure();
+
+    // Test that the error IPC file exists, and that it contains an expected value.
+    assert!(ipc_path_error.exists());
+    assert!(std::fs::read_to_string(ipc_path_error).unwrap().contains("Sandbox"));
 }


### PR DESCRIPTION
A proposed solution to #781.

`run_sandboxed` creates a temporary directory, and the `phylum sandbox` command writes to a file in it to signal failures that aren't coming from its child process. The file has to be created and opened before the sandbox is locked, but can be accessed afterwards as long as its file descriptor is not closed.

Drawback: I/O based communication which introduces errors that can't be solved by more I/O based communication. This means that there are some top-level failure cases which won't be distinguishable from child process failures (i.e. couldn't create the IPC file). This could be acceptable as I doubt it's ever going to be an attack vector (the consequences of a miscommunication here aren't security sensitive) and the conditions leading to a failure (missing write permission to a temporary path, full disk, other write errors) are most likely going to affect other parts of this flow as well.

Opening as draft PR in order to gather ideas and feedback before moving forward.

Closes #781.

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
