### PR TITLE
Add cache directory for macos

### DIFF
--- a/extensions/yarn/PhylumExt.toml
+++ b/extensions/yarn/PhylumExt.toml
@@ -3,7 +3,7 @@ description = "yarn package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-write = ["/tmp", "~/.cache/node", "~/.cache/yarn", "~/.yarn", "./"]
+write = ["/tmp", "~/.cache/node", "~/.cache/yarn", "~/.yarn", "./", "~/Library/Caches/Yarn"]
 read = true
 run = ["yarn", "/tmp"]
 net = true

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -71,7 +71,7 @@ if (
     args: [...Deno.args, "--mode=skip-build"],
     exceptions: {
       read: true,
-      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./"],
+      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./", "~/Library/Caches/Yarn"],
       run: false,
       net: true,
     },


### PR DESCRIPTION
Adds cache directory to allowed directories for Yarn on MacOS.