### PR TITLE
Add `--lockfile-type` option to `phylum analyze`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -272,6 +272,12 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_name("group_name")
                         .help("Specify a group to use for analysis")
                         .requires("project"),
+                    Arg::new("lockfile-type")
+                        .short('t')
+                        .long("lockfile-type")
+                        .value_name("type")
+                        .help("The type of the lock file (default: auto)")
+                        .value_parser(PossibleValuesParser::new(parse::lockfile_types())),
                 ]),
         )
         .subcommand(

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
@@ -11,8 +10,7 @@ use phylum_types::types::package::{PackageDescriptor, PackageType};
 use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError};
-use crate::commands::parse::get_packages_from_lockfile;
-use crate::commands::{CommandResult, CommandValue, ExitCode};
+use crate::commands::{parse, CommandResult, CommandValue, ExitCode};
 use crate::config::{get_current_project, ProjectConfig};
 use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;
@@ -130,10 +128,11 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
 
         (project, group) = cli_project(api, matches).await?;
 
-        // Should never get here if `LOCKFILE` was not specified
-        let lockfile =
-            matches.get_one::<String>("LOCKFILE").ok_or_else(|| anyhow!("Lockfile not found"))?;
-        let res = get_packages_from_lockfile(Path::new(lockfile))
+        let lockfile_type = matches.get_one::<String>("lockfile-type");
+        // LOCKFILE is a required parameter, so .unwrap() is safe.
+        let lockfile = matches.get_one::<String>("LOCKFILE").unwrap();
+
+        let res = parse::parse_lockfile(lockfile, lockfile_type)
             .context("Unable to locate any valid package in package lockfile")?;
 
         if pretty_print {

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -136,7 +136,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
             .context("Unable to locate any valid package in package lockfile")?;
 
         if pretty_print {
-            print_user_success!("Succesfully parsed lockfile as type: {}", res.format.name());
+            print_user_success!("Successfully parsed lockfile as type: {}", res.format.name());
         }
 
         packages = res.packages;

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -39,7 +39,7 @@ pub fn parse_lockfile(
 ) -> Result<ParsedLockfile> {
     // Try and determine lockfile format.
     let format = lockfile_type
-        .filter(|path| !path.eq_ignore_ascii_case("auto"))
+        .filter(|lockfile_type| lockfile_type != &"auto")
         .map(|lockfile_type| lockfile_type.parse::<LockfileFormat>().unwrap())
         .or_else(|| get_path_format(path.as_ref()));
 

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -21,25 +21,45 @@ pub fn lockfile_types() -> Vec<&'static str> {
 }
 
 pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
-    let auto_type = String::from("auto");
-    let lockfile_type = matches.get_one::<String>("lockfile-type").unwrap_or(&auto_type);
-    // LOCKFILE is a required parameter, so .unwrap() should be safe.
+    let lockfile_type = matches.get_one::<String>("lockfile-type");
+    // LOCKFILE is a required parameter, so .unwrap() is safe.
     let lockfile = matches.get_one::<String>("LOCKFILE").unwrap();
 
-    let pkgs = if lockfile_type == &auto_type {
-        let parsed = try_get_packages(Path::new(lockfile))?;
-        parsed.packages
-    } else {
-        let parser = lockfile_type.parse::<LockfileFormat>().unwrap().parser();
-
-        let data = read_to_string(lockfile)?;
-        parser.parse(&data)?
-    };
+    let pkgs = parse_lockfile(lockfile, lockfile_type)?.packages;
 
     serde_json::to_writer_pretty(&mut io::stdout(), &pkgs)?;
 
     Ok(ExitCode::Ok.into())
 }
+
+/// Parse a package lockfile.
+pub fn parse_lockfile(
+    path: impl AsRef<Path>,
+    lockfile_type: Option<&String>,
+) -> Result<ParsedLockfile> {
+    // Try and determine lockfile format.
+    let format = lockfile_type
+        .filter(|path| path.eq_ignore_ascii_case("auto"))
+        .map(|lockfile_type| lockfile_type.parse::<LockfileFormat>().unwrap())
+        .or_else(|| get_path_format(path.as_ref()));
+
+    match format {
+        // Parse with identified parser.
+        Some(format) => {
+            let data = read_to_string(path)?;
+            let parser = format.parser();
+
+            Ok(ParsedLockfile {
+                format,
+                packages: parser.parse(&data)?,
+                package_type: parser.package_type(),
+            })
+        },
+        // Attempt to parse with all parsers until success.
+        None => try_get_packages(path.as_ref()),
+    }
+}
+
 /// Attempt to get packages from an unknown lockfile type
 fn try_get_packages(path: &Path) -> Result<ParsedLockfile> {
     let data = read_to_string(path)?;
@@ -59,33 +79,6 @@ fn try_get_packages(path: &Path) -> Result<ParsedLockfile> {
     }
 
     Err(anyhow!("Failed to identify lockfile type"))
-}
-
-/// Determine the lockfile type based on its name and parse
-/// accordingly to obtain the packages from it
-pub fn get_packages_from_lockfile(path: &Path) -> Result<ParsedLockfile> {
-    let res = match get_path_format(path) {
-        Some(format) => {
-            let data = read_to_string(path)?;
-            let parser = format.parser();
-            ParsedLockfile {
-                format,
-                packages: parser.parse(&data)?,
-                package_type: parser.package_type(),
-            }
-        },
-        None => {
-            log::warn!(
-                "Attempting to obtain packages from unrecognized lockfile type: {}",
-                path.display()
-            );
-            try_get_packages(path)?
-        },
-    };
-
-    log::debug!("Read {} packages from file `{}`", res.packages.len(), path.display());
-
-    Ok(res)
 }
 
 #[cfg(test)]

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -39,7 +39,7 @@ pub fn parse_lockfile(
 ) -> Result<ParsedLockfile> {
     // Try and determine lockfile format.
     let format = lockfile_type
-        .filter(|path| path.eq_ignore_ascii_case("auto"))
+        .filter(|path| !path.eq_ignore_ascii_case("auto"))
         .map(|lockfile_type| lockfile_type.parse::<LockfileFormat>().unwrap())
         .or_else(|| get_path_format(path.as_ref()));
 

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -32,6 +32,9 @@ phylum analyze [OPTIONS] <lockfile>
 `-v`, `--verbose`
 &emsp; Increase verbosity of API response
 
+`-t`, `--lockfile-type`
+&emsp; The type of the lockfile (default: `auto`): `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `auto`
+
 ### Examples
 
 ```sh


### PR DESCRIPTION
This patch unifies the lockfile parser and enables passing the desired
lockfile for all subcommands requiring lockfile parsing as an optional
parameter.

Closes #794.