### PR TITLE
Add `phylum init` subcommand

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -349,6 +349,20 @@ pub fn add_subcommands(command: Command) -> Command {
                     ),
                 ),
         )
+        .subcommand(
+            Command::new("init")
+                .about("Setup a new Phylum project")
+                .args(&[
+                    Arg::new("project")
+                        .value_name("PROJECT_NAME")
+                        .help("Phylum project name"),
+                    Arg::new("group")
+                        .short('g')
+                        .long("group")
+                        .value_name("group_name")
+                        .help("Group which will be the owner of the project"),
+                ]),
+        )
         .subcommand(extensions::command());
 
     #[cfg(unix)]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -13,7 +13,8 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, extensions, group, jobs, packages, parse, project, CommandResult, CommandValue, ExitCode,
+    auth, extensions, group, init, jobs, packages, parse, project, CommandResult, CommandValue,
+    ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;
@@ -158,6 +159,7 @@ async fn handle_commands() -> CommandResult {
         "analyze" | "batch" => {
             jobs::handle_submission(&mut Spinner::wrap(api).await?, &matches).await
         },
+        "init" => init::handle_init(&mut Spinner::wrap(api).await?, sub_matches).await,
 
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use clap::ArgMatches;
 use dialoguer::theme::ColorfulTheme;
-use dialoguer::{Input, Confirm};
+use dialoguer::{Confirm, Input};
 
 use crate::api::PhylumApi;
 use crate::commands::{project, CommandResult};
@@ -36,10 +36,8 @@ fn prompt_project() -> io::Result<String> {
 
 // Ask for the desired group.
 fn prompt_group() -> io::Result<Option<String>> {
-    let should_prompt = Confirm::new()
-        .with_prompt("Use a project group?")
-        .default(false)
-        .interact()?;
+    let should_prompt =
+        Confirm::new().with_prompt("Use a project group?").default(false).interact()?;
 
     if !should_prompt {
         return Ok(None);

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -29,17 +29,7 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
     let cli_group = matches.get_one::<String>("group");
 
     // Interactively prompt for missing information.
-    let (project, group) = match cli_project {
-        Some(project) => (project.clone(), cli_group.cloned()),
-        None => {
-            let project = prompt_project()?;
-            let group = match cli_group {
-                Some(group) => Some(group.clone()),
-                None => prompt_group()?,
-            };
-            (project, group)
-        },
-    };
+    let (project, group) = prompt(cli_project, cli_group)?;
 
     // Attempt to create the project.
     let response = project::create_project(api, &project, group.clone()).await?;
@@ -51,6 +41,27 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
         },
         command_value => Ok(command_value),
     }
+}
+
+/// Interactively ask for missing information.
+fn prompt(
+    cli_project: Option<&String>,
+    cli_group: Option<&String>,
+) -> io::Result<(String, Option<String>)> {
+    if let Some(project) = cli_project {
+        return Ok((project.clone(), cli_group.cloned()));
+    }
+
+    // Prompt for project name.
+    let project = prompt_project()?;
+
+    // Prompt for group name.
+    let group = match cli_group {
+        Some(group) => Some(group.clone()),
+        None => prompt_group()?,
+    };
+
+    Ok((project, group))
 }
 
 /// Ask for the desired project name.

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,0 +1,53 @@
+//! Subcommand `phylum init`.
+
+use std::io;
+
+use clap::ArgMatches;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Input, Confirm};
+
+use crate::api::PhylumApi;
+use crate::commands::{project, CommandResult};
+
+/// Handle `phylum init` subcommand.
+pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+    let cli_project = matches.get_one::<String>("project");
+    let cli_group = matches.get_one::<String>("group");
+
+    let (project, group) = match cli_project {
+        Some(project) => (project.clone(), cli_group.cloned()),
+        None => {
+            let project = prompt_project()?;
+            let group = match cli_group {
+                Some(group) => Some(group.clone()),
+                None => prompt_group()?,
+            };
+            (project, group)
+        },
+    };
+
+    project::create_project(api, &project, group).await
+}
+
+/// Ask for the desired project name.
+fn prompt_project() -> io::Result<String> {
+    Input::with_theme(&ColorfulTheme::default()).with_prompt("Project Name").interact_text()
+}
+
+// Ask for the desired group.
+fn prompt_group() -> io::Result<Option<String>> {
+    let should_prompt = Confirm::new()
+        .with_prompt("Use a project group?")
+        .default(false)
+        .interact()?;
+
+    if !should_prompt {
+        return Ok(None);
+    }
+
+    let group: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Project Group (default: none)")
+        .interact_text()?;
+
+    Ok(Some(group))
+}

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,6 +1,6 @@
 //! Subcommand `phylum init`.
 
-use std::io;
+use std::{io, env};
 
 use clap::ArgMatches;
 use dialoguer::theme::ColorfulTheme;
@@ -40,7 +40,19 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
 
 /// Ask for the desired project name.
 fn prompt_project() -> io::Result<String> {
-    Input::with_theme(&ColorfulTheme::default()).with_prompt("Project Name").interact_text()
+    // Use directory name as default project name.
+    let current_dir = env::current_dir()?;
+    let default_name = current_dir.file_name().and_then(|name| name.to_str());
+
+    let theme = ColorfulTheme::default();
+    let mut prompt = Input::with_theme(&theme);
+    prompt.with_prompt("Project Name");
+
+    if let Some(default_name) = default_name {
+        prompt.default(default_name.to_owned());
+    }
+
+    prompt.interact_text()
 }
 
 // Ask for the desired group.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod project;
 pub mod sandbox;
 #[cfg(feature = "selfmanage")]
 pub mod uninstall;
+pub mod init;
 
 /// The possible result values of commands
 pub enum CommandValue {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub enum ExitCode {
     NoHistoryFound,
     JsError,
     FailedThresholds,
+    ProjectAlreadyInitialized,
     Custom(i32),
 }
 
@@ -67,6 +68,7 @@ impl From<&ExitCode> for i32 {
             ExitCode::AlreadyExists => 14,
             ExitCode::NoHistoryFound => 15,
             ExitCode::JsError => 16,
+            ExitCode::ProjectAlreadyInitialized => 17,
             ExitCode::FailedThresholds => 100,
             ExitCode::Custom(code) => *code,
         }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ use phylum_types::types::job::Action;
 pub mod auth;
 pub mod extensions;
 pub mod group;
+pub mod init;
 pub mod jobs;
 pub mod packages;
 pub mod parse;
@@ -13,7 +14,6 @@ pub mod project;
 pub mod sandbox;
 #[cfg(feature = "selfmanage")]
 pub mod uninstall;
-pub mod init;
 
 /// The possible result values of commands
 pub enum CommandValue {

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -187,7 +187,11 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 }
 
 /// Create and update the Phylum project.
-pub async fn create_project(api: &PhylumApi, project: &str, group: Option<String>) -> CommandResult {
+pub async fn create_project(
+    api: &PhylumApi,
+    project: &str,
+    group: Option<String>,
+) -> CommandResult {
     let project_id = match api.create_project(project, group.as_deref()).await {
         Ok(project_id) => project_id,
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -216,3 +216,27 @@ pub async fn create_project(
 
     Ok(ExitCode::Ok.into())
 }
+
+/// Link to an existing project.
+pub async fn link_project(api: &PhylumApi, project: &str, group: Option<String>) -> CommandResult {
+    let uuid = api
+        .get_project_id(project, group.as_deref())
+        .await
+        .context("A project with that name does not exist")?;
+
+    let project_config = ProjectConfig {
+        id: uuid,
+        name: project.into(),
+        created_at: Local::now(),
+        group_name: group,
+    };
+    save_config(Path::new(PROJ_CONF_FILE), &project_config)
+        .unwrap_or_else(|err| log::error!("Failed to save user credentials to config: {}", err));
+
+    print_user_success!(
+        "Linked the current working directory to the project {}.",
+        format!("{}", style(project_config.name).white())
+    );
+
+    Ok(ExitCode::Ok.into())
+}

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -37,27 +37,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         log::info!("Initializing new project: `{}`", name);
 
-        let project_id = match api.create_project(name, group.as_deref()).await {
-            Ok(project_id) => project_id,
-            Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-                print_user_failure!("Project '{}' already exists", name);
-                return Ok(ExitCode::AlreadyExists.into());
-            },
-            Err(err) => return Err(err.into()),
-        };
-
-        let proj_conf = ProjectConfig {
-            id: project_id.to_owned(),
-            created_at: Local::now(),
-            group_name: group,
-            name: name.to_owned(),
-        };
-
-        save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
-            print_user_failure!("Failed to save project file: {}", err);
-        });
-
-        print_user_success!("Successfully created new project, {}", name);
+        return create_project(api, name, group).await;
     } else if let Some(matches) = matches.subcommand_matches("delete") {
         let project_name = matches.get_one::<String>("name").unwrap();
         let group_name = matches.get_one::<String>("group");
@@ -202,6 +182,33 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         let group = matches.get_one::<String>("group");
         get_project_list(api, pretty_print, group.map(String::as_str)).await?;
     }
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Create and update the Phylum project.
+pub async fn create_project(api: &PhylumApi, project: &str, group: Option<String>) -> CommandResult {
+    let project_id = match api.create_project(project, group.as_deref()).await {
+        Ok(project_id) => project_id,
+        Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
+            print_user_failure!("Project '{}' already exists", project);
+            return Ok(ExitCode::AlreadyExists.into());
+        },
+        Err(err) => return Err(err.into()),
+    };
+
+    let proj_conf = ProjectConfig {
+        id: project_id.to_owned(),
+        created_at: Local::now(),
+        group_name: group,
+        name: project.to_owned(),
+    };
+
+    save_config(Path::new(PROJ_CONF_FILE), &proj_conf).unwrap_or_else(|err| {
+        print_user_failure!("Failed to save project file: {}", err);
+    });
+
+    print_user_success!("Successfully created new project, {}", project);
 
     Ok(ExitCode::Ok.into())
 }

--- a/cli/src/histogram.rs
+++ b/cli/src/histogram.rs
@@ -31,7 +31,7 @@ impl Histogram {
             }
 
             if bucket_id < values.len() {
-                values[bucket_id as usize] += 1;
+                values[bucket_id] += 1;
             }
         }
         Histogram { min, max, bins, values }

--- a/cli/src/prompt.rs
+++ b/cli/src/prompt.rs
@@ -32,7 +32,6 @@ pub fn prompt_threshold(name: &str) -> Result<Threshold, std::io::Error> {
                 Err("Threshold must be a number between 0-100 or 'Disabled'".into())
             }
         })
-        .report(true)
         .interact_text()?;
 
     if threshold.eq_ignore_ascii_case("disabled") {

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -1,0 +1,34 @@
+---
+title: phylum init
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Setup a new Phylum project
+
+```sh
+phylum init [OPTIONS] [PROJECT_NAME]
+```
+
+### Arguments
+
+`[PROJECT_NAME]`
+&emsp; Phylum project name
+
+### Options
+
+`-g`, `--group <group_name>`
+&emsp; Group which will be the owner of the project
+
+### Examples
+
+```sh
+# Interactively initialize the Phylum project.
+$ phylum init
+
+# Create the `demo` project without interactivity or associated group.
+$ phylum init demo
+
+# Create the `demo` project without interactivity for the group `users`.
+$ phylum init demo --group users
+```


### PR DESCRIPTION
This adds a new subcommand for setting up a new Phylum project.

Currently this command will only negotiate the desired project name and corresponding group, but further information like lockfile can be detected in the future.

Project and group can either be specified directly in the CLI, or specified interactively.

The user is not prompted for a group name when passing the project name on the CLI, to enable non-interactive usage without passing extra CLI flags. So in this scenario a group must be specified with `--group`.

Closes #795.