### PR TITLE
update phylum-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#60bd7fbd04a6303764e6225f8e16e6169ea1ebd1"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#138ab11a4db60313adea6cc9cbd57a3731c7eb4a"
 dependencies = [
  "chrono",
  "schemars",


### PR DESCRIPTION
update phylum-types to support "phylum package -t cargo" previously it was expecting -t rust, which is inconsistent with the rest of the options, and inconsistent with the help description. 

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
