### PR TITLE
Add lockfile path and type to .phylum_project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "tempfile",
  "zeroize",
 ]
@@ -1887,6 +1888,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -4833,6 +4843,15 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "^0.4", default-features = false, features = ["serde", "clo
 cidr = "0.2.0"
 clap = { version = "4.0.9", features = ["string", "wrap_help"] }
 console = "0.15.2"
-dialoguer = "0.10.0"
+dialoguer = { version = "0.10.0", features = ["fuzzy-select"] }
 env_logger = "0.9.0"
 futures = "^0.3"
 git-version = "0.3.5"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -357,8 +357,18 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("group")
                         .short('g')
                         .long("group")
-                        .value_name("group_name")
+                        .value_name("GROUP_NAME")
                         .help("Group which will be the owner of the project"),
+                    Arg::new("lockfile")
+                        .short('l')
+                        .long("lockfile")
+                        .value_name("LOCKFILE")
+                        .help("Project lockfile name"),
+                    Arg::new("lockfile-type")
+                        .short('t')
+                        .long("lockfile-type")
+                        .value_name("LOCKFILE_TYPE")
+                        .help("Project lockfile type"),
                 ]),
         )
         .subcommand(extensions::command());

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -227,8 +227,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("LOCKFILE")
                     .value_name("LOCKFILE")
                     .value_hint(ValueHint::FilePath)
-                    .help("The package lock file to submit.")
-                    .required(true),
+                    .help("The package lock file to submit."),
                 Arg::new("lockfile-type")
                     .short('t')
                     .long("lockfile-type")
@@ -244,8 +243,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("LOCKFILE")
                         .value_name("LOCKFILE")
                         .value_hint(ValueHint::FilePath)
-                        .help("The package lock file to submit.")
-                        .required(true),
+                        .help("The package lock file to submit."),
                     Arg::new("force").action(ArgAction::SetTrue).short('F').long("force").help(
                         "Force re-processing of packages (even if they already exist in the \
                          system)",

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -369,6 +369,11 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("lockfile-type")
                         .value_name("LOCKFILE_TYPE")
                         .help("Project lockfile type"),
+                    Arg::new("force")
+                        .short('f')
+                        .long("force")
+                        .help("Overwrite existing configurations without confirmation")
+                        .action(ArgAction::SetTrue),
                 ]),
         )
         .subcommand(extensions::command());

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -355,7 +355,7 @@ async fn parse_lockfile(
     }
 
     // Attempt to parse as requested lockfile type.
-    let parsed = parse::parse_lockfile(lockfile, lockfile_type.as_ref())?;
+    let parsed = parse::parse_lockfile(lockfile, lockfile_type.as_deref())?;
 
     Ok(PackageLock {
         package_type: parsed.package_type,

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -17,7 +17,7 @@ use crate::{config, print_user_success, print_user_warning};
 /// Handle `phylum init` subcommand.
 pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     // Prompt for confirmation if there already is a linked project.
-    if config::get_current_project().is_some() {
+    if !matches.get_flag("force") && config::get_current_project().is_some() {
         print_user_warning!("Workspace is already linked to a Phylum project");
         let should_continue = Confirm::new()
             .with_prompt("Overwrite existing project configuration?")

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,14 +1,18 @@
 //! Subcommand `phylum init`.
 
-use std::{env, io};
+use std::path::Path;
+use std::{env, fs, io};
 
+use anyhow::Context;
 use clap::ArgMatches;
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::{Confirm, Input};
+use dialoguer::{Confirm, FuzzySelect, Input};
+use phylum_lockfile::LockfileFormat;
+use reqwest::StatusCode;
 
-use crate::api::PhylumApi;
-use crate::commands::{project, CommandResult, CommandValue, ExitCode};
-use crate::{config, print_user_warning};
+use crate::api::{PhylumApi, PhylumApiError, ResponseError};
+use crate::commands::{project, CommandResult, ExitCode};
+use crate::config::PROJ_CONF_FILE;
+use crate::{config, print_user_failure, print_user_success, print_user_warning};
 
 /// Handle `phylum init` subcommand.
 pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
@@ -32,15 +36,32 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
     let (project, group) = prompt(cli_project, cli_group)?;
 
     // Attempt to create the project.
-    let response = project::create_project(api, &project, group.clone()).await?;
+    let result = project::create_project(api, &project, group.clone()).await;
 
     // If project already exists, just link to it.
-    match response {
-        CommandValue::Code(ExitCode::AlreadyExists) => {
-            project::link_project(api, &project, group).await
+    let mut project_config = match result {
+        Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
+            print_user_success!("Successfully linked to project {project:?}");
+            project::link_project(api, &project, group).await.context("Unable to link project")?
         },
-        command_value => Ok(command_value),
-    }
+        project_config => {
+            if project_config.is_ok() {
+                print_user_success!("Successfully created project {project:?}");
+            }
+            project_config.context("Unable to create project")?
+        },
+    };
+
+    // Add lockfile to project config.
+    println!();
+    project_config.lockfile = Some(prompt_lockfile()?);
+
+    // Save project config.
+    config::save_config(Path::new(PROJ_CONF_FILE), &project_config).unwrap_or_else(|err| {
+        print_user_failure!("Failed to save project file: {}", err);
+    });
+
+    Ok(ExitCode::Ok.into())
 }
 
 /// Interactively ask for missing information.
@@ -70,8 +91,7 @@ fn prompt_project() -> io::Result<String> {
     let current_dir = env::current_dir()?;
     let default_name = current_dir.file_name().and_then(|name| name.to_str());
 
-    let theme = ColorfulTheme::default();
-    let mut prompt = Input::with_theme(&theme);
+    let mut prompt = Input::new();
     prompt.with_prompt("Project Name");
 
     if let Some(default_name) = default_name {
@@ -81,7 +101,7 @@ fn prompt_project() -> io::Result<String> {
     prompt.interact_text()
 }
 
-// Ask for the desired group.
+/// Ask for the desired group.
 fn prompt_group() -> io::Result<Option<String>> {
     let should_prompt =
         Confirm::new().with_prompt("Use a project group?").default(false).interact()?;
@@ -90,9 +110,41 @@ fn prompt_group() -> io::Result<Option<String>> {
         return Ok(None);
     }
 
-    let group: String = Input::with_theme(&ColorfulTheme::default())
-        .with_prompt("Project Group (default: none)")
-        .interact_text()?;
+    let group: String =
+        Input::new().with_prompt("Project Group (default: none)").interact_text()?;
 
     Ok(Some(group))
+}
+
+/// Ask for the lockfile path.
+fn prompt_lockfile() -> io::Result<String> {
+    // Find all known lockfiles in the currenty directory.
+    let mut lockfiles: Vec<_> = fs::read_dir("./")?
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            LockfileFormat::iter().any(|format| format.parser().is_path_lockfile(&entry.path()))
+        })
+        .flat_map(|entry| entry.file_name().to_str().map(str::to_owned))
+        .collect();
+
+    // Prompt if a lockfile was found.
+    if !lockfiles.is_empty() {
+        // Add choice to specify an unknown lockfile.
+        lockfiles.push(String::from("other"));
+
+        // Ask user for lockfile.
+        let index = FuzzySelect::new()
+            .with_prompt("Select your project's lockfile")
+            .items(&lockfiles)
+            .interact()?;
+
+        // Return selected lockfile unless `other` was chosen.
+        if index + 1 != lockfiles.len() {
+            return Ok(lockfiles.remove(index));
+        }
+    }
+
+    // Prompt for lockfile name if none was selected.
+    Input::new().with_prompt("Project lockfile name").interact_text()
 }

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -236,10 +236,9 @@ impl JobsProject {
         // Pick lockfile path from CLI and fallback to the current project.
         let (lockfile, lockfile_type) = match (cli_lockfile, &current_project) {
             (Some(cli_lockfile), _) => (cli_lockfile.clone(), cli_lockfile_type.cloned()),
-            (None, Some(ProjectConfig { lockfile: Some(lockfile), lockfile_type, .. })) => (
-                lockfile.clone(),
-                lockfile_type.map(|lockfile_type| lockfile_type.name().to_owned()),
-            ),
+            (None, Some(ProjectConfig { lockfile: Some(lockfile), lockfile_type, .. })) => {
+                (lockfile.clone(), lockfile_type.clone())
+            },
             (None, _) => return Err(anyhow!("Missing lockfile parameter")),
         };
 

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -114,8 +114,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
     let mut display_filter = None;
     let mut action = Action::None;
     let is_user; // is a user (non-batch) request
-    let project;
-    let group;
+    let jobs_project;
     let label;
 
     if let Some(matches) = matches.subcommand_matches("analyze") {
@@ -126,14 +125,11 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         is_user = !matches.get_flag("force");
         synch = true;
 
-        (project, group) = cli_project(api, matches).await?;
+        jobs_project = JobsProject::new(api, matches).await?;
 
-        let lockfile_type = matches.get_one::<String>("lockfile-type");
-        // LOCKFILE is a required parameter, so .unwrap() is safe.
-        let lockfile = matches.get_one::<String>("LOCKFILE").unwrap();
-
-        let res = parse::parse_lockfile(lockfile, lockfile_type)
-            .context("Unable to locate any valid package in package lockfile")?;
+        let res =
+            parse::parse_lockfile(jobs_project.lockfile, jobs_project.lockfile_type.as_deref())
+                .context("Unable to locate any valid package in package lockfile")?;
 
         if pretty_print {
             print_user_success!("Successfully parsed lockfile as type: {}", res.format.name());
@@ -142,7 +138,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         packages = res.packages;
         request_type = res.package_type;
     } else if let Some(matches) = matches.subcommand_matches("batch") {
-        (project, group) = cli_project(api, matches).await?;
+        jobs_project = JobsProject::new(api, matches).await?;
 
         let mut eof = false;
         let mut line = String::new();
@@ -200,9 +196,9 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
             &request_type,
             &packages,
             is_user,
-            project,
+            jobs_project.project_id,
             label.map(String::from),
-            group.map(String::from),
+            jobs_project.group,
         )
         .await?;
     log::debug!("Response => {:?}", job_id);
@@ -218,26 +214,59 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
     Ok(CommandValue::Action(action))
 }
 
-/// Get the current project.
-///
-/// Assumes that the clap `matches` has a `project` and `group` arguments
-/// option.
-async fn cli_project(
-    api: &mut PhylumApi,
-    matches: &clap::ArgMatches,
-) -> Result<(ProjectId, Option<String>)> {
-    // Prefer `--project` and `--group` if they were specified.
-    if let Some(project_name) = matches.get_one::<String>("project") {
-        let group = matches.get_one::<String>("group").cloned();
-        let project = api.get_project_id(project_name, group.as_deref()).await?;
-        return Ok((project, group));
-    }
+/// Project information for analyze/batch.
+struct JobsProject {
+    project_id: ProjectId,
+    group: Option<String>,
+    lockfile: String,
+    lockfile_type: Option<String>,
+}
 
-    // Retrieve the project from the `.phylum_project` file.
-    get_current_project().map(|p: ProjectConfig| (p.id, p.group_name)).ok_or_else(|| {
-        anyhow!(
-            "Failed to find a valid project configuration. Specify an existing project using the \
-             `--project` flag, or create a new one with `phylum project create <name>`"
-        )
-    })
+impl JobsProject {
+    /// Get the current project.
+    ///
+    /// Assumes that the clap `matches` has a `project` and `group` arguments
+    /// option.
+    async fn new(api: &mut PhylumApi, matches: &clap::ArgMatches) -> Result<JobsProject> {
+        let cli_lockfile_type = matches.try_get_one::<String>("lockfile-type").ok().flatten();
+        let cli_lockfile = matches.try_get_one::<String>("LOCKFILE").ok().flatten();
+
+        let current_project = get_current_project();
+
+        // Pick lockfile path from CLI and fallback to the current project.
+        let (lockfile, lockfile_type) = match (cli_lockfile, &current_project) {
+            (Some(cli_lockfile), _) => (cli_lockfile.clone(), cli_lockfile_type.cloned()),
+            (None, Some(ProjectConfig { lockfile: Some(lockfile), lockfile_type, .. })) => (
+                lockfile.clone(),
+                lockfile_type.map(|lockfile_type| lockfile_type.name().to_owned()),
+            ),
+            (None, _) => return Err(anyhow!("Missing lockfile parameter")),
+        };
+
+        match matches.get_one::<String>("project") {
+            // Prefer `--project` and `--group` if they were specified.
+            Some(project_name) => {
+                let group = matches.get_one::<String>("group").cloned();
+                let project = api.get_project_id(project_name, group.as_deref()).await?;
+                Ok(Self { project_id: project, group, lockfile, lockfile_type })
+            },
+            // Retrieve the project from the `.phylum_project` file.
+            None => {
+                let current_project = current_project.ok_or_else(|| {
+                    anyhow!(
+                        "Failed to find a valid project configuration. Specify an existing \
+                         project using the `--project` flag, or create a new one with `phylum \
+                         project create <name>`"
+                    )
+                })?;
+
+                Ok(Self {
+                    project_id: current_project.id,
+                    group: current_project.group_name,
+                    lockfile,
+                    lockfile_type,
+                })
+            },
+        }
+    }
 }

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -29,14 +29,14 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 
     // Pick lockfile path from CLI and fallback to the current project.
     let (lockfile, lockfile_type) = match (cli_lockfile, &current_project) {
-        (Some(cli_lockfile), _) => (cli_lockfile, cli_lockfile_type.map(String::as_str)),
+        (Some(cli_lockfile), _) => (cli_lockfile, cli_lockfile_type),
         (None, Some(ProjectConfig { lockfile: Some(lockfile), lockfile_type, .. })) => {
-            (lockfile, lockfile_type.map(|lockfile_type| lockfile_type.name()))
+            (lockfile, lockfile_type.as_ref())
         },
         (None, _) => return Err(anyhow!("Missing lockfile parameter")),
     };
 
-    let pkgs = parse_lockfile(lockfile, lockfile_type)?.packages;
+    let pkgs = parse_lockfile(lockfile, lockfile_type.map(|t| &**t))?.packages;
 
     serde_json::to_writer_pretty(&mut io::stdout(), &pkgs)?;
 

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -9,6 +9,7 @@ use phylum_lockfile::{get_path_format, LockfileFormat};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 
 use crate::commands::{CommandResult, ExitCode};
+use crate::config::{self, ProjectConfig};
 
 pub struct ParsedLockfile {
     pub format: LockfileFormat,
@@ -21,9 +22,19 @@ pub fn lockfile_types() -> Vec<&'static str> {
 }
 
 pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
-    let lockfile_type = matches.get_one::<String>("lockfile-type");
-    // LOCKFILE is a required parameter, so .unwrap() is safe.
-    let lockfile = matches.get_one::<String>("LOCKFILE").unwrap();
+    let cli_lockfile_type = matches.get_one::<String>("lockfile-type");
+    let cli_lockfile = matches.get_one::<String>("LOCKFILE");
+
+    let current_project = config::get_current_project();
+
+    // Pick lockfile path from CLI and fallback to the current project.
+    let (lockfile, lockfile_type) = match (cli_lockfile, &current_project) {
+        (Some(cli_lockfile), _) => (cli_lockfile, cli_lockfile_type.map(String::as_str)),
+        (None, Some(ProjectConfig { lockfile: Some(lockfile), lockfile_type, .. })) => {
+            (lockfile, lockfile_type.map(|lockfile_type| lockfile_type.name()))
+        },
+        (None, _) => return Err(anyhow!("Missing lockfile parameter")),
+    };
 
     let pkgs = parse_lockfile(lockfile, lockfile_type)?.packages;
 
@@ -35,7 +46,7 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 /// Parse a package lockfile.
 pub fn parse_lockfile(
     path: impl AsRef<Path>,
-    lockfile_type: Option<&String>,
+    lockfile_type: Option<&str>,
 ) -> Result<ParsedLockfile> {
     // Try and determine lockfile format.
     let format = lockfile_type

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -9,6 +9,7 @@ use std::{env, fs};
 
 use anyhow::Result;
 use chrono::{DateTime, Local};
+use phylum_lockfile::LockfileFormat;
 use phylum_types::types::auth::RefreshToken;
 use phylum_types::types::common::ProjectId;
 use phylum_types::types::package::PackageType;
@@ -96,6 +97,8 @@ pub struct ProjectConfig {
     pub name: String,
     pub created_at: DateTime<Local>,
     pub group_name: Option<String>,
+    pub lockfile: Option<String>,
+    pub lockfile_type: Option<LockfileFormat>,
 }
 
 /// Create or open a file. If the file is created, it will restrict permissions

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -9,7 +9,6 @@ use std::{env, fs};
 
 use anyhow::Result;
 use chrono::{DateTime, Local};
-use phylum_lockfile::LockfileFormat;
 use phylum_types::types::auth::RefreshToken;
 use phylum_types::types::common::ProjectId;
 use phylum_types::types::package::PackageType;
@@ -98,7 +97,7 @@ pub struct ProjectConfig {
     pub created_at: DateTime<Local>,
     pub group_name: Option<String>,
     pub lockfile: Option<String>,
-    pub lockfile_type: Option<LockfileFormat>,
+    pub lockfile_type: Option<String>,
 }
 
 /// Create or open a file. If the file is created, it will restrict permissions

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -7,10 +7,11 @@ hidden: false
 Submit a request for analysis to the processing system
 
 ```sh
-phylum analyze [OPTIONS] <lockfile>
+phylum analyze [OPTIONS] [LOCKFILE]
 ```
 
 ### Options
+
 `-F`, `--force`
 &emsp; Force re-processing of packages (even if they already exist in the system)
 

--- a/docs/command_line_tool/phylum_parse.md
+++ b/docs/command_line_tool/phylum_parse.md
@@ -3,16 +3,20 @@ title: phylum parse
 category: 6255e67693d5200013b1fa3e
 hidden: false
 ---
+
 Parse a lockfile and output the packages as JSON
+
 ```sh
-phylum parse [OPTIONS] <LOCKFILE>
+phylum parse [OPTIONS] [LOCKFILE]
 ```
 
 ### Options
+
 `-t`, `--lockfile-type`
 &emsp; The type of the lockfile (default: `auto`): `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `auto`
 
 ### Examples
+
 ```sh
 # Parse a lockfile
 $ phylum parse -t npm package-lock.json

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -123,7 +123,7 @@ mod cli_args_test {
         let dst = project_root().join("target").join("tmp");
         std::fs::remove_dir_all(&dst).ok();
         std::fs::create_dir_all(&dst).ok();
-        fs_extra::dir::copy(&src, &dst, &fs_extra::dir::CopyOptions::new())?;
+        fs_extra::dir::copy(src, &dst, &fs_extra::dir::CopyOptions::new())?;
         Ok(())
     }
 


### PR DESCRIPTION
This patch extends the existing .phylum_project with two new optional
fields: `lockfile` and `lockfile_type`.

When the `lockfile` type is present in the .phylum_project file and no
lockfile override is specified on the CLI, then the project file from
the .phylum_project file will be used with the lockfile type specified
in the same file.

If the lockfile type is specified on the CLI without the lockfile being
specified, it will be ignored.

The lockfile name and type can be set when running `phylum init`, either
by passing `--lockfile` and (optionally) `--lockfile-type`, or by
specifying them interactively.

Closes https://github.com/phylum-dev/cli/issues/793.