### PR TITLE
Add group member management subcommands

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -98,6 +98,20 @@ pub fn group_project_summary(api_uri: &str, group: &str) -> Result<Url, BaseUriE
     Ok(url)
 }
 
+/// POST/DELETE /groups/<groupName>/members/<userEmail>
+pub fn group_usermod(api_uri: &str, group: &str, user: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group, "members", user]);
+    Ok(url)
+}
+
+/// GET /groups/<groupName>/members
+pub fn group_members(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group, "members"]);
+    Ok(url)
+}
+
 /// GET /.well-known/openid-configuration
 pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/openid-configuration")?)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -347,7 +347,49 @@ pub fn add_subcommands(command: Command) -> Command {
                             .help("Name for the new group")
                             .required(true),
                     ),
-                ),
+                )
+                .subcommand(
+                    Command::new("members").about("List group members").args(&[
+                        Arg::new("group")
+                            .short('g')
+                            .long("group")
+                            .value_name("GROUP")
+                            .help("Group to list the members for")
+                            .required(true),
+                        Arg::new("json")
+                            .action(ArgAction::SetTrue)
+                            .short('j')
+                            .long("json")
+                            .help("Produce group list in json format (default: false)"),
+                        ])
+                    .subcommand(
+                        Command::new("list").about("List all existing projects").args(&[
+                            Arg::new("json")
+                                .action(ArgAction::SetTrue)
+                                .short('j')
+                                .long("json")
+                                .help("Produce output in json format (default: false)"),
+                        ]),
+                    )
+                    .subcommand(
+                        Command::new("add").about("Add user to group").args(&[
+                            Arg::new("user")
+                                .value_name("USER")
+                                .help("User to be added")
+                                .action(ArgAction::Append)
+                                .required(true),
+                        ]),
+                    )
+                    .subcommand(
+                        Command::new("remove").about("Remove user from group").args(&[
+                            Arg::new("user")
+                                .value_name("USER")
+                                .help("User(s) to be removed")
+                                .action(ArgAction::Append)
+                                .required(true),
+                        ]),
+                    )
+                )
         )
         .subcommand(
             Command::new("init")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -360,7 +360,7 @@ pub fn add_subcommands(command: Command) -> Command {
                             .action(ArgAction::SetTrue)
                             .short('j')
                             .long("json")
-                            .help("Produce group list in json format (default: false)"),
+                            .help("Produce member list in json format (default: false)"),
                         ])
                     .subcommand(
                         Command::new("list").about("List group members").args(&[
@@ -368,7 +368,7 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .action(ArgAction::SetTrue)
                                 .short('j')
                                 .long("json")
-                                .help("Produce output in json format (default: false)"),
+                                .help("Produce member list in json format (default: false)"),
                         ]),
                     )
                     .subcommand(

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -349,7 +349,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     ),
                 )
                 .subcommand(
-                    Command::new("members").about("List group members").args(&[
+                    Command::new("member").about("Manage group members").args(&[
                         Arg::new("group")
                             .short('g')
                             .long("group")
@@ -363,7 +363,7 @@ pub fn add_subcommands(command: Command) -> Command {
                             .help("Produce group list in json format (default: false)"),
                         ])
                     .subcommand(
-                        Command::new("list").about("List all existing projects").args(&[
+                        Command::new("list").about("List group members").args(&[
                             Arg::new("json")
                                 .action(ArgAction::SetTrue)
                                 .short('j')
@@ -375,19 +375,22 @@ pub fn add_subcommands(command: Command) -> Command {
                         Command::new("add").about("Add user to group").args(&[
                             Arg::new("user")
                                 .value_name("USER")
-                                .help("User to be added")
+                                .help("User(s) to be added")
                                 .action(ArgAction::Append)
                                 .required(true),
                         ]),
                     )
                     .subcommand(
-                        Command::new("remove").about("Remove user from group").args(&[
-                            Arg::new("user")
-                                .value_name("USER")
-                                .help("User(s) to be removed")
-                                .action(ArgAction::Append)
-                                .required(true),
-                        ]),
+                        Command::new("remove")
+                            .alias("rm")
+                            .about("Remove user from group")
+                            .args(&[
+                                Arg::new("user")
+                                    .value_name("USER")
+                                    .help("User(s) to be removed")
+                                    .action(ArgAction::Append)
+                                    .required(true),
+                            ]),
                     )
                 )
         )

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -9,28 +9,96 @@ use crate::format::Format;
 use crate::{print_user_failure, print_user_success};
 
 /// Handle `phylum group` subcommand.
-pub async fn handle_group(api: &mut PhylumApi, mut matches: &ArgMatches) -> CommandResult {
+pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
-        let group_name = matches.get_one::<String>("group_name").unwrap();
-        match api.create_group(group_name).await {
-            Ok(response) => {
-                print_user_success!("Successfully created group {}", response.group_name);
-                Ok(ExitCode::Ok.into())
-            },
-            Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-                print_user_failure!("Group '{}' already exists", group_name);
-                Ok(ExitCode::AlreadyExists.into())
-            },
-            Err(err) => Err(err.into()),
+        handle_group_create(api, matches).await
+    } else if let Some(matches) = matches.subcommand_matches("members") {
+        let group = matches.get_one::<String>("group").unwrap();
+
+        if let Some(matches) = matches.subcommand_matches("add") {
+            handle_members_add(api, matches, group).await
+        } else if let Some(matches) = matches.subcommand_matches("remove") {
+            handle_members_remove(api, matches, group).await
+        } else {
+            handle_members_list(api, matches, group).await
         }
     } else {
-        matches = matches.subcommand_matches("list").unwrap_or(matches);
-
-        let response = api.get_groups_list().await?;
-
-        let pretty = !matches.get_flag("json");
-        response.write_stdout(pretty);
-
-        Ok(ExitCode::Ok.into())
+        handle_group_list(api, matches).await
     }
+}
+
+/// Handle `phylum group create` subcommand.
+pub async fn handle_group_create(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+    let group_name = matches.get_one::<String>("group_name").unwrap();
+    match api.create_group(group_name).await {
+        Ok(response) => {
+            print_user_success!("Successfully created group {}", response.group_name);
+            Ok(ExitCode::Ok.into())
+        },
+        Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
+            print_user_failure!("Group '{}' already exists", group_name);
+            Ok(ExitCode::AlreadyExists.into())
+        },
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Handle `phylum group list` subcommand.
+pub async fn handle_group_list(api: &mut PhylumApi, mut matches: &ArgMatches) -> CommandResult {
+    matches = matches.subcommand_matches("list").unwrap_or(matches);
+    let pretty = !matches.get_flag("json");
+
+    let response = api.get_groups_list().await?;
+
+    response.write_stdout(pretty);
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Handle `phylum group members add` subcommand.
+pub async fn handle_members_add(
+    api: &mut PhylumApi,
+    matches: &ArgMatches,
+    group: &str,
+) -> CommandResult {
+    let users = matches.get_many::<String>("user").unwrap();
+
+    for user in users {
+        api.group_add(group, user).await?;
+        print_user_success!("Successfully added {user:?} to group {group:?}");
+    }
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Handle `phylum group members remove` subcommand.
+pub async fn handle_members_remove(
+    api: &mut PhylumApi,
+    matches: &ArgMatches,
+    group: &str,
+) -> CommandResult {
+    let users = matches.get_many::<String>("user").unwrap();
+
+    for user in users {
+        api.group_remove(group, user).await?;
+        print_user_success!("Successfully removed {user:?} from group {group:?}");
+    }
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Handle `phylum group members` subcommand.
+pub async fn handle_members_list(
+    api: &mut PhylumApi,
+    mut matches: &ArgMatches,
+    group: &str,
+) -> CommandResult {
+    matches = matches.subcommand_matches("list").unwrap_or(matches);
+    let pretty = !matches.get_flag("json");
+
+    let response = api.group_members(group).await?;
+
+    response.write_stdout(pretty);
+
+    Ok(ExitCode::Ok.into())
 }

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -12,15 +12,15 @@ use crate::{print_user_failure, print_user_success};
 pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         handle_group_create(api, matches).await
-    } else if let Some(matches) = matches.subcommand_matches("members") {
+    } else if let Some(matches) = matches.subcommand_matches("member") {
         let group = matches.get_one::<String>("group").unwrap();
 
         if let Some(matches) = matches.subcommand_matches("add") {
-            handle_members_add(api, matches, group).await
+            handle_member_add(api, matches, group).await
         } else if let Some(matches) = matches.subcommand_matches("remove") {
-            handle_members_remove(api, matches, group).await
+            handle_member_remove(api, matches, group).await
         } else {
-            handle_members_list(api, matches, group).await
+            handle_member_list(api, matches, group).await
         }
     } else {
         handle_group_list(api, matches).await
@@ -55,8 +55,8 @@ pub async fn handle_group_list(api: &mut PhylumApi, mut matches: &ArgMatches) ->
     Ok(ExitCode::Ok.into())
 }
 
-/// Handle `phylum group members add` subcommand.
-pub async fn handle_members_add(
+/// Handle `phylum group member add` subcommand.
+pub async fn handle_member_add(
     api: &mut PhylumApi,
     matches: &ArgMatches,
     group: &str,
@@ -71,8 +71,8 @@ pub async fn handle_members_add(
     Ok(ExitCode::Ok.into())
 }
 
-/// Handle `phylum group members remove` subcommand.
-pub async fn handle_members_remove(
+/// Handle `phylum group member remove` subcommand.
+pub async fn handle_member_remove(
     api: &mut PhylumApi,
     matches: &ArgMatches,
     group: &str,
@@ -87,8 +87,8 @@ pub async fn handle_members_remove(
     Ok(ExitCode::Ok.into())
 }
 
-/// Handle `phylum group members` subcommand.
-pub async fn handle_members_list(
+/// Handle `phylum group member` subcommand.
+pub async fn handle_member_list(
     api: &mut PhylumApi,
     mut matches: &ArgMatches,
     group: &str,

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -4,7 +4,9 @@ use std::str::{self, FromStr};
 
 use chrono::NaiveDateTime;
 use console::style;
-use phylum_types::types::group::{ListUserGroupsResponse, UserGroup};
+use phylum_types::types::group::{
+    GroupMember, ListGroupMembersResponse, ListUserGroupsResponse, UserGroup,
+};
 use phylum_types::types::job::{AllJobsStatusResponse, JobDescriptor, JobStatusResponse};
 use phylum_types::types::package::{
     Issue, IssuesListItem, Package, PackageStatus, PackageStatusExtended, PackageType, RiskLevel,
@@ -66,6 +68,28 @@ impl Format for ListUserGroupsResponse {
             ("Group Name", |group| print::truncate(&group.group_name, MAX_NAME_WIDTH).into_owned()),
             ("Owner", |group| print::truncate(&group.owner_email, MAX_OWNER_WIDTH).into_owned()),
             ("Creation Time", |group| group.created_at.format("%FT%RZ").to_string()),
+        ]);
+        let _ = writeln!(writer, "{table}");
+    }
+}
+
+impl Format for ListGroupMembersResponse {
+    fn pretty<W: Write>(&self, writer: &mut W) {
+        // Maximum length of email column.
+        const MAX_EMAIL_WIDTH: usize = 25;
+        // Maximum length of first name column.
+        const MAX_FIRST_NAME_WIDTH: usize = 15;
+        // Maximum length of last name column.
+        const MAX_LAST_NAME_WIDTH: usize = 15;
+
+        let table = format_table::<fn(&GroupMember) -> String, _>(&self.members, &[
+            ("E-Mail", |member| print::truncate(&member.user_email, MAX_EMAIL_WIDTH).into_owned()),
+            ("First Name", |member| {
+                print::truncate(&member.first_name, MAX_FIRST_NAME_WIDTH).into_owned()
+            }),
+            ("Last Name", |member| {
+                print::truncate(&member.last_name, MAX_LAST_NAME_WIDTH).into_owned()
+            }),
         ]);
         let _ = writeln!(writer, "{table}");
     }

--- a/docs/command_line_tool/phylum_group.md
+++ b/docs/command_line_tool/phylum_group.md
@@ -11,14 +11,18 @@ phylum group [OPTIONS] [SUBCOMMAND]
 ```
 
 ### Options
+
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
 ### Commands
-* [phylum group create](https://docs.phylum.io/docs/phylum_group_create)
+
 * [phylum group list](https://docs.phylum.io/docs/phylum_group_list)
+* [phylum group create](https://docs.phylum.io/docs/phylum_group_create)
+* [phylum group member](https://docs.phylum.io/docs/phylum_group_member)
 
 ### Examples
+
 ```sh
 # List all groups for the current account
 $ phylum group

--- a/docs/command_line_tool/phylum_group_member.md
+++ b/docs/command_line_tool/phylum_group_member.md
@@ -1,0 +1,31 @@
+---
+title: phylum group member
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Manage group members
+
+```sh
+phylum group member [OPTIONS] --group <GROUP> [COMMAND]
+```
+
+### Options
+
+`-j`, `--json`
+&emsp; Produce member list in json format (default: false)
+
+`-g`, `--group <GROUP>`
+&emsp; Group to list the members for
+
+### Commands
+* [phylum group_member_list](https://docs.phylum.io/docs/phylum_group_member_list)
+* [phylum group_member_add](https://docs.phylum.io/docs/phylum_group_member_add)
+* [phylum group_member_remove](https://docs.phylum.io/docs/phylum_group_member_remove)
+
+### Examples
+
+```sh
+# List all group members for the 'sample' group
+$ phylum group member --group sample
+```

--- a/docs/command_line_tool/phylum_group_member_add.md
+++ b/docs/command_line_tool/phylum_group_member_add.md
@@ -1,0 +1,23 @@
+---
+title: phylum group member add
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Add user to group
+
+```sh
+phylum group member --group <GROUP> add [OPTIONS] <USER>...
+```
+
+### Arguments
+
+`<USER>`...
+&emsp; User(s) to be added
+
+### Examples
+
+```sh
+# Add user `demo@phylum.io` to the `sample` group
+$ phylum group member --group add demo@phylum.io
+```

--- a/docs/command_line_tool/phylum_group_member_list.md
+++ b/docs/command_line_tool/phylum_group_member_list.md
@@ -1,0 +1,23 @@
+---
+title: phylum group member list
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+List group members
+
+```sh
+phylum group member --group <GROUP> list [OPTIONS]
+```
+
+### Options
+
+`-j`, `--json`
+&emsp; Produce member list in json format (default: false)
+
+### Examples
+
+```sh
+# List all group members for the 'sample' group
+$ phylum group member --group sample list
+```

--- a/docs/command_line_tool/phylum_group_member_remove.md
+++ b/docs/command_line_tool/phylum_group_member_remove.md
@@ -1,0 +1,23 @@
+---
+title: phylum group member remove
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Remove user from group
+
+```sh
+phylum group member --group <GROUP> remove [OPTIONS] <USER>...
+```
+
+### Arguments
+
+`<USER>`...
+&emsp; User(s) to be removed
+
+### Examples
+
+```sh
+# Remove user `demo@phylum.io` from the `sample` group
+$ phylum group member --group remove demo@phylum.io
+```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -123,7 +123,7 @@ mod cli_args_test {
         let dst = project_root().join("target").join("tmp");
         std::fs::remove_dir_all(&dst).ok();
         std::fs::create_dir_all(&dst).ok();
-        fs_extra::dir::copy(&src, &dst, &fs_extra::dir::CopyOptions::new())?;
+        fs_extra::dir::copy(src, &dst, &fs_extra::dir::CopyOptions::new())?;
         Ok(())
     }
 


### PR DESCRIPTION
This patch adds the new `phylum group members` subcommand which has the additional `list`/`add`/`remove` subcommands. These allow managing and inspecting the users which are part of a group.

The `members`/`list` commands behave similarly to all our other commands, doing the same thing and just listing all members that are part of the specified group.

The group parameter is a required parameter for the `members` subcommand, which allows clap to provide helpful messages guiding the user to specify it in the correct location, rather than having to handle all possible locations internally.

Closes #810.
