### PR TITLE
Add lockfile CLI docs for `phylum init`

### DIFF
--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -17,8 +17,17 @@ phylum init [OPTIONS] [PROJECT_NAME]
 
 ### Options
 
-`-g`, `--group <group_name>`
+`-g`, `--group <GROUP_NAME>`
 &emsp; Group which will be the owner of the project
+
+`-l`, `--lockfile <LOCKFILE>`
+&emsp; Project lockfile name
+
+`-t`, `--lockfile-type <LOCKFILE_TYPE>`
+&emsp; Project lockfile type
+
+`-f`, `--force`
+&emsp; Overwrite existing configurations without confirmation
 
 ### Examples
 
@@ -26,9 +35,6 @@ phylum init [OPTIONS] [PROJECT_NAME]
 # Interactively initialize the Phylum project.
 $ phylum init
 
-# Create the `demo` project without interactivity or associated group.
-$ phylum init demo
-
-# Create the `demo` project without interactivity for the group `users`.
-$ phylum init demo --group users
+# Create the `demo` project with a yarn lockfile and no associated group.
+$ phylum init --lockfile yarn.lock --lockfile-type yarn demo
 ```


### PR DESCRIPTION
The d4d70a5 patch introduced changes to the `phylum init` CLI subcommand which were not appropriately documented in our website's documentation.

This patch fixes this and updates the docs to be up to date with the current `phylum init` command and its arguments.