### PR TITLE
Remove minisign artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - name: Install host dependencies
-        run: |
-          sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
-          sudo apt update
-          sudo apt install -yq minisign
-
       - name: Download release artifacts
         uses: actions/download-artifact@v3
         with:
@@ -142,16 +136,12 @@ jobs:
 
       - name: Sign archives
         run: |
-          echo -e $MINISIGN_KEY > minisign.key
           echo "$OPENSSL_KEY" > key.pem
           for archive in phylum-*.zip;
           do
-            echo $MINISIGN_PASSWORD | minisign -Sm ${archive} -s minisign.key -t 'Phylum - The Software Supply Chain Company'
             openssl dgst -sha256 -sign key.pem -out "${archive}.signature" "${archive}"
           done
         env:
-          MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
-          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
           OPENSSL_KEY: ${{ secrets.OPENSSL_KEY }}
 
       - name: Create GitHub release
@@ -163,7 +153,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             phylum-*.zip
-            phylum-*.zip.minisig
             phylum-*.zip.signature
 
   Trigger:

--- a/docs/command_line_tool/alternate_install.md
+++ b/docs/command_line_tool/alternate_install.md
@@ -38,7 +38,7 @@ phylum-init
 
 ## Install with curl
 
-This script requires `curl`, `mktemp`, `unzip`, and [`minisign`](https://jedisct1.github.io/minisign/):
+This script requires `curl`, `mktemp`, `unzip`, and `openssl`:
 
 ```sh
 curl https://sh.phylum.io/ | sh -


### PR DESCRIPTION
Remove `.minisig` files from future releases and close #738 

After a `grep -r minisig .`, I realized that I forgot to update the alternate install docs during the 2517c58 patch. So I have fixed that here as well.