### PR TITLE
Use release environment to protect repo secrets

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -30,7 +30,6 @@ jobs:
         if: ${{ steps.commit.outcome == 'success' }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
             github.rest.pulls.create({
               owner: context.repo.owner,
@@ -39,4 +38,11 @@ jobs:
               base: context.ref,
               title: "build: Bump Cargo.lock dependencies",
               body: "Bump dependencies in Cargo.lock for all SemVer-compatible updates.",
+            });
+
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.owner,
+              workflow_id: "test.yml",
+              ref: "auto-cargo-update"
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,30 +159,20 @@ jobs:
             phylum-*.zip
             phylum-*.zip.signature
 
-  Trigger:
-    name: Trigger phylum-ci Docker image creation
-    needs: Release
-    # Don't trigger for pre-releases
-    # NOTE: This is an instance where the expression syntax (`${{ }}`) is required for the `if` conditional,
-    #       contrary to the GitHub workflow syntax documentation. Do not remove the expression syntax.
-    if: ${{ !contains(github.ref, 'rc') }}
-    # The `--fail-with-body` option in `curl` was added in v7.76.0, which is too
-    # new for the `ubuntu-latest` runner that currently makes use of Ubuntu 20.04.
-    # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
-    #       https://github.com/phylum-dev/cli/issues/467
-    runs-on: ubuntu-22.04
-    steps:
       - name: Trigger phylum-ci Docker image creation
+        # Don't trigger for pre-releases
+        if: ${{ !contains(github.ref, 'rc') }}
         # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-        run: |
-          curl \
-            -X POST \
-            --fail-with-body \
-            --no-progress-meter \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GH_RELEASE_PAT }}" \
-            -d "{\"event_type\":\"build-push-docker-images\",\"client_payload\":{\"CLI_version\":\"$GITHUB_REF_NAME\"}}" \
-            https://api.github.com/repos/phylum-dev/phylum-ci/dispatches
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
+          script: |
+            github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: "build-push-docker-images",
+              client_payload: {CLI_version: process.env.GITHUB_REF_NAME},
+            });
 
   Update-Documentation:
     name: Update the documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,9 @@ jobs:
     needs: Build-Release-Artifacts
     # Only run this job when pushing a tag
     if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: release
+      url: ${{ steps.release.outputs.url }}
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
@@ -144,13 +147,14 @@ jobs:
         env:
           OPENSSL_KEY: ${{ secrets.OPENSSL_KEY }}
 
-      - name: Create GitHub release
+      - id: release
+        name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
           # This check is already filtered down to only 'refs/tags/' and shouldn't "overmatch"
           prerelease: ${{ contains(github.ref, 'rc') }}
           fail_on_unmatched_files: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           files: |
             phylum-*.zip
             phylum-*.zip.signature


### PR DESCRIPTION
This patch contains multiple changes that allow us to protect the `OPENSSL_KEY` and `GH_RELEASE_PAT` secrets by putting them in a GitHub environment named `release`.

Additional details for each change can be found in the respective commit messages.