### PR TITLE
Use plus suffix for git_version's cargo fallback

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 
 use crate::commands::{extensions, parse};
 
-const VERSION: &str = git_version!(args = ["--dirty=-modified", "--tags"], cargo_prefix = "cargo:");
+const VERSION: &str = git_version!(args = ["--dirty=-modified", "--tags"], cargo_suffix = "+");
 
 lazy_static! {
     pub static ref USER_AGENT: String = format!("{}/{}", env!("CARGO_PKG_NAME"), VERSION);


### PR DESCRIPTION
The cargo fallback is used when no git information is present (like when the source tarball is downloaded instead of cloning the repo).

The + suffix was chosen to indicate "something after version X".  For example, this would currently show "v3.12.1+" as the version, which is accurate.

This fixes #818. After this change, builds outside of git (including Homebrew) will look like so:
```
❯ phylum --version
phylum 3.12.1+

❯ phylum version  
✅ phylum (Version 3.12.1+)
Copyright (C) 2022  Phylum, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```