### PR TITLE
Fill out copyright notice in license templates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    phylum-cli, a command-line interface for the Phylum API
+    Copyright (C) 2022  Phylum, Inc.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    phylum-cli  Copyright (C) 2022  Phylum, Inc.
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
While not necessary, this fills out the copyright information in the license. This could help point out Phylum's involvement should the license ever get packaged with another application.

The main argument for adding this additional information however is consistency with phylum-dev/birdcage. This way all of our licenses have the same structure.
