### PR TITLE
Fix package-lock parsing with 3rd-party registries

### DIFF
--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -51,10 +51,13 @@ impl Parse for PackageLock {
                     .ok_or_else(|| anyhow!("Dependency '{name}' is missing \"resolved\" key"))?;
 
                 // Get dependency version.
-                let version = if resolved.starts_with("https://registry.npmjs.org") {
-                    get_version(keys, name)?
-                } else if let Some(git_url) = resolved.strip_prefix("git+") {
+                let version = if let Some(git_url) = resolved.strip_prefix("git+") {
                     git_url.to_owned()
+                } else if resolved.starts_with("http") {
+                    // NOTE: This accepts packages that are not hosted by NPM and submits them
+                    // pretending they are hosted on npmjs.org. This is currently necessary to
+                    // allow analysis for third-party registries.
+                    get_version(keys, name)?
                 } else {
                     // Filter filesystem dependencies.
                     continue;

--- a/tests/fixtures/package-lock.json
+++ b/tests/fixtures/package-lock.json
@@ -539,7 +539,7 @@
     },
     "node_modules/match-sorter": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-3.1.1.tgz",
+      "resolved": "https://custom-registry.org/match-sorter/-/match-sorter-3.1.1.tgz",
       "integrity": "sha512-Qlox3wRM/Q4Ww9rv1cBmYKNJwWVX/WC+eA3+1S3Fv4EOhrqyp812ZEfVFKQk0AP6RfzmPUUOwEZBbJ8IRt8SOw==",
       "bundleDependencies": [
         "remove-accents"


### PR DESCRIPTION
This changes the v7+ package-lock.json parser to accept third-party registries and submit their packages pretending they are hosted on npmjs.org.

Since the v6 parser has the same behavior, it should allow for a more consistent user experience while still providing as good of an analysis as we can get with the information we have.
