### PR TITLE
Revert to using a PAT for cargo update

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -30,6 +30,7 @@ jobs:
         if: ${{ steps.commit.outcome == 'success' }}
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
             github.rest.pulls.create({
               owner: context.repo.owner,
@@ -38,11 +39,4 @@ jobs:
               base: context.ref,
               title: "build: Bump Cargo.lock dependencies",
               body: "Bump dependencies in Cargo.lock for all SemVer-compatible updates.",
-            });
-
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "test.yml",
-              ref: "auto-cargo-update",
             });


### PR DESCRIPTION
In #816 (and #817), I tried to change the `cargo-update.yml` workflow to use `GITHUB_TOKEN` instead of a PAT. That was a mistake. The workflow_dispatch trigger does not properly connect to the opened PR.

This patch reverts the 8f4f7e5 and 82fb0a3 changes to that workflow. Other changes made in those commits (namely, to the `release.yml` workflow) are not reverted.