### PR TITLE
Add `phylum group transfer` subcommand

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -112,6 +112,13 @@ pub fn group_members(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
     Ok(url)
 }
 
+/// PUT /groups/<groupName>/owner/<userEmail>
+pub fn set_owner(api_uri: &str, group: &str, owner: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group, "owner", owner]);
+    Ok(url)
+}
+
 /// GET /.well-known/openid-configuration
 pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/openid-configuration")?)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -387,6 +387,13 @@ impl PhylumApi {
         Ok(())
     }
 
+    /// Change group ownership.
+    pub async fn group_set_owner(&self, group_name: &str, new_owner_email: &str) -> Result<()> {
+        let url = endpoints::set_owner(&self.config.connection.uri, group_name, new_owner_email)?;
+        self.send_request_raw(Method::PUT, url, None::<()>).await?;
+        Ok(())
+    }
+
     pub fn config(&self) -> &Config {
         &self.config
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -391,6 +391,25 @@ pub fn add_subcommands(command: Command) -> Command {
                             ]),
                     )
                 )
+                .subcommand(
+                    Command::new("transfer").about("Transfer group ownership between users").args(&[
+                        Arg::new("group")
+                            .short('g')
+                            .long("group")
+                            .value_name("GROUP")
+                            .help("Group to transfer")
+                            .required(true),
+                        Arg::new("user")
+                            .value_name("USER")
+                            .help("User the group ownership will be transferred to")
+                            .required(true),
+                        Arg::new("force")
+                            .short('f')
+                            .long("force")
+                            .help("Do not prompt for confirmation")
+                            .action(ArgAction::SetTrue),
+                    ])
+                )
         )
         .subcommand(
             Command::new("init")

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -1,6 +1,5 @@
 //! Subcommand `phylum group`.
 
-use anyhow::anyhow;
 use clap::ArgMatches;
 use dialoguer::Confirm;
 use reqwest::StatusCode;
@@ -130,13 +129,7 @@ pub async fn handle_group_transfer(api: &mut PhylumApi, matches: &ArgMatches) ->
     }
 
     // Transfer ownership.
-    match api.group_set_owner(group, user).await {
-        // Improve error message for invalid groups.
-        Err(PhylumApiError::Response(ResponseError { code: StatusCode::NOT_FOUND, .. })) => {
-            return Err(anyhow!(format!("Group `{group}` does not exist")));
-        },
-        result => result,
-    }?;
+    api.group_set_owner(group, user).await?;
 
     print_user_success!("Successfully transferred group ownership!");
 

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -1,17 +1,21 @@
 //! Subcommand `phylum group`.
 
+use anyhow::anyhow;
 use clap::ArgMatches;
+use dialoguer::Confirm;
 use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError, ResponseError};
 use crate::commands::{CommandResult, ExitCode};
 use crate::format::Format;
-use crate::{print_user_failure, print_user_success};
+use crate::{print_user_failure, print_user_success, print_user_warning};
 
 /// Handle `phylum group` subcommand.
 pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         handle_group_create(api, matches).await
+    } else if let Some(matches) = matches.subcommand_matches("transfer") {
+        handle_group_transfer(api, matches).await
     } else if let Some(matches) = matches.subcommand_matches("member") {
         let group = matches.get_one::<String>("group").unwrap();
 
@@ -99,6 +103,42 @@ pub async fn handle_member_list(
     let response = api.group_members(group).await?;
 
     response.write_stdout(pretty);
+
+    Ok(ExitCode::Ok.into())
+}
+
+/// Handle `phylum group transfer` subcommand.
+pub async fn handle_group_transfer(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+    let group = matches.get_one::<String>("group").unwrap();
+    let user = matches.get_one::<String>("user").unwrap();
+
+    if !matches.get_flag("force") {
+        // Prompt user to avoid accidental transfer.
+        let should_continue = Confirm::new()
+            .with_prompt(format!(
+                "This will transfer ownership of `{group}` to `{user}`. You will no longer own \
+                 the group. Are you sure?"
+            ))
+            .default(false)
+            .interact()?;
+
+        // Abort if user did not confirm our prompt.
+        if !should_continue {
+            print_user_warning!("Aborting group transfer");
+            return Ok(ExitCode::ConfirmationFailed.into());
+        }
+    }
+
+    // Transfer ownership.
+    match api.group_set_owner(group, user).await {
+        // Improve error message for invalid groups.
+        Err(PhylumApiError::Response(ResponseError { code: StatusCode::NOT_FOUND, .. })) => {
+            return Err(anyhow!(format!("Group `{group}` does not exist")));
+        },
+        result => result,
+    }?;
+
+    print_user_success!("Successfully transferred group ownership!");
 
     Ok(ExitCode::Ok.into())
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -25,7 +25,7 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
             .interact()?;
 
         if !should_continue {
-            return Ok(ExitCode::ProjectAlreadyInitialized.into());
+            return Ok(ExitCode::ConfirmationFailed.into());
         }
 
         println!();

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -45,7 +45,7 @@ pub enum ExitCode {
     NoHistoryFound,
     JsError,
     FailedThresholds,
-    ProjectAlreadyInitialized,
+    ConfirmationFailed,
     Custom(i32),
 }
 
@@ -68,7 +68,7 @@ impl From<&ExitCode> for i32 {
             ExitCode::AlreadyExists => 14,
             ExitCode::NoHistoryFound => 15,
             ExitCode::JsError => 16,
-            ExitCode::ProjectAlreadyInitialized => 17,
+            ExitCode::ConfirmationFailed => 17,
             ExitCode::FailedThresholds => 100,
             ExitCode::Custom(code) => *code,
         }

--- a/docs/command_line_tool/phylum_group.md
+++ b/docs/command_line_tool/phylum_group.md
@@ -29,6 +29,7 @@ Usage: phylum group [OPTIONS] [COMMAND]
 * [phylum group list](./phylum_group_list)
 * [phylum group create](./phylum_group_create)
 * [phylum group member](./phylum_group_member)
+* [phylum group transfer](./phylum_group_transfer)
 
 ### Examples
 

--- a/docs/command_line_tool/phylum_group_transfer.md
+++ b/docs/command_line_tool/phylum_group_transfer.md
@@ -1,0 +1,33 @@
+---
+title: phylum group transfer
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Transfer group ownership between users
+
+```sh
+Usage: phylum group transfer [OPTIONS] --group <GROUP> <USER>
+```
+
+### Arguments
+
+<USER>
+&emsp; User the group ownership will be transferred to
+
+### Options
+
+-g, --group <GROUP>
+&emsp; Group to transfer
+
+-f, --force
+&emsp; Do not prompt for confirmation
+
+-v, --verbose...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+-q, --quiet...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+-h, --help
+&emsp; Print help information


### PR DESCRIPTION
This patch adds support for the new API endpoint to transfer group ownership between users.

To ensure that groups are not accidentally transferred to incorrect users and since the operation cannot be reverted easily, extra precautions are taken in the form of a confirmation prompt.

Closes #832.