### PR TITLE
Downgrade linux builder to 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, [self-hosted, macos, arm64]]
+        os: [ubuntu-20.04, windows-latest, [self-hosted, macos, arm64]]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
In order to drop the glibc requirement for our binaries, this patch downgrades our linux builders to ubuntu 20.04