### PR TITLE
Bump to v4.0.1 - Use a lower version of GLIBC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 4.0.1 - Use a lower version of GLIBC
 * 4.0.0 - Extensions are sandboxed by default
 * 3.12.1 - Fix to avoid stdout when run with --json
 * 3.12.0 - Permissions extension API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release-Version: v4.0.1
Release-Summary: Use a lower version of GLIBC

