### PR TITLE
Ignore parent directory projects for `phylum init`

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -16,8 +16,8 @@ use crate::{config, print_user_success, print_user_warning};
 
 /// Handle `phylum init` subcommand.
 pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
-    // Prompt for confirmation if there already is a linked project.
-    if !matches.get_flag("force") && config::get_current_project().is_some() {
+    // Prompt for confirmation if a linked project is already in this directory.
+    if !matches.get_flag("force") && config::find_project_conf(".", false).is_some() {
         print_user_warning!("Workspace is already linked to a Phylum project");
         let should_continue = Confirm::new()
             .with_prompt("Overwrite existing project configuration?")

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -213,6 +213,8 @@ pub fn find_project_conf(
         path = path.parent()?;
     }
 
+    log::warn!("Max depth exceeded; abandoning search for .phylum_project file");
+
     None
 }
 


### PR DESCRIPTION
Previously, `phylum init` would query if the project should be overwritten when a parent project contained a project file already.

Since we do not actually overwrite any project files outside of the current directory, and since having nested Phylum projects is perfectly valid, a warning is now only emitted when there's already a Phylum project file in the current directory.

Closes #839.
