### PR TITLE
Fix subdir analysis without lockfile parameter

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -63,8 +63,7 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
     // Add lockfile and its type to the project configuration.
     println!();
     let (lockfile, lockfile_type) = prompt_lockfile(cli_lockfile, cli_lockfile_type)?;
-    project_config.lockfile_type = Some(lockfile_type);
-    project_config.lockfile = Some(lockfile);
+    project_config.set_lockfile(lockfile_type, lockfile);
 
     // Save project config.
     config::save_config(Path::new(PROJ_CONF_FILE), &project_config)

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::result::Result as StdResult;
 
 use anyhow::{anyhow, Context, Result};
-use chrono::Local;
 use console::style;
 use reqwest::StatusCode;
 
@@ -198,14 +197,7 @@ pub async fn create_project(
 ) -> StdResult<ProjectConfig, PhylumApiError> {
     let project_id = api.create_project(project, group.as_deref()).await?;
 
-    Ok(ProjectConfig {
-        id: project_id.to_owned(),
-        created_at: Local::now(),
-        group_name: group,
-        name: project.to_owned(),
-        lockfile: None,
-        lockfile_type: None,
-    })
+    Ok(ProjectConfig::new(project_id.to_owned(), project.to_owned(), group))
 }
 
 /// Link to an existing project.
@@ -219,12 +211,5 @@ pub async fn link_project(
         .await
         .context("A project with that name does not exist")?;
 
-    Ok(ProjectConfig {
-        id: uuid,
-        name: project.into(),
-        created_at: Local::now(),
-        group_name: group,
-        lockfile: None,
-        lockfile_type: None,
-    })
+    Ok(ProjectConfig::new(uuid, project.into(), group))
 }


### PR DESCRIPTION
Since the lockfile was specified as a relative path in the project lockfile, an analysis would fail when the analysis was started from a child directory of the Phylum project directory.

To ensure that analysis will work in any of the child directories, a root path of the project is now stored in the config on load and the lockfile location is determined based on that root directory whenever it is required.

While an absolute path to the lockfile might work temporarily, it was intentionally avoided as a solution since it would break when the project is moved to a different location or shared between different systems.

Closes #843.
