### PR TITLE
Reorder project initialization

### DIFF
--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -79,7 +79,7 @@ impl Permission {
             },
             // Parent set vs child set have to be validated.
             // This will error if child is not subset of parent, and return the child set otherwise.
-            (&Permission::List(ref parent), &Permission::List(ref child)) => {
+            (Permission::List(parent), Permission::List(child)) => {
                 Permission::check_paths_include_children(parent, child)
                     .map(|_| Permission::List(child.clone()))
                     .map_err(|mismatches| {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -53,14 +53,9 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
             let project_config = project::lookup_project(api, &project, group)
                 .await
                 .context(format!("Could not find project {project:?}"))?;
-            print_user_success!("Successfully linked to project {project:?}");
             project_config
         },
-        Err(err) => return Err(err).context("Unable to create project"),
-        Ok(project_config) => {
-            print_user_success!("Successfully created project {project:?}");
-            project_config
-        },
+        project_config => project_config.context("Unable to create project")?,
     };
 
     // Override project lockfile info.
@@ -69,6 +64,8 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
     // Save project config.
     config::save_config(Path::new(PROJ_CONF_FILE), &project_config)
         .context("Failed to save project file")?;
+
+    print_user_success!("Successfully created project configuration");
 
     Ok(ExitCode::Ok.into())
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -50,10 +50,9 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
     let mut project_config = match result {
         // If project already exists, try looking it up to link to it.
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-            let project_config = project::lookup_project(api, &project, group)
+            project::lookup_project(api, &project, group)
                 .await
-                .context(format!("Could not find project {project:?}"))?;
-            project_config
+                .context(format!("Could not find project {project:?}"))?
         },
         project_config => project_config.context("Unable to create project")?,
     };

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -31,38 +31,39 @@ pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandRe
         println!();
     }
 
+    let cli_lockfile_type = matches.get_one::<String>("lockfile-type");
+    let cli_lockfile = matches.get_one::<String>("lockfile");
     let cli_project = matches.get_one::<String>("project");
     let cli_group = matches.get_one::<String>("group");
 
-    // Interactively prompt for missing information.
+    // Interactively prompt for missing project information.
     let (project, group) = prompt_project(cli_project, cli_group)?;
 
+    // Interactively prompt for missing lockfile information.
+    println!();
+    let (lockfile, lockfile_type) = prompt_lockfile(cli_lockfile, cli_lockfile_type)?;
+
     // Attempt to create the project.
+    println!();
     let result = project::create_project(api, &project, group.clone()).await;
 
-    // If project already exists, just link to it.
     let mut project_config = match result {
+        // If project already exists, try looking it up to link to it.
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-            let project_config = project::link_project(api, &project, group)
+            let project_config = project::lookup_project(api, &project, group)
                 .await
-                .context("Unable to link project")?;
+                .context(format!("Could not find project {project:?}"))?;
             print_user_success!("Successfully linked to project {project:?}");
             project_config
         },
-        project_config => {
-            if project_config.is_ok() {
-                print_user_success!("Successfully created project {project:?}");
-            }
-            project_config.context("Unable to create project")?
+        Err(err) => return Err(err).context("Unable to create project"),
+        Ok(project_config) => {
+            print_user_success!("Successfully created project {project:?}");
+            project_config
         },
     };
 
-    let cli_lockfile_type = matches.get_one::<String>("lockfile-type");
-    let cli_lockfile = matches.get_one::<String>("lockfile");
-
-    // Add lockfile and its type to the project configuration.
-    println!();
-    let (lockfile, lockfile_type) = prompt_lockfile(cli_lockfile, cli_lockfile_type)?;
+    // Override project lockfile info.
     project_config.set_lockfile(lockfile_type, lockfile);
 
     // Save project config.

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -70,7 +70,7 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
         let project_name = matches.get_one::<String>("name").unwrap();
         let group_name = matches.get_one::<String>("group").cloned();
 
-        let project_config = link_project(api, project_name, group_name).await?;
+        let project_config = lookup_project(api, project_name, group_name).await?;
 
         save_config(Path::new(PROJ_CONF_FILE), &project_config).unwrap_or_else(|err| {
             log::error!("Failed to save user credentials to config: {}", err)
@@ -200,8 +200,8 @@ pub async fn create_project(
     Ok(ProjectConfig::new(project_id.to_owned(), project.to_owned(), group))
 }
 
-/// Link to an existing project.
-pub async fn link_project(
+/// Lookup project by name and group.
+pub async fn lookup_project(
     api: &PhylumApi,
     project: &str,
     group: Option<String>,


### PR DESCRIPTION
This reorders the steps in the project initialization for the `phylum init` command, to improve user experience with the command.

Instead of trying to create or link to the project before prompting for the lockfile path and type, all API operations are now moved to the end after the user has finished his inputs. This way looking can go on in the background without users waiting for long-running API calls to complete.

Closes #841.
