### PR TITLE
Add possible values to `phylum init -t`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -233,7 +233,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .long("lockfile-type")
                     .value_name("type")
                     .help("The type of the lock file (default: auto)")
-                    .value_parser(PossibleValuesParser::new(parse::lockfile_types())),
+                    .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
             ]),
         )
         .subcommand(
@@ -275,7 +275,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("lockfile-type")
                         .value_name("type")
                         .help("The type of the lock file (default: auto)")
-                        .value_parser(PossibleValuesParser::new(parse::lockfile_types())),
+                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 ]),
         )
         .subcommand(
@@ -432,7 +432,8 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("lockfile-type")
                         .value_name("LOCKFILE_TYPE")
-                        .help("Project lockfile type"),
+                        .help("Project lockfile type")
+                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(false))),
                     Arg::new("force")
                         .short('f')
                         .long("force")

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -17,8 +17,15 @@ pub struct ParsedLockfile {
     pub package_type: PackageType,
 }
 
-pub fn lockfile_types() -> Vec<&'static str> {
-    LockfileFormat::iter().map(|format| format.name()).chain(["auto"]).collect()
+pub fn lockfile_types(add_auto: bool) -> Vec<&'static str> {
+    let mut lockfile_types = LockfileFormat::iter().map(|format| format.name()).collect::<Vec<_>>();
+
+    // Add generic lockfile type.
+    if add_auto {
+        lockfile_types.push("auto");
+    }
+
+    lockfile_types
 }
 
 pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -25,6 +25,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 
 -t, --lockfile-type <LOCKFILE_TYPE>
 &emsp; Project lockfile type
+&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`
 
 -f, --force
 &emsp; Overwrite existing configurations without confirmation


### PR DESCRIPTION
This adds restrictions on the allowed parameters that can be passed to the lockfile types parameter on `phylum init` to clap, allowing for proper documentation and feedback when an invalid value is specified.

Closes #847.
