### PR TITLE
Remove actions-rs GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+        run: rustup toolchain install stable --profile minimal
 
       - name: Generate shell completion files
-        uses: actions-rs/cargo@v1
-        with:
-          command: xtask
-          args: gencomp
+        run: cargo +stable xtask gencomp
 
       - name: Upload shell completions
         uses: actions/upload-artifact@v3
@@ -62,17 +56,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
+        run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
 
       - name: Build Distributions
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }}
+        run: cargo +stable build --release --target ${{ matrix.target }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Generate shell completion files
-        run: cargo +stable xtask gencomp
+        run: cargo xtask gencomp
 
       - name: Upload shell completions
         uses: actions/upload-artifact@v3
@@ -56,10 +58,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
+          rustup default stable
 
       - name: Build Distributions
-        run: cargo +stable build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal -c clippy
+        run: |
+          rustup toolchain install stable --profile minimal -c clippy
+          rustup default stable
 
       - name: Install Rust nightly toolchain
         if: github.event_name != 'schedule'
@@ -35,18 +37,18 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        run: cargo +stable build --locked
+        run: cargo build --locked
 
       - name: Clippy
         if: github.event_name != 'schedule'
-        run: cargo +stable clippy --locked -- -D warnings
+        run: cargo clippy --locked -- -D warnings
 
       - name: Test generating shell completion files
         if: matrix.os == 'ubuntu-latest'
-        run: cargo +stable xtask gencomp
+        run: cargo xtask gencomp
 
       - name: Test
-        run: cargo +stable test --locked
+        run: cargo test --locked
 
       - name: Oldstable
         if: matrix.os != 'windows-latest'
@@ -60,7 +62,7 @@ jobs:
         name: All Features
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN_STAGING }}
-        run: cargo +stable test --all-features
+        run: cargo test --all-features
 
   prettier:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,49 +24,29 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
+        run: rustup toolchain install stable --profile minimal -c clippy
 
       - name: Install Rust nightly toolchain
         if: github.event_name != 'schedule'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt
+        run: rustup toolchain install nightly --profile minimal -c rustfmt
 
       - name: Format check
         if: github.event_name != 'schedule'
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --locked
+        run: cargo +stable build --locked
 
       - name: Clippy
         if: github.event_name != 'schedule'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --locked -- -D warnings
+        run: cargo +stable clippy --locked -- -D warnings
 
       - name: Test generating shell completion files
         if: matrix.os == 'ubuntu-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          command: xtask
-          args: gencomp
+        run: cargo +stable xtask gencomp
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --locked
+        run: cargo +stable test --locked
 
       - name: Oldstable
         if: matrix.os != 'windows-latest'
@@ -78,12 +58,9 @@ jobs:
       # Skip this step when the secret is unavailable
       - if: github.secret_source == 'Actions'
         name: All Features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN_STAGING }}
+        run: cargo +stable test --all-features
 
   prettier:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This removes the unnecessary usage of actions-rs/toolchain and actions-rs/cargo in favor of using rustup and cargo directly.

The patch should also ensure that when running with a specific toolchain version (like `stable`), that this version is always up to date.