### PR TITLE
Traverse directories to find ecosystem root

### DIFF
--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -41,16 +41,8 @@ if (
     "udpate".startsWith(Deno.args[0])
   )
 ) {
-  let status = PhylumApi.runSandboxed({
-    cmd: "npm",
-    args: Deno.args,
-    exceptions: {
-      write: ["~/.npm", "./"],
-      read: true,
-      run: ["npm", "node"],
-      net: true,
-    },
-  });
+  let cmd = await Deno.run({ cmd: ["npm", ...Deno.args] });
+  let status = await cmd.status();
   Deno.exit(status.code);
 }
 

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -31,6 +31,25 @@ class FileBackup {
   }
 }
 
+// Find project root directory.
+async function findRoot(manifest: string): string | undefined {
+  let workingDir = Deno.cwd();
+
+  // Traverse up to 32 directories to find the root directory.
+  for (var i = 0; i < 32; i++) {
+    try {
+      // Check if manifest exists at location.
+      await Deno.stat(workingDir + "/" + manifest);
+      return workingDir;
+    } catch (e) {
+      // Pop to parent if manifest doesn't exist.
+      workingDir += "/..";
+    }
+  }
+
+  return undefined;
+}
+
 // Ignore all commands that shouldn't be intercepted.
 if (
   Deno.args.length == 0 ||
@@ -47,26 +66,19 @@ if (
 }
 
 // Ensure we're in an npm root directory.
-try {
-  await Deno.stat("package.json");
-} catch (e) {
+const root = await findRoot("package.json");
+if (!root) {
+  console.error(`[${red("phylum")}] unable to find npm project root.`);
   console.error(
-    `[${red(
-      "phylum"
-    )}] \`package.json\` was not found in the current directory.`
-  );
-  console.error(
-    `[${red(
-      "phylum"
-    )}] Please move to the npm project's top level directory and try again.`
+    `[${red("phylum")}] Please change to a npm project directory and try again.`
   );
   Deno.exit(125);
 }
 
 // Store initial package manager file state.
-const packageLockBackup = new FileBackup("./package-lock.json");
+const packageLockBackup = new FileBackup(root + "/package-lock.json");
 await packageLockBackup.backup();
-const manifestBackup = new FileBackup("./package.json");
+const manifestBackup = new FileBackup(root + "/package.json");
 await manifestBackup.backup();
 
 // Analyze new dependencies with phylum before install/update.

--- a/extensions/poetry/PhylumExt.toml
+++ b/extensions/poetry/PhylumExt.toml
@@ -7,3 +7,4 @@ run = ["poetry", "python", "python3"]
 read = true
 write = ["./", "~/.cache/pypoetry", "~/.local/share/virtualenv", "~/Library/Caches/pypoetry"]
 net = true
+unsandboxed_run = ["poetry"]

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -36,21 +36,8 @@ if (
   Deno.args.length == 0 ||
   !["add", "update", "install"].includes(Deno.args[0])
 ) {
-  let status = PhylumApi.runSandboxed({
-    cmd: "poetry",
-    args: Deno.args,
-    exceptions: {
-      read: true,
-      write: [
-        "./",
-        "~/.local/share/virtualenv",
-        "~/.cache/pypoetry",
-        "~/Library/Caches/pypoetry",
-      ],
-      run: ["poetry"],
-      net: true,
-    },
-  });
+  let cmd = await Deno.run({ cmd: ["poetry", ...Deno.args] });
+  let status = await cmd.status();
   Deno.exit(status.code);
 }
 

--- a/extensions/yarn/PhylumExt.toml
+++ b/extensions/yarn/PhylumExt.toml
@@ -7,3 +7,4 @@ write = ["/tmp", "~/.cache/node", "~/.cache/yarn", "~/.yarn", "./", "~/Library/C
 read = true
 run = true
 net = true
+unsandboxed_run = ["yarn"]

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -36,16 +36,8 @@ if (
   Deno.args.length == 0 ||
   !["add", "install", "up", "dedupe"].includes(Deno.args[0])
 ) {
-  let status = PhylumApi.runSandboxed({
-    cmd: "yarn",
-    args: Deno.args,
-    exceptions: {
-      read: true,
-      write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./", "/tmp"],
-      run: ["yarn", "node"],
-      net: true,
-    },
-  });
+  let cmd = await Deno.run({ cmd: ["yarn", ...Deno.args] });
+  let status = await cmd.status();
   Deno.exit(status.code);
 }
 


### PR DESCRIPTION
This patch traverses up to 32 directories upwards to find the root of a
potential ecosystem project. This way the ecosystem commands should
still work when inside a nested directory in a project.

---

Ecosystem extension subcommands which aren't intercepted by Phylum could
do theoretically anything and at the same time aren't particularly at
risk. As a result it is more reliable to just not sandbox these and use
normal `Deno.run` instead.