### PR TITLE
Use JSDoc comments in extension API

### DIFF
--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -24,13 +24,13 @@ export class PhylumApi {
    *
    * Analyze Job ID, which can later be queried with `getJobStatus`.
    */
-  static async analyze(
+  static analyze(
     package_type: string,
-    packages: [object],
+    packages: object[],
     project?: string,
     group?: string
-  ): string {
-    return await Deno.core.opAsync(
+  ): Promise<string> {
+    return Deno.core.opAsync(
       "analyze",
       package_type,
       packages,
@@ -58,18 +58,18 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async getUserInfo(): object {
-    return await Deno.core.opAsync("get_user_info");
+  static getUserInfo(): Promise<object> {
+    return Deno.core.opAsync("get_user_info");
   }
 
   /** Get the current short-lived API access token. */
-  static async getAccessToken(): string {
-    return await Deno.core.opAsync("get_access_token");
+  static getAccessToken(): Promise<string> {
+    return Deno.core.opAsync("get_access_token");
   }
 
   /** Get the long-lived user refresh token. */
-  static async getRefreshToken(): string {
-    return await Deno.core.opAsync("get_refresh_token");
+  static getRefreshToken(): Promise<string> {
+    return Deno.core.opAsync("get_refresh_token");
   }
 
   /**
@@ -123,8 +123,8 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async getJobStatus(jobId: string): object {
-    return await Deno.core.opAsync("get_job_status", jobId);
+  static getJobStatus(jobId: string): Promise<object> {
+    return Deno.core.opAsync("get_job_status", jobId);
   }
 
   /**
@@ -171,7 +171,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async getGroups(): object {
+  static getGroups(): Promise<object> {
     return Deno.core.opAsync("get_groups");
   }
 
@@ -195,7 +195,7 @@ export class PhylumApi {
    * ]
    * ```
    */
-  static async getProjects(group?: string): object {
+  static getProjects(group?: string): Promise<object> {
     return Deno.core.opAsync("get_projects", group);
   }
 
@@ -221,7 +221,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async createProject(name: string, group?: string): string {
+  static createProject(name: string, group?: string): Promise<string> {
     return Deno.core.opAsync("create_project", name, group);
   }
 
@@ -232,7 +232,7 @@ export class PhylumApi {
    *
    * Nothing if successful; throws an error if unsuccessful.
    */
-  static async deleteProject(name: string, group?: string): string {
+  static deleteProject(name: string, group?: string): Promise<string> {
     return Deno.core.opAsync("delete_project", name, group);
   }
 
@@ -289,12 +289,12 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async getPackageDetails(
+  static getPackageDetails(
     name: string,
     version: string,
     packageType: string
-  ): object {
-    return await Deno.core.opAsync(
+  ): Promise<object> {
+    return Deno.core.opAsync(
       "get_package_details",
       name,
       version,
@@ -321,8 +321,8 @@ export class PhylumApi {
    * }
    * ```
    */
-  static async parseLockfile(lockfile: string, lockfileType?: string): object {
-    return await Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
+  static parseLockfile(lockfile: string, lockfileType?: string): Promise<object> {
+    return Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
   }
 
   /**

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -1,27 +1,29 @@
 export class PhylumApi {
-  /// Analyze dependencies in a lockfile.
-  ///
-  /// This expects a `.phylum_project` file to be present if the `project`
-  /// parameter is undefined.
-  ///
-  /// # Parameters
-  ///
-  /// Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
-  ///
-  /// Packages are expected in the following format:
-  ///
-  /// ```
-  /// [
-  ///   { name: "accepts", version: "1.3.8" },
-  ///   { name: "ms", version: "2.0.0" },
-  ///   { name: "negotiator", version: "0.6.3" },
-  ///   { name: "ms", version: "2.1.3" }
-  /// ]
-  /// ```
-  ///
-  /// # Returns
-  ///
-  /// Analyze Job ID, which can later be queried with `getJobStatus`.
+  /**
+   * Analyze dependencies in a lockfile.
+   *
+   * This expects a `.phylum_project` file to be present if the `project`
+   * parameter is undefined.
+   *
+   * # Parameters
+   *
+   * Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
+   *
+   * Packages are expected in the following format:
+   *
+   * ```
+   * [
+   *   { name: "accepts", version: "1.3.8" },
+   *   { name: "ms", version: "2.0.0" },
+   *   { name: "negotiator", version: "0.6.3" },
+   *   { name: "ms", version: "2.1.3" }
+   * ]
+   * ```
+   *
+   * # Returns
+   *
+   * Analyze Job ID, which can later be queried with `getJobStatus`.
+   */
   static async analyze(
     package_type: string,
     packages: [object],
@@ -37,240 +39,256 @@ export class PhylumApi {
     );
   }
 
-  /// Get info about the logged in user.
-  ///
-  /// # Returns
-  ///
-  /// Object containing user information:
-  ///
-  /// ```
-  /// {
-  ///   email: "user@phylum.io",
-  ///   sub: "af8b5c32-9966-496a-e5ae-9ca9ceb43294",
-  ///   name: "John Doe",
-  ///   given_name: "John",
-  ///   family_name: "Doe",
-  ///   preferred_username: "JD",
-  ///   email_verified: true,
-  /// }
-  /// ```
+  /**
+   * Get info about the logged in user.
+   *
+   * # Returns
+   *
+   * Object containing user information:
+   *
+   * ```
+   * {
+   *   email: "user@phylum.io",
+   *   sub: "af8b5c32-9966-496a-e5ae-9ca9ceb43294",
+   *   name: "John Doe",
+   *   given_name: "John",
+   *   family_name: "Doe",
+   *   preferred_username: "JD",
+   *   email_verified: true,
+   * }
+   * ```
+   */
   static async getUserInfo(): object {
     return await Deno.core.opAsync("get_user_info");
   }
 
-  /// Get the current short-lived API access token.
+  /** Get the current short-lived API access token. */
   static async getAccessToken(): string {
     return await Deno.core.opAsync("get_access_token");
   }
 
-  /// Get the long-lived user refresh token.
+  /** Get the long-lived user refresh token. */
   static async getRefreshToken(): string {
     return await Deno.core.opAsync("get_refresh_token");
   }
 
-  /// Get job results.
-  ///
-  /// # Returns
-  ///
-  /// Job analysis results:
-  ///
-  /// ```
-  /// {
-  ///   job_id: "de2d74b1-3925-4de9-9b8f-0c7b27f9b3c8",
-  ///   ecosystem: "npm",
-  ///   user_id: "0f2a8e3d-9f75-49fa-89c7-718c4f87fc93",
-  ///   user_email: "",
-  ///   created_at: 1657106760573,
-  ///   status: "complete",
-  ///   score: 1,
-  ///   pass: true,
-  ///   msg: "Project met threshold requirements",
-  ///   action: "none",
-  ///   num_incomplete: 0,
-  ///   last_updated: 1657106760573,
-  ///   project: "02a8dcdd-69bd-469f-8c39-be76c786fd2b",
-  ///   project_name: "api-docs",
-  ///   label: "uncategorized",
-  ///   thresholds: { author: 0, engineering: 0, license: 0, malicious: 0, total: 0, vulnerability: 0 },
-  ///   packages: [
-  ///     {
-  ///       name: "typescript",
-  ///       version: "4.7.4",
-  ///       status: "complete",
-  ///       last_updated: 1657106208802,
-  ///       license: "Apache-2.0",
-  ///       package_score: 1,
-  ///       num_dependencies: 0,
-  ///       num_vulnerabilities: 0,
-  ///       type: "npm",
-  ///       riskVectors: {
-  ///         author: 1,
-  ///         vulnerabilities: 1,
-  ///         total: 1,
-  ///         engineering: 1,
-  ///         malicious_code: 1,
-  ///         license: 1
-  ///       },
-  ///       dependencies: {},
-  ///       issues: []
-  ///     }
-  ///   ]
-  /// }
-  /// ```
+  /**
+   * Get job results.
+   *
+   * # Returns
+   *
+   * Job analysis results:
+   *
+   * ```
+   * {
+   *   job_id: "de2d74b1-3925-4de9-9b8f-0c7b27f9b3c8",
+   *   ecosystem: "npm",
+   *   user_id: "0f2a8e3d-9f75-49fa-89c7-718c4f87fc93",
+   *   user_email: "",
+   *   created_at: 1657106760573,
+   *   status: "complete",
+   *   score: 1,
+   *   pass: true,
+   *   msg: "Project met threshold requirements",
+   *   action: "none",
+   *   num_incomplete: 0,
+   *   last_updated: 1657106760573,
+   *   project: "02a8dcdd-69bd-469f-8c39-be76c786fd2b",
+   *   project_name: "api-docs",
+   *   label: "uncategorized",
+   *   thresholds: { author: 0, engineering: 0, license: 0, malicious: 0, total: 0, vulnerability: 0 },
+   *   packages: [
+   *     {
+   *       name: "typescript",
+   *       version: "4.7.4",
+   *       status: "complete",
+   *       last_updated: 1657106208802,
+   *       license: "Apache-2.0",
+   *       package_score: 1,
+   *       num_dependencies: 0,
+   *       num_vulnerabilities: 0,
+   *       type: "npm",
+   *       riskVectors: {
+   *         author: 1,
+   *         vulnerabilities: 1,
+   *         total: 1,
+   *         engineering: 1,
+   *         malicious_code: 1,
+   *         license: 1
+   *       },
+   *       dependencies: {},
+   *       issues: []
+   *     }
+   *   ]
+   * }
+   * ```
+   */
   static async getJobStatus(jobId: string): object {
     return await Deno.core.opAsync("get_job_status", jobId);
   }
 
-  /// Get currently linked project.
-  ///
-  /// # Returns
-  ///
-  /// Project information:
-  ///
-  /// ```
-  /// {
-  ///   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
-  ///   name: "phylum",
-  ///   created_at: "2022-08-18T18:41:46.468054855+02:00",
-  ///   group_name: null
-  /// }
-  /// ```
-  ///
-  /// If no project is linked, this will return `null`.
+  /**
+   * Get currently linked project.
+   *
+   * # Returns
+   *
+   * Project information:
+   *
+   * ```
+   * {
+   *   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
+   *   name: "phylum",
+   *   created_at: "2022-08-18T18:41:46.468054855+02:00",
+   *   group_name: null
+   * }
+   * ```
+   *
+   * If no project is linked, this will return `null`.
+   */
   static getCurrentProject(): object {
     return Deno.core.opSync("get_current_project");
   }
 
-  /// List the user's groups.
-  ///
-  /// # Returns
-  ///
-  /// Accessible groups:
-  ///
-  /// ```
-  /// {
-  ///   groups: [
-  ///     {
-  ///       created_at: "2022-05-02T14:25:24.184866508Z",
-  ///       last_modified: "2022-05-02T14:25:24.599950299Z",
-  ///       owner_email: "null@phylum.io",
-  ///       group_name: "phlock",
-  ///       is_admin: false,
-  ///       is_owner: true
-  ///     }
-  ///   ]
-  /// }
-  /// ```
+  /**
+   * List the user's groups.
+   *
+   * # Returns
+   *
+   * Accessible groups:
+   *
+   * ```
+   * {
+   *   groups: [
+   *     {
+   *       created_at: "2022-05-02T14:25:24.184866508Z",
+   *       last_modified: "2022-05-02T14:25:24.599950299Z",
+   *       owner_email: "null@phylum.io",
+   *       group_name: "phlock",
+   *       is_admin: false,
+   *       is_owner: true
+   *     }
+   *   ]
+   * }
+   * ```
+   */
   static async getGroups(): object {
     return Deno.core.opAsync("get_groups");
   }
 
-  /// List the user's projects.
-  ///
-  /// # Returns
-  ///
-  /// Accessible projects:
-  ///
-  /// ```
-  /// [
-  ///   {
-  ///     name: "phylum",
-  ///     id: "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-  ///     updated_at: "2022-08-16T22:22:14.092474Z",
-  ///     created_at: "2022-06-24T22:45:47.054472Z",
-  ///     ecosystem: "npm",
-  ///     group_name: null
-  ///   }
-  /// ]
-  /// ```
+  /**
+   * List the user's projects.
+   *
+   * # Returns
+   *
+   * Accessible projects:
+   *
+   * ```
+   * [
+   *   {
+   *     name: "phylum",
+   *     id: "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+   *     updated_at: "2022-08-16T22:22:14.092474Z",
+   *     created_at: "2022-06-24T22:45:47.054472Z",
+   *     ecosystem: "npm",
+   *     group_name: null
+   *   }
+   * ]
+   * ```
+   */
   static async getProjects(group?: string): object {
     return Deno.core.opAsync("get_projects", group);
   }
 
-  /// Create a project.
-  ///
-  /// # Returns
-  ///
-  /// An object containing the id of the project, and an indication
-  /// stating whether the project was just created or already existing.
-  ///
-  /// ```
-  /// {
-  ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-  ///   "status": "created"
-  /// }
-  /// ```
-  ///
-  /// ```
-  /// {
-  ///   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-  ///   "status": "exists"
-  /// }
-  /// ```
+  /**
+   * Create a project.
+   *
+   * # Returns
+   *
+   * An object containing the id of the project, and an indication
+   * stating whether the project was just created or already existing.
+   *
+   * ```
+   * {
+   *   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+   *   "status": "created"
+   * }
+   * ```
+   *
+   * ```
+   * {
+   *   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
+   *   "status": "exists"
+   * }
+   * ```
+   */
   static async createProject(name: string, group?: string): string {
     return Deno.core.opAsync("create_project", name, group);
   }
 
-  /// Delete a project.
-  ///
-  /// # Returns
-  ///
-  /// Nothing if successful; throws an error if unsuccessful.
+  /**
+   * Delete a project.
+   *
+   * # Returns
+   *
+   * Nothing if successful; throws an error if unsuccessful.
+   */
   static async deleteProject(name: string, group?: string): string {
     return Deno.core.opAsync("delete_project", name, group);
   }
 
-  /// Get analysis results for a single package.
-  ///
-  /// This will not start a new package analysis, but only retrieve previous
-  /// analysis results.
-  ///
-  /// # Returns
-  ///
-  /// Package analysis results:
-  ///
-  /// ```
-  /// {
-  ///   id: "npm:typescript:4.7.4",
-  ///   name: "typescript",
-  ///   version: "4.7.4",
-  ///   registry: "npm",
-  ///   publishedDate: "2022-06-17T18:21:36+00:00",
-  ///   latestVersion: null,
-  ///   versions: [
-  ///     { version: "4.5.4", total_risk_score: 1 },
-  ///     { version: "3.9.7", total_risk_score: 1 },
-  ///     { version: "4.2.4", total_risk_score: 1 }
-  ///   ],
-  ///   description: "TypeScript is a language for application scale JavaScript development",
-  ///   license: "Apache-2.0",
-  ///   depSpecs: [],
-  ///   dependencies: [],
-  ///   downloadCount: 134637844,
-  ///   riskScores: {
-  ///     total: 1,
-  ///     vulnerability: 1,
-  ///     malicious_code: 1,
-  ///     author: 1,
-  ///     engineering: 1,
-  ///     license: 1
-  ///   },
-  ///   totalRiskScoreDynamics: null,
-  ///   issuesDetails: [],
-  ///   issues: [],
-  ///   authors: [],
-  ///   developerResponsiveness: {
-  ///     open_issue_count: 0,
-  ///     total_issue_count: 0,
-  ///     open_issue_avg_duration: null,
-  ///     open_pull_request_count: 0,
-  ///     total_pull_request_count: 0,
-  ///     open_pull_request_avg_duration: null
-  ///   },
-  ///   issueImpacts: { low: 0, medium: 0, high: 0, critical: 0 },
-  ///   complete: true
-  /// }
-  /// ```
+  /**
+   * Get analysis results for a single package.
+   *
+   * This will not start a new package analysis, but only retrieve previous
+   * analysis results.
+   *
+   * # Returns
+   *
+   * Package analysis results:
+   *
+   * ```
+   * {
+   *   id: "npm:typescript:4.7.4",
+   *   name: "typescript",
+   *   version: "4.7.4",
+   *   registry: "npm",
+   *   publishedDate: "2022-06-17T18:21:36+00:00",
+   *   latestVersion: null,
+   *   versions: [
+   *     { version: "4.5.4", total_risk_score: 1 },
+   *     { version: "3.9.7", total_risk_score: 1 },
+   *     { version: "4.2.4", total_risk_score: 1 }
+   *   ],
+   *   description: "TypeScript is a language for application scale JavaScript development",
+   *   license: "Apache-2.0",
+   *   depSpecs: [],
+   *   dependencies: [],
+   *   downloadCount: 134637844,
+   *   riskScores: {
+   *     total: 1,
+   *     vulnerability: 1,
+   *     malicious_code: 1,
+   *     author: 1,
+   *     engineering: 1,
+   *     license: 1
+   *   },
+   *   totalRiskScoreDynamics: null,
+   *   issuesDetails: [],
+   *   issues: [],
+   *   authors: [],
+   *   developerResponsiveness: {
+   *     open_issue_count: 0,
+   *     total_issue_count: 0,
+   *     open_issue_avg_duration: null,
+   *     open_pull_request_count: 0,
+   *     total_pull_request_count: 0,
+   *     open_pull_request_avg_duration: null
+   *   },
+   *   issueImpacts: { low: 0, medium: 0, high: 0, critical: 0 },
+   *   complete: true
+   * }
+   * ```
+   */
   static async getPackageDetails(
     name: string,
     version: string,
@@ -284,111 +302,117 @@ export class PhylumApi {
     );
   }
 
-  /// Get dependencies inside a lockfile.
-  ///
-  /// # Returns
-  ///
-  /// List of dependencies:
-  ///
-  /// ```
-  /// {
-  ///   package_type: "npm",
-  ///   packages: [
-  ///     { name: "accepts", version: "1.3.8" },
-  ///     { name: "ms", version: "2.0.0" },
-  ///     { name: "negotiator", version: "0.6.3" },
-  ///     { name: "ms", version: "2.1.3" }
-  ///   ]
-  /// }
-  /// ```
+  /**
+   * Get dependencies inside a lockfile.
+   *
+   * # Returns
+   *
+   * List of dependencies:
+   *
+   * ```
+   * {
+   *   package_type: "npm",
+   *   packages: [
+   *     { name: "accepts", version: "1.3.8" },
+   *     { name: "ms", version: "2.0.0" },
+   *     { name: "negotiator", version: "0.6.3" },
+   *     { name: "ms", version: "2.1.3" }
+   *   ]
+   * }
+   * ```
+   */
   static async parseLockfile(lockfile: string, lockfileType?: string): object {
     return await Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
   }
 
-  /// Run a command inside a more restrictive sandbox.
-  ///
-  /// While all extensions are already sandboxed, it can be useful to further
-  /// restrict this execution environment when dealing with external commands
-  /// that could potentially misbehave. This API allows restricting
-  /// filesystem and network access for those processes.
-  ///
-  /// # Parameters
-  ///
-  /// The `process` parameter contains the command which shall be executed
-  /// and its restrictions:
-  ///
-  /// ```
-  /// {
-  ///   cmd: "ls",
-  ///   args: ["-lah"],
-  ///   stdin: "null",
-  ///   stdout: "piped",
-  ///   stderr: "inherit",
-  ///   exceptions: {
-  ///     read: ["~/"],
-  ///     write: false,
-  ///     run: ["ls"],
-  ///     net: false,
-  ///     strict: false,
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// The `read`/`write`/`run` permissions accept either an array of paths,
-  /// or a boolean. Paths must either be absolute or start with `~/`.
-  ///
-  /// For `run` the executables will be resolved from `$PATH` when they are
-  /// neither absolute nor start with `~/`.
-  ///
-  /// The `net` permission accepts only boolean values.
-  ///
-  /// Some exceptions are added by default, to simplify the extension creation
-  /// process. If you're looking for more granular control, you can set strict
-  /// to `true` and no exceptions will be added without explicitly specifying
-  /// them.
-  ///
-  /// # Returns
-  ///
-  /// Process status and output:
-  ///
-  /// ```
-  /// {
-  ///   stdout: "Hello, World!",
-  ///   stderr: "",
-  ///   success: true,
-  ///   code: 0,
-  /// }
-  /// ```
-  ///
-  /// If the process got killed by a signal, it will contain a `signal` field
-  /// instead of `code`:
-  ///
-  /// ```
-  /// {
-  ///   stdout: "",
-  ///   stderr: "Getting killed by signal...",
-  ///   success: false,
-  ///   signal: 31,
-  /// }
-  /// ```
+  /**
+   * Run a command inside a more restrictive sandbox.
+   *
+   * While all extensions are already sandboxed, it can be useful to further
+   * restrict this execution environment when dealing with external commands
+   * that could potentially misbehave. This API allows restricting
+   * filesystem and network access for those processes.
+   *
+   * # Parameters
+   *
+   * The `process` parameter contains the command which shall be executed
+   * and its restrictions:
+   *
+   * ```
+   * {
+   *   cmd: "ls",
+   *   args: ["-lah"],
+   *   stdin: "null",
+   *   stdout: "piped",
+   *   stderr: "inherit",
+   *   exceptions: {
+   *     read: ["~/"],
+   *     write: false,
+   *     run: ["ls"],
+   *     net: false,
+   *     strict: false,
+   *   }
+   * }
+   * ```
+   *
+   * The `read`/`write`/`run` permissions accept either an array of paths,
+   * or a boolean. Paths must either be absolute or start with `~/`.
+   *
+   * For `run` the executables will be resolved from `$PATH` when they are
+   * neither absolute nor start with `~/`.
+   *
+   * The `net` permission accepts only boolean values.
+   *
+   * Some exceptions are added by default, to simplify the extension creation
+   * process. If you're looking for more granular control, you can set strict
+   * to `true` and no exceptions will be added without explicitly specifying
+   * them.
+   *
+   * # Returns
+   *
+   * Process status and output:
+   *
+   * ```
+   * {
+   *   stdout: "Hello, World!",
+   *   stderr: "",
+   *   success: true,
+   *   code: 0,
+   * }
+   * ```
+   *
+   * If the process got killed by a signal, it will contain a `signal` field
+   * instead of `code`:
+   *
+   * ```
+   * {
+   *   stdout: "",
+   *   stderr: "Getting killed by signal...",
+   *   success: false,
+   *   signal: 31,
+   * }
+   * ```
+   */
   static runSandboxed(process: object): object {
     return Deno.core.opSync("run_sandboxed", process);
   }
 
-  /// Get the extension's manifest permissions.
-  ///
-  /// # Returns
-  ///
-  /// The permissions object:
-  /// ```
-  /// {
-  ///   read: ["~/.npm"],
-  ///   write: ["/tmp"],
-  ///   run: ["ls", "echo", "npm"],
-  ///   env: ["HOME", "PATH"],
-  ///   net: false
-  /// }
-  /// ```
+  /**
+   * Get the extension's manifest permissions.
+   *
+   * # Returns
+   *
+   * The permissions object:
+   * ```
+   * {
+   *   read: ["~/.npm"],
+   *   write: ["/tmp"],
+   *   run: ["ls", "echo", "npm"],
+   *   env: ["HOME", "PATH"],
+   *   net: false
+   * }
+   * ```
+   */
   static permissions(): object {
     return Deno.core.opSync("op_permissions");
   }

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -2,13 +2,6 @@ export class PhylumApi {
   /**
    * Analyze dependencies in a lockfile.
    *
-   * This expects a `.phylum_project` file to be present if the `project`
-   * parameter is undefined.
-   *
-   * # Parameters
-   *
-   * Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget".
-   *
    * Packages are expected in the following format:
    *
    * ```
@@ -20,9 +13,12 @@ export class PhylumApi {
    * ]
    * ```
    *
-   * # Returns
+   * @param package_type - Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget"
+   * @param packages - List of packages to analyze
+   * @param project - Project name. If undefined, the `.phylum_project` file will be used
+   * @param group - Group name
    *
-   * Analyze Job ID, which can later be queried with `getJobStatus`.
+   * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
     package_type: string,
@@ -42,10 +38,9 @@ export class PhylumApi {
   /**
    * Get info about the logged in user.
    *
-   * # Returns
+   * @returns User information
    *
-   * Object containing user information:
-   *
+   * User information object example:
    * ```
    * {
    *   email: "user@phylum.io",
@@ -75,10 +70,9 @@ export class PhylumApi {
   /**
    * Get job results.
    *
-   * # Returns
+   * @returns Job analysis results
    *
-   * Job analysis results:
-   *
+   * Job analysis results example:
    * ```
    * {
    *   job_id: "de2d74b1-3925-4de9-9b8f-0c7b27f9b3c8",
@@ -130,10 +124,9 @@ export class PhylumApi {
   /**
    * Get currently linked project.
    *
-   * # Returns
+   * @returns Linked project information or null
    *
-   * Project information:
-   *
+   * Project information example:
    * ```
    * {
    *   id: "a3a898bc-e954-4ff6-ea36-6a19beefedaa",
@@ -142,8 +135,6 @@ export class PhylumApi {
    *   group_name: null
    * }
    * ```
-   *
-   * If no project is linked, this will return `null`.
    */
   static getCurrentProject(): object {
     return Deno.core.opSync("get_current_project");
@@ -152,10 +143,9 @@ export class PhylumApi {
   /**
    * List the user's groups.
    *
-   * # Returns
+   * @returns Accessible groups
    *
-   * Accessible groups:
-   *
+   * Accessible groups example:
    * ```
    * {
    *   groups: [
@@ -178,10 +168,9 @@ export class PhylumApi {
   /**
    * List the user's projects.
    *
-   * # Returns
+   * @returns Accessible projects
    *
-   * Accessible projects:
-   *
+   * Accessible projects example
    * ```
    * [
    *   {
@@ -202,24 +191,7 @@ export class PhylumApi {
   /**
    * Create a project.
    *
-   * # Returns
-   *
-   * An object containing the id of the project, and an indication
-   * stating whether the project was just created or already existing.
-   *
-   * ```
-   * {
-   *   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-   *   "status": "created"
-   * }
-   * ```
-   *
-   * ```
-   * {
-   *   "id": "5d6eaa97-dff8-dead-a619-bcafffefeef0",
-   *   "status": "exists"
-   * }
-   * ```
+   * @return Project ID and status indication
    */
   static createProject(name: string, group?: string): Promise<string> {
     return Deno.core.opAsync("create_project", name, group);
@@ -228,9 +200,7 @@ export class PhylumApi {
   /**
    * Delete a project.
    *
-   * # Returns
-   *
-   * Nothing if successful; throws an error if unsuccessful.
+   * Throws an error if unsuccessful.
    */
   static deleteProject(name: string, group?: string): Promise<string> {
     return Deno.core.opAsync("delete_project", name, group);
@@ -242,10 +212,9 @@ export class PhylumApi {
    * This will not start a new package analysis, but only retrieve previous
    * analysis results.
    *
-   * # Returns
+   * @returns Package analysis results
    *
-   * Package analysis results:
-   *
+   * Package analysis results example:
    * ```
    * {
    *   id: "npm:typescript:4.7.4",
@@ -305,10 +274,9 @@ export class PhylumApi {
   /**
    * Get dependencies inside a lockfile.
    *
-   * # Returns
+   * @returns Lockfile dependencies
    *
-   * List of dependencies:
-   *
+   * Lockfile dependencies example:
    * ```
    * {
    *   package_type: "npm",
@@ -333,11 +301,9 @@ export class PhylumApi {
    * that could potentially misbehave. This API allows restricting
    * filesystem and network access for those processes.
    *
-   * # Parameters
+   * @param process - The command which shall be executed and its restrictions
    *
-   * The `process` parameter contains the command which shall be executed
-   * and its restrictions:
-   *
+   * Process example:
    * ```
    * {
    *   cmd: "ls",
@@ -368,10 +334,9 @@ export class PhylumApi {
    * to `true` and no exceptions will be added without explicitly specifying
    * them.
    *
-   * # Returns
+   * @return Process status and output
    *
-   * Process status and output:
-   *
+   * Process status and output example:
    * ```
    * {
    *   stdout: "Hello, World!",
@@ -400,9 +365,9 @@ export class PhylumApi {
   /**
    * Get the extension's manifest permissions.
    *
-   * # Returns
+   * @returns Extension permissions
    *
-   * The permissions object:
+   * Permissions object example:
    * ```
    * {
    *   read: ["~/.npm"],

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file ban-types
+
 export class PhylumApi {
   /**
    * Analyze dependencies in a lockfile.
@@ -24,14 +26,14 @@ export class PhylumApi {
     package_type: string,
     packages: object[],
     project?: string,
-    group?: string
+    group?: string,
   ): Promise<string> {
-    return Deno.core.opAsync(
+    return opAsync(
       "analyze",
       package_type,
       packages,
       project,
-      group
+      group,
     );
   }
 
@@ -54,17 +56,17 @@ export class PhylumApi {
    * ```
    */
   static getUserInfo(): Promise<object> {
-    return Deno.core.opAsync("get_user_info");
+    return opAsync("get_user_info");
   }
 
   /** Get the current short-lived API access token. */
   static getAccessToken(): Promise<string> {
-    return Deno.core.opAsync("get_access_token");
+    return opAsync("get_access_token");
   }
 
   /** Get the long-lived user refresh token. */
   static getRefreshToken(): Promise<string> {
-    return Deno.core.opAsync("get_refresh_token");
+    return opAsync("get_refresh_token");
   }
 
   /**
@@ -118,7 +120,7 @@ export class PhylumApi {
    * ```
    */
   static getJobStatus(jobId: string): Promise<object> {
-    return Deno.core.opAsync("get_job_status", jobId);
+    return opAsync("get_job_status", jobId);
   }
 
   /**
@@ -136,8 +138,8 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getCurrentProject(): object {
-    return Deno.core.opSync("get_current_project");
+  static getCurrentProject(): object | null {
+    return opSync("get_current_project");
   }
 
   /**
@@ -162,7 +164,7 @@ export class PhylumApi {
    * ```
    */
   static getGroups(): Promise<object> {
-    return Deno.core.opAsync("get_groups");
+    return opAsync("get_groups");
   }
 
   /**
@@ -184,8 +186,8 @@ export class PhylumApi {
    * ]
    * ```
    */
-  static getProjects(group?: string): Promise<object> {
-    return Deno.core.opAsync("get_projects", group);
+  static getProjects(group?: string): Promise<object[]> {
+    return opAsync("get_projects", group);
   }
 
   /**
@@ -193,8 +195,11 @@ export class PhylumApi {
    *
    * @return Project ID and status indication
    */
-  static createProject(name: string, group?: string): Promise<string> {
-    return Deno.core.opAsync("create_project", name, group);
+  static createProject(
+    name: string,
+    group?: string,
+  ): Promise<{ id: string; status: "created" | "existed" }> {
+    return opAsync("create_project", name, group);
   }
 
   /**
@@ -202,8 +207,8 @@ export class PhylumApi {
    *
    * Throws an error if unsuccessful.
    */
-  static deleteProject(name: string, group?: string): Promise<string> {
-    return Deno.core.opAsync("delete_project", name, group);
+  static deleteProject(name: string, group?: string): Promise<void> {
+    return opAsync("delete_project", name, group);
   }
 
   /**
@@ -261,13 +266,13 @@ export class PhylumApi {
   static getPackageDetails(
     name: string,
     version: string,
-    packageType: string
+    packageType: string,
   ): Promise<object> {
-    return Deno.core.opAsync(
+    return opAsync(
       "get_package_details",
       name,
       version,
-      packageType
+      packageType,
     );
   }
 
@@ -289,8 +294,11 @@ export class PhylumApi {
    * }
    * ```
    */
-  static parseLockfile(lockfile: string, lockfileType?: string): Promise<object> {
-    return Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
+  static parseLockfile(
+    lockfile: string,
+    lockfileType?: string,
+  ): Promise<object> {
+    return opAsync("parse_lockfile", lockfile, lockfileType);
   }
 
   /**
@@ -359,7 +367,7 @@ export class PhylumApi {
    * ```
    */
   static runSandboxed(process: object): object {
-    return Deno.core.opSync("run_sandboxed", process);
+    return opSync("run_sandboxed", process);
   }
 
   /**
@@ -379,6 +387,16 @@ export class PhylumApi {
    * ```
    */
   static permissions(): object {
-    return Deno.core.opSync("op_permissions");
+    return opSync("op_permissions");
   }
+}
+
+function opSync<T>(op: string, ...args: unknown[]): T {
+  // deno-lint-ignore no-explicit-any
+  return (Deno as any).core.opSync(op, ...args) as T;
+}
+
+function opAsync<T>(op: string, ...args: unknown[]): Promise<T> {
+  // deno-lint-ignore no-explicit-any
+  return (Deno as any).core.opAsync(op, ...args) as Promise<T>;
 }

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -15,7 +15,7 @@ export class PhylumApi {
    * ]
    * ```
    *
-   * @param package_type - Accepted package types are "npm", "pypi", "maven", "rubygems", and "nuget"
+   * @param package_type - Accepted package types are "npm", "pypi", "maven", "rubygems", "nuget", "cargo", and "golang"
    * @param packages - List of packages to analyze
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
    * @param group - Group name


### PR DESCRIPTION
This patch switches the doc comments in our extension API definition file to JSDoc style comments. This change allows our docs to be consumed by normal deno tools for generating docs.

To see an example of these docs rendered, view them here on [doc.deno.land](https://doc.deno.land/https://raw.githubusercontent.com/phylum-dev/cli/jsdoc/cli/src/extension_api.ts/~/PhylumApi).