### PR TITLE
Add extension helpers for direct API requests

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -473,6 +473,14 @@ fn op_permissions(op_state: Rc<RefCell<OpState>>) -> permissions::Permissions {
     state.extension().permissions().into_owned()
 }
 
+#[op]
+async fn api_base_url(op_state: Rc<RefCell<OpState>>) -> Result<String> {
+    let state = ExtensionState::from(op_state);
+    let api = state.api().await?;
+    let url = api.config().connection.uri.clone() + "/api";
+    Ok(url)
+}
+
 pub(crate) fn api_decls() -> Vec<OpDecl> {
     vec![
         analyze::decl(),
@@ -489,5 +497,6 @@ pub(crate) fn api_decls() -> Vec<OpDecl> {
         parse_lockfile::decl(),
         run_sandboxed::decl(),
         op_permissions::decl(),
+        api_base_url::decl(),
     ]
 }

--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -244,16 +244,20 @@ impl From<&Permissions> for PermissionsOptions {
         let allow_write =
             value.write.get().map(|write| write.iter().map(PathBuf::from).collect::<Vec<_>>());
 
-        let allow_env = value.env.get().cloned();
-        let allow_net = value.net.get().cloned();
+        let mut allow_net = value.net.get().cloned().unwrap_or_default();
         let allow_run = value.unsandboxed_run.get().cloned();
+        let allow_env = value.env.get().cloned();
+
+        // Add net exceptions to phylum.io's domains by default.
+        allow_net.push("api.staging.phylum.io".into());
+        allow_net.push("api.phylum.io".into());
 
         PermissionsOptions {
             allow_read,
             allow_write,
-            allow_net,
             allow_run,
             allow_env,
+            allow_net: Some(allow_net),
             allow_sys: None,
             allow_ffi: None,
             allow_hrtime: false,

--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -361,7 +361,12 @@ mod tests {
         assert!(permissions_options.allow_write.is_none());
         assert!(permissions_options.allow_env.is_none());
         assert!(permissions_options.allow_run.is_none());
-        assert!(permissions_options.allow_net.is_none());
+
+        // NOTE: Net is an exception since we allow our own API domains by default.
+        assert_eq!(
+            permissions_options.allow_net,
+            Some(vec!["api.staging.phylum.io".into(), "api.phylum.io".into()])
+        );
     }
 
     #[test]

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -48,7 +48,7 @@ export class PhylumApi {
    * This will usually return `https://api.phylum.io/api`.
    */
   static async apiBaseUrl(): Promise<URL> {
-    return new URL(await opAsync("api_base_url"));
+    return new URL(await Deno.core.opAsync("api_base_url"));
   }
 
   /**

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -8,37 +8,30 @@ export class PhylumApi {
    *
    * See https://api.staging.phylum.io/api/v0/swagger/index.html for available API endpoints.
    *
-   * The `options` parameter matches the `options` parameter of the `fetch` function:
-   * https://developer.mozilla.org/en-US/docs/Web/API/fetch
+   * The `init` parameter matches the `init` parameter of the Deno `fetch` function:
+   * https://deno.land/api@latest?s=fetch
    */
   static async fetch(
     apiVersion: ApiVersion | string,
     endpoint: string,
-    options?: RequestInit,
+    init?: RequestInit,
   ): Promise<object> {
     // Ensure header object is initialized.
-    const fetchOptions = options ?? {};
-    fetchOptions.headers = fetchOptions.headers ?? {};
+    const fetchInit = init ?? {};
+    fetchInit.headers = fetchInit.headers ?? {};
 
-    // Set Authorization/Content-Type headers if they are missing.
-    if (fetchOptions.headers instanceof Headers) {
-      if (!fetchOptions.headers.has("Authorization")) {
-        const token = await PhylumApi.getAccessToken();
-        fetchOptions.headers.set("Authorization", `Bearer ${token}`);
-      }
+    // Ensure consistent headers type.
+    fetchInit.headers = new Headers(fetchInit.headers);
 
-      if (fetchOptions.headers.has("Content-Type")) {
-        fetchOptions.headers.set("Content-Type", "application/json");
-      }
-    } else {
-      if (!fetchOptions.headers["Authorization"]) {
-        const token = await PhylumApi.getAccessToken();
-        fetchOptions.headers["Authorization"] = `Bearer ${token}`;
-      }
+    // Set Authorization header if it is missing.
+    if (!fetchInit.headers.has("Authorization")) {
+      const token = await PhylumApi.getAccessToken();
+      fetchInit.headers.set("Authorization", `Bearer ${token}`);
+    }
 
-      if (!fetchOptions.headers["Content-Type"]) {
-        fetchOptions.headers["Content-Type"] = "application/json";
-      }
+    // Set Content-Type header if it is missing.
+    if (fetchInit.headers.has("Content-Type")) {
+      fetchInit.headers.set("Content-Type", "application/json");
     }
 
     // Set Content-Type header if it is missing.
@@ -47,7 +40,7 @@ export class PhylumApi {
     const baseUrl = await PhylumApi.apiBaseUrl();
 
     // Send fetch request.
-    return fetch(`${baseUrl}/${apiVersion}${endpoint}`, fetchOptions);
+    return fetch(`${baseUrl}/${apiVersion}${endpoint}`, fetchInit);
   }
 
   /**

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -4,15 +4,6 @@
 
 export class PhylumApi {
   /**
-   * Get the Phylum REST API base URL.
-   *
-   * This will usually return `https://api.phylum.io/api`.
-   */
-  static async apiBaseUrl(): string {
-    return Deno.core.opAsync("api_base_url");
-  }
-
-  /**
    * Send a request to the Phylum REST API.
    *
    * See https://api.staging.phylum.io/api/v0/swagger/index.html for available API endpoints.
@@ -20,11 +11,11 @@ export class PhylumApi {
    * The `options` parameter matches the `options` parameter of the `fetch` function:
    * https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
-  static async fetchPhylum(
-    apiVersion: ApiVersion,
+  static fetch(
+    apiVersion: ApiVersion | string,
     endpoint: string,
     options?: object
-  ): object {
+  ): Promise<object> {
     // Ensure header object is initialized.
     const fetchOptions = options ?? {};
     fetchOptions.headers = fetchOptions.headers ?? {};
@@ -57,6 +48,15 @@ export class PhylumApi {
 
     // Send fetch request.
     return fetch(`${baseUrl}/${apiVersion}${endpoint}`, fetchOptions);
+  }
+
+  /**
+   * Get the Phylum REST API base URL.
+   *
+   * This will usually return `https://api.phylum.io/api`.
+   */
+  static async apiBaseUrl(): Promise<URL> {
+    return new Url(await opAsync("api_base_url"));
   }
 
   /**

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -18,7 +18,6 @@ export class PhylumApi {
   ): Promise<object> {
     // Ensure header object is initialized.
     const fetchInit = init ?? {};
-    fetchInit.headers = fetchInit.headers ?? {};
 
     // Ensure consistent headers type.
     fetchInit.headers = new Headers(fetchInit.headers);
@@ -77,7 +76,7 @@ export class PhylumApi {
     package_type: string,
     packages: object[],
     project?: string,
-    group?: string
+    group?: string,
   ): Promise<string> {
     return Deno.core.opAsync(
       "analyze",
@@ -248,7 +247,7 @@ export class PhylumApi {
    */
   static createProject(
     name: string,
-    group?: string
+    group?: string,
   ): Promise<{ id: string; status: "created" | "existed" }> {
     return Deno.core.opAsync("create_project", name, group);
   }
@@ -317,7 +316,7 @@ export class PhylumApi {
   static getPackageDetails(
     name: string,
     version: string,
-    packageType: string
+    packageType: string,
   ): Promise<object> {
     return Deno.core.opAsync(
       "get_package_details",
@@ -347,7 +346,7 @@ export class PhylumApi {
    */
   static parseLockfile(
     lockfile: string,
-    lockfileType?: string
+    lockfileType?: string,
   ): Promise<object> {
     return Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
   }

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -11,10 +11,10 @@ export class PhylumApi {
    * The `options` parameter matches the `options` parameter of the `fetch` function:
    * https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
-  static fetch(
+  static async fetch(
     apiVersion: ApiVersion | string,
     endpoint: string,
-    options?: object
+    options?: RequestInit,
   ): Promise<object> {
     // Ensure header object is initialized.
     const fetchOptions = options ?? {};
@@ -56,7 +56,7 @@ export class PhylumApi {
    * This will usually return `https://api.phylum.io/api`.
    */
   static async apiBaseUrl(): Promise<URL> {
-    return new Url(await opAsync("api_base_url"));
+    return new URL(await opAsync("api_base_url"));
   }
 
   /**

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -158,8 +158,11 @@ impl<'a> TestExtension<'a> {
 
         // Overwrite skeleton code.
         let main = extension_path.join("main.ts");
-        fs::write(main, format!("import {{ PhylumApi }} from 'phylum';\n{code}").as_bytes())
-            .unwrap();
+        fs::write(
+            main,
+            format!("import {{ PhylumApi, ApiVersion }} from 'phylum';\n{code}").as_bytes(),
+        )
+        .unwrap();
 
         // Overwrite permissions.
         let manifest_path = extension_path.join("PhylumExt.toml");

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -185,3 +185,21 @@ pub fn async_state() {
         .run()
         .success();
 }
+
+#[tokio::test]
+pub async fn rest_api() {
+    let test_cli = TestCli::builder().with_config(None).build();
+
+    test_cli
+        .extension(
+            "
+            const reply = await PhylumApi.fetchPhylum(ApiVersion.V0, '/health');
+            console.log(await reply.json());
+        ",
+        )
+        .with_permissions(Permissions { net: Permission::Boolean(true), ..Permissions::default() })
+        .build()
+        .run()
+        .success()
+        .stdout("{ response: \"alive!\" }\n");
+}

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -193,7 +193,7 @@ pub async fn rest_api() {
     test_cli
         .extension(
             "
-            const reply = await PhylumApi.fetchPhylum(ApiVersion.V0, '/health');
+            const reply = await PhylumApi.fetch(ApiVersion.V0, '/health');
             console.log(await reply.json());
         ",
         )

--- a/docs/extensions/extension_overview.md
+++ b/docs/extensions/extension_overview.md
@@ -29,6 +29,7 @@ look at the [CLI's extension documentation].
 * [Manifest Format](https://docs.phylum.io/docs/extension_manifest)
 * [Extension API](https://docs.phylum.io/docs/extension_api)
 * [Example](https://docs.phylum.io/docs/extension_example)
+* [Direct Phylum API Requests](https://docs.phylum.io/docs/extension_rest_api)
 
 ## Official Extensions
 

--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -36,9 +36,11 @@ const projects = await reply.json();
 console.log(projects);
 ```
 
-Allowed options match the `fetch` API and can be overwritten to send more
-complicated requests. The following example creates a new Phylum project through
-the API:
+The last parameter matches [Deno's `fetch` function] and can be overwritten to
+send more complicated requests. The following example creates a new Phylum
+project through the API:
+
+[Deno's `fetch` function]: https://deno.land/api@latest?s=fetch
 
 ```ts
 import { PhylumApi, ApiVersion } from "phylum";

--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -16,15 +16,15 @@ https://api.staging.phylum.io/api/v0/swagger/index.html
 ## Extension API requests
 
 To make a Request to Phylum's REST API, you can use the built-in
-`PhylumApi.fetchPhylum` function, which takes care of authentication and finding
-the correct base URI. The following example retrieves projects owned by the
-user which do not belong to any group:
+`PhylumApi.fetch` function, which takes care of authentication and finding the
+correct base URI. The following example retrieves projects owned by the user
+which do not belong to any group:
 
 ```ts
 import { PhylumApi, ApiVersion } from "phylum";
 
 // Create a fetch request to the `/data/projects/overview` endpoint.
-const reply = await PhylumApi.fetchPhylum(
+const reply = await PhylumApi.fetch(
     ApiVersion.V0,
     '/data/projects/overview',
 );
@@ -44,7 +44,7 @@ the API:
 import { PhylumApi, ApiVersion } from "phylum";
 
 // Create a fetch request to the `/data/projects` endpoint.
-const reply = await PhylumApi.fetchPhylum(
+const reply = await PhylumApi.fetch(
     ApiVersion.V0,
     '/data/projects',
     {

--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -1,0 +1,63 @@
+---
+title: Direct Phylum API Requests
+category: 62c5cb137dbdad00536291a6
+hidden: false
+---
+
+## Phylum REST API
+
+Phylum provides a versioned REST API for retrieving all available data. This
+REST API can be used directly by extensions if there is no TypeScript API
+available.
+
+All endpoins are documented here:
+https://api.staging.phylum.io/api/v0/swagger/index.html
+
+## Extension API requests
+
+To make a Request to Phylum's REST API, you can use the built-in
+`PhylumApi.fetchPhylum` function, which takes care of authentication and finding
+the correct base URI. The following example retrieves projects owned by the
+user which do not belong to any group:
+
+```ts
+import { PhylumApi, ApiVersion } from "phylum";
+
+// Create a fetch request to the `/data/projects/overview` endpoint.
+const reply = await PhylumApi.fetchPhylum(
+    ApiVersion.V0,
+    '/data/projects/overview',
+);
+
+// Parse the reply as JSON.
+const projects = await reply.json();
+
+// Output all our projects.
+console.log(projects);
+```
+
+Allowed options match the `fetch` API and can be overwritten to send more
+complicated requests. The following example creates a new Phylum project through
+the API:
+
+```ts
+import { PhylumApi, ApiVersion } from "phylum";
+
+// Create a fetch request to the `/data/projects` endpoint.
+const reply = await PhylumApi.fetchPhylum(
+    ApiVersion.V0,
+    '/data/projects',
+    {
+        method: 'POST',
+        body: JSON.stringify({
+            name: 'api_example',
+        }),
+    },
+);
+
+// Parse the reply as JSON.
+const project = await reply.json();
+
+// Output the new project.
+console.log(project);
+```


### PR DESCRIPTION
This patch adds some new abstractions to the extension API which make it easier for extension authors to make requests directly to Phylum's REST API.

To ensure people can figure out how they're supposed to use these new functions, the functionality has also been documented in our extension documentation.

Closes #863.
Closes #862.

---

Outstanding questions before undraft:
 - [x] Should probably write some tests
 - [x] Do we like the `fetchPhylum` name? Suggestions welcome
 - [x] Should we add a general net exception for our API URIs, or require adding them manually?