### PR TITLE
Fix group prompt during `phylum init`

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -108,17 +108,12 @@ fn prompt_project_name() -> io::Result<String> {
 
 /// Ask for the desired group.
 fn prompt_group() -> io::Result<Option<String>> {
-    let should_prompt =
-        Confirm::new().with_prompt("Use a project group?").default(false).interact()?;
+    let group: String = Input::new()
+        .with_prompt("Project Group [default: no group]")
+        .allow_empty(true)
+        .interact_text()?;
 
-    if !should_prompt {
-        return Ok(None);
-    }
-
-    let group: String =
-        Input::new().with_prompt("Project Group (default: none)").interact_text()?;
-
-    Ok(Some(group))
+    Ok((!group.is_empty()).then_some(group))
 }
 
 /// Interactively ask for missing lockfile information.


### PR DESCRIPTION
Currently when running `phylum init`, the user is first asked if they want to use a group and then forced to enter a group name. While it has documented none sa the default, it is not possible to just press enter to use that default. As a result users are forced to abort and restart `phylum init` if they accidentally landed here.

This patch combines the prompt for entering a group and the actual group name input into a single prompt. This way the user is never "stuck" in a state where he has to Ctrl+C out of. This also makes it quicker to enter a group should it be desired.
