### PR TITLE
Don't warn about config search if we didn't recurse

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -213,7 +213,9 @@ pub fn find_project_conf(
         path = path.parent()?;
     }
 
-    log::warn!("Max depth exceeded; abandoning search for .phylum_project file");
+    if recurse_upwards {
+        log::warn!("Max depth exceeded; abandoning search for .phylum_project file");
+    }
 
     None
 }


### PR DESCRIPTION
This patch fixes the warning emitted by `phylum init` when there is no config file in the current directory.