### PR TITLE
Type check TypeScript files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,8 @@ jobs:
         run: deno fmt --check
       - name: deno lint
         run: deno lint
+      - name: deno check
+        run: deno check --no-lock cli/src/extension_api.ts extensions/**/*.ts
 
   shellcheck:
     # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -15,8 +15,8 @@ type ProcessOutput = {
   stdout: string;
   stderr: string;
   success: boolean;
-  signal?: number;
-  code?: number;
+  signal: number | null;
+  code: number | null;
 };
 
 export class PhylumApi {

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -1,7 +1,23 @@
-// deno-lint-ignore-file ban-types
-
 /// <reference types="https://raw.githubusercontent.com/denoland/deno/v1.28.3/core/lib.deno_core.d.ts" />
 /// <reference lib="deno.window" />
+
+type Package = {
+  name: string;
+  version: string;
+};
+
+type Lockfile = {
+  package_type: string;
+  packages: Package[];
+};
+
+type ProcessOutput = {
+  stdout: string;
+  stderr: string;
+  success: boolean;
+  signal?: number;
+  code?: number;
+};
 
 export class PhylumApi {
   /**
@@ -16,7 +32,7 @@ export class PhylumApi {
     apiVersion: ApiVersion | string,
     endpoint: string,
     init?: RequestInit,
-  ): Promise<object> {
+  ): Promise<Response> {
     // Ensure header object is initialized.
     const fetchInit = init ?? {};
 
@@ -75,7 +91,7 @@ export class PhylumApi {
    */
   static analyze(
     package_type: string,
-    packages: object[],
+    packages: Package[],
     project?: string,
     group?: string,
   ): Promise<string> {
@@ -106,7 +122,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getUserInfo(): Promise<object> {
+  static getUserInfo(): Promise<Record<string, unknown>> {
     return Deno.core.opAsync("get_user_info");
   }
 
@@ -170,7 +186,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getJobStatus(jobId: string): Promise<object> {
+  static getJobStatus(jobId: string): Promise<Record<string, unknown>> {
     return Deno.core.opAsync("get_job_status", jobId);
   }
 
@@ -189,7 +205,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getCurrentProject(): object | null {
+  static getCurrentProject(): Record<string, unknown> | null {
     return Deno.core.ops.get_current_project();
   }
 
@@ -214,7 +230,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getGroups(): Promise<object> {
+  static getGroups(): Promise<Record<string, unknown>> {
     return Deno.core.opAsync("get_groups");
   }
 
@@ -237,7 +253,7 @@ export class PhylumApi {
    * ]
    * ```
    */
-  static getProjects(group?: string): Promise<object[]> {
+  static getProjects(group?: string): Promise<Record<string, unknown>[]> {
     return Deno.core.opAsync("get_projects", group);
   }
 
@@ -318,7 +334,7 @@ export class PhylumApi {
     name: string,
     version: string,
     packageType: string,
-  ): Promise<object> {
+  ): Promise<Record<string, unknown>> {
     return Deno.core.opAsync(
       "get_package_details",
       name,
@@ -348,7 +364,7 @@ export class PhylumApi {
   static parseLockfile(
     lockfile: string,
     lockfileType?: string,
-  ): Promise<object> {
+  ): Promise<Lockfile> {
     return Deno.core.opAsync("parse_lockfile", lockfile, lockfileType);
   }
 
@@ -417,7 +433,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static runSandboxed(process: object): object {
+  static runSandboxed(process: Record<string, unknown>): ProcessOutput {
     return Deno.core.ops.run_sandboxed(process);
   }
 
@@ -437,7 +453,7 @@ export class PhylumApi {
    * }
    * ```
    */
-  static permissions(): object {
+  static permissions(): Record<string, unknown> {
     return Deno.core.ops.op_permissions();
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -9,5 +9,6 @@
     "files": {
       "include": ["extensions/", "cli/src/extension_api.ts"]
     }
-  }
+  },
+  "lock": false
 }

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,5 @@
 {
+  "importMap": "import_map.json",
   "lint": {
     "files": {
       "include": ["extensions/", "cli/src/extension_api.ts"]

--- a/extensions/duplicates/main.ts
+++ b/extensions/duplicates/main.ts
@@ -19,7 +19,7 @@ const groupedDeps = groupBy(lockfile.packages, (dep) => dep.name);
 // Reduce each dependency to a list of its versions.
 const reducedDeps = mapValues(
   groupedDeps,
-  (deps) => deps.map((dep) => dep.version),
+  (deps) => deps!.map((dep) => dep.version),
 );
 
 for (const [dep, versions] of Object.entries(reducedDeps)) {

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -216,7 +216,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | undefined) {
+async function abort(code: number | null) {
   await restoreBackup();
   Deno.exit(code ?? -1);
 }

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -147,7 +147,7 @@ if (!output.success) {
     }] Please submit your lockfile to Phylum should this error persist.`,
   );
 
-  await abort(output.code);
+  await abort(output.code ?? 255);
 } else {
   console.log(`[${green("phylum")}] Packages built successfully.`);
 }
@@ -216,9 +216,9 @@ async function checkDryRun(subcommand: string, args: string[]) {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | null) {
+async function abort(code: number) {
   await restoreBackup();
-  Deno.exit(code ?? -1);
+  Deno.exit(code);
 }
 
 // Restore package manager files.

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -216,9 +216,9 @@ async function checkDryRun(subcommand: string, args: string[]) {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number) {
+async function abort(code: number | undefined) {
   await restoreBackup();
-  Deno.exit(code);
+  Deno.exit(code ?? -1);
 }
 
 // Restore package manager files.

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -121,7 +121,7 @@ async function poetryCheckDryRun(
   // Ensure dry-run update was successful.
   if (!status.success) {
     console.error(`[${red("phylum")}] Lockfile update failed.\n`);
-    await abort(status.code);
+    await abort(status.code ?? 255);
   }
 
   const lockfileData = await PhylumApi.parseLockfile("./poetry.lock", "poetry");
@@ -168,9 +168,9 @@ async function poetryCheckDryRun(
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | null) {
+async function abort(code: number) {
   await restoreBackup();
-  Deno.exit(code ?? -1);
+  Deno.exit(code);
 }
 
 // Restore package manager files.

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -168,9 +168,9 @@ async function poetryCheckDryRun(
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number) {
+async function abort(code: number | undefined) {
   await restoreBackup();
-  Deno.exit(code);
+  Deno.exit(code ?? -1);
 }
 
 // Restore package manager files.

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -168,7 +168,7 @@ async function poetryCheckDryRun(
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | undefined) {
+async function abort(code: number | null) {
   await restoreBackup();
   Deno.exit(code ?? -1);
 }

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -220,9 +220,9 @@ async function checkDryRun() {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number) {
+async function abort(code: number | undefined) {
   await restoreBackup();
-  Deno.exit(code);
+  Deno.exit(code ?? -1);
 }
 
 // Restore package manager files.

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -112,7 +112,7 @@ const status = PhylumApi.runSandboxed({
 // Ensure download worked. Failure is still "safe" for the user.
 if (!status.success) {
   console.error(`[${red("phylum")}] Downloading packages to cache failed.\n`);
-  await abort(status.code);
+  await abort(status.code ?? 255);
 } else {
   console.log(`[${green("phylum")}] Cache updated successfully.\n`);
 }
@@ -154,7 +154,7 @@ if (!output.success) {
     }] Please submit your lockfile to Phylum should this error persist.`,
   );
 
-  await abort(output.code);
+  await abort(output.code ?? 255);
 } else {
   console.log(`[${green("phylum")}] Packages built successfully.`);
 }
@@ -177,7 +177,7 @@ async function checkDryRun() {
   // Ensure lockfile update was successful.
   if (!status.success) {
     console.error(`[${red("phylum")}] Lockfile update failed.\n`);
-    await abort(status.code);
+    await abort(status.code ?? 255);
   }
 
   const lockfile = await PhylumApi.parseLockfile("./yarn.lock", "yarn");
@@ -220,9 +220,9 @@ async function checkDryRun() {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | null) {
+async function abort(code: number) {
   await restoreBackup();
-  Deno.exit(code ?? -1);
+  Deno.exit(code);
 }
 
 // Restore package manager files.

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -220,7 +220,7 @@ async function checkDryRun() {
 //
 // This assumes that execution was not successful and it will automatically
 // revert to the last stored package manager files.
-async function abort(code: number | undefined) {
+async function abort(code: number | null) {
   await restoreBackup();
   Deno.exit(code ?? -1);
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "phylum": "./cli/src/extension_api.ts"
+  }
+}


### PR DESCRIPTION
Our files have a lot of type checking issues because most of our `PhylumApi` function return `object` instead of an actual type.

Resolving these issues might mean adding lots of new types to our extension API. It might be a while before I can do that, but I am putting up the PR to keep track of it.