### PR TITLE
Add --reauth flag to phylum auth login

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -201,8 +201,10 @@ impl PhylumApi {
         mut auth_info: AuthInfo,
         ignore_certs: bool,
         api_uri: &str,
+        reauth: bool,
     ) -> Result<AuthInfo> {
-        let tokens = handle_auth_flow(&AuthAction::Login, ignore_certs, api_uri).await?;
+        let action = if reauth { AuthAction::Reauth } else { AuthAction::Login };
+        let tokens = handle_auth_flow(&action, ignore_certs, api_uri).await?;
         auth_info.set_offline_access(tokens.refresh_token);
         Ok(auth_info)
     }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -166,7 +166,7 @@ impl PhylumApi {
                     .context("Token refresh failed")?
             },
             None => {
-                handle_auth_flow(&AuthAction::Login, config.ignore_certs(), &config.connection.uri)
+                handle_auth_flow(AuthAction::Login, config.ignore_certs(), &config.connection.uri)
                     .await
                     .context("User login failed")?
             },
@@ -204,7 +204,7 @@ impl PhylumApi {
         reauth: bool,
     ) -> Result<AuthInfo> {
         let action = if reauth { AuthAction::Reauth } else { AuthAction::Login };
-        let tokens = handle_auth_flow(&action, ignore_certs, api_uri).await?;
+        let tokens = handle_auth_flow(action, ignore_certs, api_uri).await?;
         auth_info.set_offline_access(tokens.refresh_token);
         Ok(auth_info)
     }
@@ -217,7 +217,7 @@ impl PhylumApi {
         ignore_certs: bool,
         api_uri: &str,
     ) -> Result<AuthInfo> {
-        let tokens = handle_auth_flow(&AuthAction::Register, ignore_certs, api_uri).await?;
+        let tokens = handle_auth_flow(AuthAction::Register, ignore_certs, api_uri).await?;
         auth_info.set_offline_access(tokens.refresh_token);
         Ok(auth_info)
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -200,7 +200,15 @@ pub fn add_subcommands(command: Command) -> Command {
             Command::new("auth")
                 .about("Manage authentication, registration, and API keys")
                 .subcommand(Command::new("register").about("Register a new account"))
-                .subcommand(Command::new("login").about("Login to an existing account"))
+                .subcommand(
+                    Command::new("login").about("Login to an existing account").arg(
+                        Arg::new("reauth")
+                            .action(ArgAction::SetTrue)
+                            .short('r')
+                            .long("reauth")
+                            .help("Force a login prompt"),
+                    ),
+                )
                 .subcommand(
                     Command::new("status").about("Return the current authentication status"),
                 )

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -24,6 +24,7 @@ pub const OIDC_SCOPES: [&str; 4] = ["openid", "offline_access", "profile", "emai
 /// OIDC Client id used to identify this client to the oidc server
 pub const OIDC_CLIENT_ID: &str = "phylum_cli";
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AuthAction {
     Login,
     Reauth,
@@ -100,13 +101,13 @@ pub struct OidcServerSettings {
 
 /// Using config information, build the url for the keycloak login page.
 pub fn build_auth_url(
-    action: &AuthAction,
+    action: AuthAction,
     oidc_settings: &OidcServerSettings,
     callback_url: &Url,
     code_challenge: &ChallengeCode,
     state: impl AsRef<str>,
 ) -> Result<Url> {
-    let mut auth_url = match *action {
+    let mut auth_url = match action {
         // Login uses the oidc defined /auth endpoint as is
         AuthAction::Login | AuthAction::Reauth => oidc_settings.authorization_endpoint.to_owned(),
         // Register uses the non-standard /registrations endpoint
@@ -133,7 +134,7 @@ pub fn build_auth_url(
         .append_pair("scope", &OIDC_SCOPES.join(" "))
         .append_pair("state", state.as_ref());
 
-    if matches!(*action, AuthAction::Reauth) {
+    if action == AuthAction::Reauth {
         auth_url.query_pairs_mut().append_pair("prompt", "login");
     }
 

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -26,6 +26,7 @@ pub const OIDC_CLIENT_ID: &str = "phylum_cli";
 
 pub enum AuthAction {
     Login,
+    Reauth,
     Register,
 }
 
@@ -107,7 +108,7 @@ pub fn build_auth_url(
 ) -> Result<Url> {
     let mut auth_url = match *action {
         // Login uses the oidc defined /auth endpoint as is
-        AuthAction::Login => oidc_settings.authorization_endpoint.to_owned(),
+        AuthAction::Login | AuthAction::Reauth => oidc_settings.authorization_endpoint.to_owned(),
         // Register uses the non-standard /registrations endpoint
         AuthAction::Register => {
             let mut auth_url = oidc_settings.authorization_endpoint.to_owned();
@@ -131,6 +132,10 @@ pub fn build_auth_url(
         .append_pair("response_mode", "query")
         .append_pair("scope", &OIDC_SCOPES.join(" "))
         .append_pair("state", state.as_ref());
+
+    if matches!(*action, AuthAction::Reauth) {
+        auth_url.query_pairs_mut().append_pair("prompt", "login");
+    }
 
     Ok(auth_url)
 }

--- a/cli/src/auth/server.rs
+++ b/cli/src/auth/server.rs
@@ -131,7 +131,7 @@ async fn keycloak_callback_handler(request: Request<Body>) -> Result<Response<Bo
 /// which then need to passed on to the /token endpoint to obtain tokens
 async fn spawn_server_and_get_auth_code(
     oidc_settings: &OidcServerSettings,
-    redirect_type: &AuthAction,
+    redirect_type: AuthAction,
     code_challenge: &ChallengeCode,
     state: impl AsRef<str> + 'static,
 ) -> Result<(AuthorizationCode, Url)> {
@@ -219,7 +219,7 @@ async fn spawn_server_and_get_auth_code(
 
 /// Handle the user login/registration flow.
 pub async fn handle_auth_flow(
-    auth_action: &AuthAction,
+    auth_action: AuthAction,
     ignore_certs: bool,
     api_uri: &str,
 ) -> Result<TokenResponse> {
@@ -252,7 +252,7 @@ mod test {
         let state: String =
             thread_rng().sample_iter(&Alphanumeric).take(32).map(char::from).collect();
 
-        spawn_server_and_get_auth_code(&oidc_settings, &AuthAction::Login, &challenge, state)
+        spawn_server_and_get_auth_code(&oidc_settings, AuthAction::Login, &challenge, state)
             .await?;
 
         Ok(())
@@ -267,7 +267,7 @@ mod test {
         let (_verifier, _challenge) =
             CodeVerifier::generate(64).expect("Failed to build PKCE verifier and challenge");
 
-        let result = handle_auth_flow(&AuthAction::Login, false, &api_uri).await?;
+        let result = handle_auth_flow(AuthAction::Login, false, &api_uri).await?;
 
         log::debug!("{:?}", result);
 
@@ -283,7 +283,7 @@ mod test {
         let (_verifier, _challenge) =
             CodeVerifier::generate(64).expect("Failed to build PKCE verifier and challenge");
 
-        let result = handle_auth_flow(&AuthAction::Register, false, &api_uri).await?;
+        let result = handle_auth_flow(AuthAction::Register, false, &api_uri).await?;
 
         log::debug!("{:?}", result);
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
-use clap::Command;
+use clap::{ArgMatches, Command};
 use phylum_types::types::auth::RefreshToken;
 use tokio::io::{self, AsyncBufReadExt, BufReader};
 
@@ -23,10 +23,16 @@ async fn handle_auth_register(mut config: Config, config_path: &Path) -> Result<
 
 /// Login a user. Opens a browser, and redirects the user to the oauth server
 /// login page
-async fn handle_auth_login(mut config: Config, config_path: &Path, reauth: bool) -> Result<()> {
+async fn handle_auth_login(
+    mut config: Config,
+    config_path: &Path,
+    matches: &ArgMatches,
+) -> Result<()> {
     let api_uri = &config.connection.uri;
     let ignore_certs = config.ignore_certs();
-    config.auth_info = PhylumApi::login(config.auth_info, ignore_certs, api_uri, reauth).await?;
+    config.auth_info =
+        PhylumApi::login(config.auth_info, ignore_certs, api_uri, matches.get_flag("reauth"))
+            .await?;
     save_config(config_path, &config).map_err(|error| anyhow!(error))?;
     Ok(())
 }
@@ -130,14 +136,12 @@ pub async fn handle_auth(
             },
             Err(error) => Err(error).context("User registration failed"),
         },
-        Some(("login", matches)) => {
-            match handle_auth_login(config, config_path, matches.get_flag("reauth")).await {
-                Ok(_) => {
-                    print_user_success!("{}", "User login successful");
-                    Ok(ExitCode::Ok.into())
-                },
-                Err(error) => Err(error).context("User login failed"),
-            }
+        Some(("login", matches)) => match handle_auth_login(config, config_path, matches).await {
+            Ok(_) => {
+                print_user_success!("{}", "User login successful");
+                Ok(ExitCode::Ok.into())
+            },
+            Err(error) => Err(error).context("User login failed"),
         },
         Some(("status", _)) => handle_auth_status(config, timeout).await,
         Some(("token", matches)) => handle_auth_token(&config, matches).await,

--- a/docs/command_line_tool/phylum_auth_login.md
+++ b/docs/command_line_tool/phylum_auth_login.md
@@ -13,6 +13,9 @@ Usage: phylum auth login [OPTIONS]
 
 ### Options
 
+-r, --reauth
+&emsp; Force a login prompt
+
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 


### PR DESCRIPTION
This patch adds support for `phylum auth login --reauth` to force reauthentication.

## Display issue

There seems to be an issue with the way Keycloak displays informational messages. This isn't something that can be fixed in the CLI so we'll have to take care of it separately. Maybe @janasheehan can take a look. Here is how to reproduce:

1. Login to [staging](https://app.staging.phylum.io/)
2. Run `phylum auth login -r` from this branch. Or just click [this link](https://login.staging.phylum.io/realms/phylum/protocol/openid-connect/auth?client_id=phylum_cli&code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A12345%2F&response_type=code&response_mode=query&scope=openid+offline_access+profile+email&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&prompt=login), which hopefully should have the same effect.
3. See a banner that looks like this: 
   ![banner](https://user-images.githubusercontent.com/616067/207717536-6b7fb456-091e-44ed-a129-458d3db34a9b.png)

Closes #858
