### PR TITLE
Submit single package with `phylum package`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#138ab11a4db60313adea6cc9cbd57a3731c7eb4a"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#21d5e7bb611344137ad59e24ff0d8885ed6dad1d"
 dependencies = [
  "chrono",
  "schemars",

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -10,7 +10,8 @@ use phylum_types::types::job::{
     AllJobsStatusResponse, JobStatusResponse, SubmitPackageRequest, SubmitPackageResponse,
 };
 use phylum_types::types::package::{
-    Package, PackageDescriptor, PackageSpecifier, PackageStatus, PackageStatusExtended, PackageType,
+    PackageDescriptor, PackageSpecifier, PackageStatus, PackageStatusExtended,
+    PackageSubmitResponse, PackageType,
 };
 use phylum_types::types::preferences::{CorePreferences, ProjectPreferences};
 use phylum_types::types::project::{
@@ -37,14 +38,6 @@ type Result<T> = std::result::Result<T, PhylumApiError>;
 pub struct PhylumApi {
     config: Config,
     client: Client,
-}
-
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
-#[serde(tag = "status", content = "data")]
-pub enum PackageSubmitResponse {
-    AlreadyProcessed(Package),
-    AlreadySubmitted,
-    New,
 }
 
 /// Phylum Api Error type

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -21,13 +21,14 @@ use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::group::ListUserGroupsResponse;
 use phylum_types::types::job::JobStatusResponse;
 use phylum_types::types::package::{
-    Package, PackageDescriptor, PackageStatusExtended, PackageType,
+    Package, PackageDescriptor, PackageSpecifier as PTPackageSpecifier, PackageStatusExtended,
+    PackageType,
 };
 use phylum_types::types::project::ProjectSummaryResponse;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::api::{PhylumApiError, ResponseError};
+use crate::api::{PackageSubmitResponse, PhylumApiError, ResponseError};
 use crate::auth::UserInfo;
 use crate::commands::extensions::permissions::{self, Permission};
 use crate::commands::extensions::state::ExtensionState;
@@ -329,15 +330,17 @@ async fn get_package_details(
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
-    let package_type = PackageType::from_str(&package_type)
-        .map_err(|e| anyhow!("Unrecognized package type `{package_type}`: {e:?}"))?;
-    api.get_package_details(&PackageDescriptor {
+    api.submit_package(&PTPackageSpecifier {
         name: name.to_string(),
         version: version.to_string(),
-        package_type,
+        registry: package_type,
     })
     .await
     .map_err(Error::from)
+    .and_then(|resp| match resp {
+        PackageSubmitResponse::AlreadyProcessed(data) => Ok(data),
+        _ => Err(anyhow!("Package has not yet been processed.")),
+    })
 }
 
 /// Parse a lockfile and return the package descriptors contained therein.

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -22,13 +22,13 @@ use phylum_types::types::group::ListUserGroupsResponse;
 use phylum_types::types::job::JobStatusResponse;
 use phylum_types::types::package::{
     Package, PackageDescriptor, PackageSpecifier as PTPackageSpecifier, PackageStatusExtended,
-    PackageType,
+    PackageSubmitResponse, PackageType,
 };
 use phylum_types::types::project::ProjectSummaryResponse;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::api::{PackageSubmitResponse, PhylumApiError, ResponseError};
+use crate::api::{PhylumApiError, ResponseError};
 use crate::auth::UserInfo;
 use crate::commands::extensions::permissions::{self, Permission};
 use crate::commands::extensions::state::ExtensionState;

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -1,32 +1,29 @@
 use std::str::FromStr;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::ArgMatches;
-use console::style;
-use phylum_types::types::package::{PackageDescriptor, PackageType};
+use phylum_types::types::package::{PackageSpecifier, PackageType};
 use reqwest::StatusCode;
 
-use crate::api::PhylumApi;
+use crate::api::{PackageSubmitResponse, PhylumApi};
 use crate::commands::{CommandResult, ExitCode};
 use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;
 use crate::print_user_warning;
 
-fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<PackageDescriptor> {
+fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<PackageSpecifier> {
     // Read required options.
     let name = matches.get_one::<String>("name").unwrap().to_string();
     let version = matches.get_one::<String>("version").unwrap().to_string();
 
     // If a package type was provided on the command line, prefer that
     // to the global setting
-    let package_type = match matches.get_one::<String>("package-type") {
-        Some(pt) => {
-            PackageType::from_str(pt).map_err(|_| anyhow!("invalid package type: {}", pt))?
-        },
-        None => request_type,
+    let registry = match matches.get_one::<String>("package-type") {
+        Some(pt) => pt.clone(),
+        None => request_type.to_string(),
     };
 
-    Ok(PackageDescriptor { name, version, package_type })
+    Ok(PackageSpecifier { name, version, registry })
 }
 
 /// Handle the subcommands for the `package` subcommand.
@@ -34,24 +31,35 @@ pub async fn handle_get_package(api: &mut PhylumApi, matches: &clap::ArgMatches)
     let pretty_print = !matches.get_flag("json");
 
     let pkg = parse_package(matches, api.config().request_type)?;
-    let mut resp = match api.get_package_details(&pkg).await {
+    let resp = match api.submit_package(&pkg).await {
         Ok(resp) => resp,
         Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => {
-            print_user_warning!(
-                "No matching packages found. Submit a lockfile for processing:\n\n\t{}\n",
-                style("phylum analyze <lock_file>").blue()
-            );
+            print_user_warning!("No matching package found.");
             return Ok(ExitCode::PackageNotFound.into());
         },
         Err(err) => return Err(err.into()),
     };
 
-    let filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
-    if let Some(filter) = filter {
-        resp.filter(&filter);
-    }
+    match resp {
+        PackageSubmitResponse::AlreadyProcessed(mut resp) => {
+            let filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
+            if let Some(filter) = filter {
+                resp.filter(&filter);
+            }
 
-    resp.write_stdout(pretty_print);
+            resp.write_stdout(pretty_print);
+        },
+        PackageSubmitResponse::AlreadySubmitted => {
+            print_user_warning!(
+                "Package is still processing. Please check back later for results."
+            );
+        },
+        PackageSubmitResponse::New => {
+            print_user_warning!(
+                "Thank you for submitting this package. Please check back later for results."
+            );
+        },
+    }
 
     Ok(ExitCode::Ok.into())
 }

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -19,7 +19,7 @@ fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<Pack
     // If a package type was provided on the command line, prefer that
     // to the global setting
     let registry = match matches.get_one::<String>("package-type") {
-        Some(pt) => pt.clone(),
+        Some(package_type) => package_type.clone(),
         None => request_type.to_string(),
     };
 

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use clap::ArgMatches;
-use phylum_types::types::package::{PackageSpecifier, PackageType};
+use phylum_types::types::package::{PackageSpecifier, PackageSubmitResponse, PackageType};
 use reqwest::StatusCode;
 
-use crate::api::{PackageSubmitResponse, PhylumApi};
+use crate::api::PhylumApi;
 use crate::commands::{CommandResult, ExitCode};
 use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;

--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -264,8 +264,8 @@ export class PhylumApi {
   /**
    * Get analysis results for a single package.
    *
-   * This will not start a new package analysis, but only retrieve previous
-   * analysis results.
+   * If the requested package has not yet been analyzed by Phylum, it will
+   * automatically be submitted for processing.
    *
    * @returns Package analysis results
    *

--- a/doc_templates/phylum_package.md
+++ b/doc_templates/phylum_package.md
@@ -2,6 +2,13 @@
 
 {PH-MARKDOWN}
 
+### Details
+
+If the requested package has not yet been analyzed by Phylum, it will
+automatically be submitted for [processing].
+
+[processing]: https://docs.phylum.io/docs/processing
+
 ### Examples
 
 ```sh

--- a/docs/command_line_tool/phylum_package.md
+++ b/docs/command_line_tool/phylum_package.md
@@ -46,6 +46,13 @@ Usage: phylum package [OPTIONS] <name> <version>
 -h, --help
 &emsp; Print help information
 
+### Details
+
+If the requested package has not yet been analyzed by Phylum, it will
+automatically be submitted for [processing].
+
+[processing]: https://docs.phylum.io/docs/processing
+
 ### Examples
 
 ```sh


### PR DESCRIPTION
This patch modifies the `phylum package` command to use the [`/data/packages/submit`](https://api.phylum.io/api/v0/swagger/index.html#/Packages/packages_submit_endpoint) endpoint. That means that any requested package will be automatically submitted for processing if it is not already known to Phylum.

The new behavior looks like this:
```
# Brand new package
❯ phylum package -t npm left_pad 0.0.5
⚠️  Thank you for submitting this package. Please check back later for results.

# Package in processing
❯ phylum package -t npm left_pad 0.0.5
⚠️  Package is still processing. Please check back later for results.
```

Closes #871
