### PR TITLE
Add a `.phylum_project` file for GitHub App

### DIFF
--- a/.phylum_project
+++ b/.phylum_project
@@ -1,0 +1,6 @@
+# This file is a temporary fix to appease the Phylum GitHub App.
+# The format of this data is likely to change in the near future.
+
+lock_files:
+  - path: Cargo.lock
+    format: cargo


### PR DESCRIPTION
This is a temporary solution to convince the GitHub App to ignore the many lockfiles in this repository that are used for testing. Those lockfiles contain many issues that would be concerning if they were actually in use.