### PR TITLE
Make project ID and name optional in .phylum_project file

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -157,13 +157,9 @@ async fn analyze(
 
     let (project, group) = match (project, group) {
         (Some(project), group) => (api.get_project_id(&project, group.as_deref()).await?, None),
-        (None, _) => {
-            if let Some(p) = config::get_current_project() {
-                (p.id, p.group_name)
-            } else {
-                return Err(anyhow!("Failed to find a valid project configuration"));
-            }
-        },
+        (None, _) => config::get_current_project()
+            .and_then(|c| c.project_group())
+            .ok_or_else(|| anyhow!("Failed to find a valid project configuration"))?,
     };
 
     let packages = packages

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -253,20 +253,16 @@ impl JobsProject {
             },
             // Retrieve the project from the `.phylum_project` file.
             None => {
-                let current_project = current_project.ok_or_else(|| {
-                    anyhow!(
-                        "Failed to find a valid project configuration. Specify an existing \
-                         project using the `--project` flag, or create a new one with `phylum \
-                         project create <name>`"
-                    )
-                })?;
+                let (project_id, group) =
+                    current_project.and_then(|c| c.project_group()).ok_or_else(|| {
+                        anyhow!(
+                            "Failed to find a valid project configuration. Specify an existing \
+                             project using the `--project` flag, or create a new one with `phylum \
+                             project create <name>`"
+                        )
+                    })?;
 
-                Ok(Self {
-                    project_id: current_project.id,
-                    group: current_project.group_name,
-                    lockfile,
-                    lockfile_type,
-                })
+                Ok(Self { project_id, group, lockfile, lockfile_type })
             },
         }
     }

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -78,15 +78,18 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
 
         print_user_success!(
             "Linked the current working directory to the project {}.",
-            format!("{}", style(project_config.name).white())
+            format!("{}", style(project_name).white())
         );
     } else if let Some(matches) = matches.subcommand_matches("set-thresholds") {
         let mut project_name =
             matches.get_one::<String>("name").cloned().unwrap_or_else(|| String::from("current"));
         let group_name = matches.get_one::<String>("group");
 
-        let proj =
-            if project_name == "current" { get_current_project().map(|p| p.name) } else { None };
+        let proj = if project_name == "current" {
+            get_current_project().and_then(|p| p.name)
+        } else {
+            None
+        };
 
         project_name = proj.unwrap_or(project_name);
         log::debug!("Setting thresholds for project `{}`", project_name);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -92,8 +92,8 @@ where
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProjectConfig {
-    pub id: ProjectId,
-    pub name: String,
+    pub id: Option<ProjectId>,
+    pub name: Option<String>,
     pub created_at: DateTime<Local>,
     pub group_name: Option<String>,
     pub lockfile_type: Option<String>,
@@ -106,8 +106,8 @@ impl ProjectConfig {
     pub fn new(id: ProjectId, name: String, group_name: Option<String>) -> Self {
         Self {
             group_name,
-            name,
-            id,
+            name: Some(name),
+            id: Some(id),
             root: PathBuf::from("."),
             created_at: Local::now(),
             lockfile_type: None,
@@ -124,6 +124,11 @@ impl ProjectConfig {
     pub fn set_lockfile(&mut self, lockfile_type: String, lockfile: String) {
         self.lockfile_type = Some(lockfile_type);
         self.lockfile_path = Some(lockfile);
+    }
+
+    /// Get project ID and group, if present.
+    pub fn project_group(self) -> Option<(ProjectId, Option<String>)> {
+        self.id.map(|id| (id, self.group_name))
     }
 }
 


### PR DESCRIPTION
Sometimes a `.phylum_project` file is useful for specifying a lockfile, but unnecessary for specifying an associated project. This change makes the project details optional in the `.phylum_project` file to allow for that possibility.

With this patch, a project could use a simple `.phylum_project` file like this one:

```yaml
lockfile_path: Cargo.lock
lockfile_type: cargo
```

And then submit their analysis jobs to different projects depending on the context:

* Local developer testing: `phylum analyze -p myproj`
* Manual CI: `phylum analyze --group company-devs --project some-proj`
* GitHub App: Submitted to appropriate project based on org settings
* `phylum-ci`: Submitted to appropriate project as configured in the workflow

### Additional questions

- [ ] Would it be better to put all project details in an optional sub-key? For example:
  ```yaml
  project:
    created_at: 2022-12-30T09:39:27.626246-06:00 # Is this even useful?
    id: 06babf58-62dd-4ffb-8f44-b65257b18b0c
    name: foo
    group_name: blah # This is optional
  lockfile_path: Cargo.lock
  lockfile_type: cargo
  ```
  If yes, how should users update to this new format? Do we need a command for that?
- [ ] Should `phylum init` allow skipping project details?
- [ ] Should a `phylum project unlink` command be added to remove project details?