### PR TITLE
Add deno.window lib reference to extension_api.ts

### DIFF
--- a/cli/src/extension_api.ts
+++ b/cli/src/extension_api.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file ban-types
 
 /// <reference types="https://raw.githubusercontent.com/denoland/deno/v1.28.3/core/lib.deno_core.d.ts" />
+/// <reference lib="deno.window" />
 
 export class PhylumApi {
   /**


### PR DESCRIPTION
When adding the reference to deno_core in b1f1c81, I did not think about [this line in deno_core] which prevents loading the default libs... This flaw extends to any users of our extension_api.ts and causes issues when accessing basic things like `Deno.exit` or `Deno.args`.

To counteract that, this patch adds a lib reference to `deno.window`, which is the default library that is used for Phylum extensions.

[this line in deno_core]: https://github.com/denoland/deno/blob/98bbf87742969802b392130c536454aa61a20395/core/lib.deno_core.d.ts#L5