### PR TITLE
Remove caveats section from ecosystem extensions

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -44,12 +44,6 @@ When invoking `phylum npm`, subcommands that would modify the `package.json` or
 - Commands that modify neither `package.json` nor `package-lock.json` will be
   passed through to `npm` directly.
 
-## Caveats
-
-Unlike the `npm` CLI, this extension needs to be launched in the directory that
-contains the `package.json` and `package-lock.json` files. Launching it from any
-of its subdirectories will result in an error.
-
 [phylum]: https://phylum.io
 [phylum-cli]: https://github.com/phylum-dev/cli
 [npm]: https://www.npmjs.com/

--- a/extensions/poetry/README.md
+++ b/extensions/poetry/README.md
@@ -44,12 +44,6 @@ When invoking `phylum poetry`, subcommands that would modify the
 - Commands that modify neither `pyproject.toml` nor `poetry.lock` will be passed
   through to `poetry` directly.
 
-## Caveats
-
-Unlike the `poetry` CLI, this extension needs to be launched in the directory
-that contains the `pyproject.toml` and `poetry.lock` files. Launching it from
-any of its subdirectories will result in an error.
-
 [phylum]: https://phylum.io
 [phylum-cli]: https://github.com/phylum-dev/cli
 [poetry]: https://python-poetry.org/

--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -44,12 +44,6 @@ When invoking `phylum yarn`, subcommands that would modify the `package.json` or
 - Commands that modify neither `package.json` nor `yarn.lock` will be passed
   through to `yarn` directly.
 
-## Caveats
-
-Unlike the `yarn` CLI, this extension needs to be launched in the directory that
-contains the `package.json` and `yarn.lock` files. Launching it from any of its
-subdirectories will result in an error.
-
 [phylum]: https://phylum.io
 [phylum-cli]: https://github.com/phylum-dev/cli
 [yarn]: https://yarnpkg.com/


### PR DESCRIPTION
Previously we were not able to run our ecosystem extensions when the user wasn't in the project's root directory, which was documented for each extension in a `Caveats` section.

Since this has been resolved and is now possible, the caveats sections have been removed.