### PR TITLE
Link to prod API docs

### DIFF
--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -11,7 +11,7 @@ REST API can be used directly by extensions if there is no TypeScript API
 available.
 
 All endpoins are documented here:
-https://api.staging.phylum.io/api/v0/swagger/index.html
+https://api.phylum.io/api/v0/swagger/index.html
 
 ## Extension API requests
 

--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -10,7 +10,7 @@ Phylum provides a versioned REST API for retrieving all available data. This
 REST API can be used directly by extensions if there is no TypeScript API
 available.
 
-All endpoins are documented here:
+All endpoints are documented here:
 https://api.phylum.io/api/v0/swagger/index.html
 
 ## Extension API requests


### PR DESCRIPTION
Fix #897 by switching to prod for the API docs link in the extension docs.