### PR TITLE
docs: Update `phylum group member add` example

### DIFF
--- a/doc_templates/phylum_group_member_add.md
+++ b/doc_templates/phylum_group_member_add.md
@@ -11,5 +11,5 @@ hidden: false
 
 ```sh
 # Add user `demo@phylum.io` to the `sample` group
-$ phylum group member --group add demo@phylum.io
+$ phylum group member --group sample add demo@phylum.io
 ```

--- a/doc_templates/phylum_group_member_remove.md
+++ b/doc_templates/phylum_group_member_remove.md
@@ -11,5 +11,5 @@ hidden: false
 
 ```sh
 # Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group remove demo@phylum.io
+$ phylum group member --group sample remove demo@phylum.io
 ```

--- a/docs/command_line_tool/phylum_group_member_add.md
+++ b/docs/command_line_tool/phylum_group_member_add.md
@@ -31,5 +31,5 @@ Usage: phylum group member --group <GROUP> add [OPTIONS] <USER>...
 
 ```sh
 # Add user `demo@phylum.io` to the `sample` group
-$ phylum group member --group sample add demo@phylum.io
+$ phylum group member --group add demo@phylum.io
 ```

--- a/docs/command_line_tool/phylum_group_member_add.md
+++ b/docs/command_line_tool/phylum_group_member_add.md
@@ -31,5 +31,5 @@ Usage: phylum group member --group <GROUP> add [OPTIONS] <USER>...
 
 ```sh
 # Add user `demo@phylum.io` to the `sample` group
-$ phylum group member --group add demo@phylum.io
+$ phylum group member --group sample add demo@phylum.io
 ```

--- a/docs/command_line_tool/phylum_group_member_remove.md
+++ b/docs/command_line_tool/phylum_group_member_remove.md
@@ -31,5 +31,5 @@ Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
 
 ```sh
 # Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group remove demo@phylum.io
+$ phylum group member --group sample remove demo@phylum.io
 ```


### PR DESCRIPTION
The example was missing the group in the command.