### PR TITLE
Add multi-lockfile support to phylum init

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -240,6 +240,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('t')
                     .long("lockfile-type")
                     .value_name("type")
+                    .requires("LOCKFILE")
                     .help("The type of the lock file (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
             ]),
@@ -248,10 +249,6 @@ pub fn add_subcommands(command: Command) -> Command {
             Command::new("analyze")
                 .about("Submit a request for analysis to the processing system")
                 .args(&[
-                    Arg::new("LOCKFILE")
-                        .value_name("LOCKFILE")
-                        .value_hint(ValueHint::FilePath)
-                        .help("The package lock file to submit."),
                     Arg::new("force").action(ArgAction::SetTrue).short('F').long("force").help(
                         "Force re-processing of packages (even if they already exist in the \
                          system)",
@@ -278,10 +275,15 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_name("group_name")
                         .help("Specify a group to use for analysis")
                         .requires("project"),
+                    Arg::new("LOCKFILE")
+                        .value_name("LOCKFILE")
+                        .value_hint(ValueHint::FilePath)
+                        .help("The package lock file to submit."),
                     Arg::new("lockfile-type")
                         .short('t')
                         .long("lockfile-type")
                         .value_name("type")
+                        .requires("LOCKFILE")
                         .help("The type of the lock file (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 ]),
@@ -448,6 +450,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("lockfile-type")
                         .value_name("LOCKFILE_TYPE")
+                        .requires("lockfile")
                         .help("Project lockfile type")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(false))),
                     Arg::new("force")

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -146,7 +146,7 @@ fn prompt_lockfile(
         }
 
         // Prompt for lockfile type.
-        let lockfile_type = prompt_lockfile_type(&lockfile)?;
+        let lockfile_type = prompt_lockfile_type(lockfile)?;
 
         lockfile_configs.push(LockfileConfig::new(lockfile, lockfile_type));
     }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -121,7 +121,7 @@ fn prompt_lockfile(
     cli_lockfile: Option<&String>,
     cli_lockfile_type: Option<&String>,
 ) -> io::Result<Vec<LockfileConfig>> {
-    let mut lockfiles = match (cli_lockfile.cloned(), cli_lockfile_type) {
+    let lockfiles = match (cli_lockfile.cloned(), cli_lockfile_type) {
         // Do not prompt if name and type were specified on CLI.
         (Some(lockfile), Some(lockfile_type)) => {
             let lockfiles = vec![LockfileConfig::new(lockfile, lockfile_type.into())];
@@ -129,13 +129,13 @@ fn prompt_lockfile(
         },
         // Prompt for type if only lockfile was passed.
         (Some(lockfile), _) => vec![lockfile],
-        // Prompt for lockfile if it wasn't specified.
-        (None, _) => prompt_lockfile_name()?,
+        // Prompt for lockfiles if it wasn't specified.
+        (None, _) => prompt_lockfile_names()?,
     };
 
     // Find lockfile type for each lockfile.
     let mut lockfile_configs = Vec::new();
-    for lockfile in lockfiles.drain(..) {
+    for lockfile in &lockfiles {
         // Try to determine lockfile type from known formats.
         if let Some(format) = LockfileFormat::iter()
             .find(|format| format.parser().is_path_lockfile(Path::new(&lockfile)))
@@ -154,8 +154,8 @@ fn prompt_lockfile(
     Ok(lockfile_configs)
 }
 
-/// Ask for the lockfile name.
-fn prompt_lockfile_name() -> io::Result<Vec<String>> {
+/// Ask for the lockfile names.
+fn prompt_lockfile_names() -> io::Result<Vec<String>> {
     // Find all known lockfiles in the currenty directory.
     let mut lockfiles: Vec<_> = fs::read_dir("./")?
         .flatten()
@@ -165,7 +165,7 @@ fn prompt_lockfile_name() -> io::Result<Vec<String>> {
         .flat_map(|entry| entry.file_name().to_str().map(str::to_owned))
         .collect();
 
-    // Prompt for selection any lockfile was found.
+    // Prompt for selection if any lockfile was found.
     if !lockfiles.is_empty() {
         // Add choice to specify additional unidentified lockfiles.
         lockfiles.push(String::from("others"));

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -161,8 +161,8 @@ impl ProjectConfig {
     }
 
     /// Update the lockfile.
-    pub fn set_lockfile(&mut self, lockfile_type: String, path: String) {
-        self.lockfiles = vec![LockfileConfig::new(path, lockfile_type)];
+    pub fn set_lockfiles(&mut self, lockfiles: Vec<LockfileConfig>) {
+        self.lockfiles = lockfiles;
     }
 }
 


### PR DESCRIPTION
Allow selecting multiple lockfiles when running `phylum init`, including
an option to specify a comma separated list of additional lockfiles.

Closes #907.

---

Depends on https://github.com/phylum-dev/cli/pull/902.