### PR TITLE
Inline format arguments when possible

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -255,7 +255,7 @@ impl PhylumApi {
         let _: IgnoredAny = self
             .delete(endpoints::delete_project(
                 &self.config.connection.uri,
-                &format!("{}", project_id),
+                &format!("{project_id}"),
             )?)
             .await?;
         Ok(())

--- a/cli/src/auth/server.rs
+++ b/cli/src/auth/server.rs
@@ -181,7 +181,7 @@ async fn spawn_server_and_get_auth_code(
     let auth_scheme = authorization_url.scheme();
     let fallback_port: u16 = if auth_scheme == "https" { 443 } else { 80 };
     let port = authorization_url.port().unwrap_or(fallback_port);
-    let is_routable = check_if_routable(format!("{}:{}", auth_host, port))?;
+    let is_routable = check_if_routable(format!("{auth_host}:{port}"))?;
     if is_routable && auth_scheme == "http" {
         return Err(anyhow!(
             "Authorization host {} is publically routable, must use https to connect.",
@@ -191,8 +191,7 @@ async fn spawn_server_and_get_auth_code(
 
     println!("Please use browser window to complete login process");
     println!(
-        "If browser window doesn't open, you can use the link below:\n    {}",
-        authorization_url
+        "If browser window doesn't open, you can use the link below:\n    {authorization_url}"
     );
 
     // Open browser pointing at this server's /redirect url

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -205,6 +205,6 @@ async fn main() {
             ),
         },
         Ok(CommandValue::Code(code)) => code.exit(),
-        Err(error) => exit_fail(format!("{:?}", error), ExitCode::Generic),
+        Err(error) => exit_fail(format!("{error:?}"), ExitCode::Generic),
     }
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -83,7 +83,7 @@ pub async fn handle_auth_token(config: &Config, matches: &clap::ArgMatches) -> C
         println!("{}", tokens.access_token);
         Ok(ExitCode::Ok.into())
     } else {
-        println!("{}", refresh_token);
+        println!("{refresh_token}");
         Ok(ExitCode::Ok.into())
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -151,7 +151,6 @@ fn prompt_lockfile(
 fn prompt_lockfile_name() -> io::Result<String> {
     // Find all known lockfiles in the currenty directory.
     let mut lockfiles: Vec<_> = fs::read_dir("./")?
-        .into_iter()
         .flatten()
         .filter(|entry| {
             LockfileFormat::iter().any(|format| format.parser().is_path_lockfile(&entry.path()))

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -18,7 +18,7 @@ pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
     // Start subprocess.
     let cmd = matches.get_one::<String>("cmd").unwrap();
     let args: Vec<&String> = matches.get_many("args").unwrap_or_default().collect();
-    let status = Command::new(cmd).args(&args).status()?;
+    let status = Command::new(cmd).args(args).status()?;
 
     if let Some(code) = status.code() {
         Ok(CommandValue::Code(ExitCode::Custom(code)))

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -337,7 +337,7 @@ where
             "Proj Score",
             (100.0 * resp.score).round().to_string(),
             "Date",
-            format!("{} UTC", date_time),
+            format!("{date_time} UTC"),
         ),
         ("Num Deps", resp.packages.len().to_string(), "Job ID", resp.job_id.to_string()),
     ];

--- a/cli/src/histogram.rs
+++ b/cli/src/histogram.rs
@@ -64,10 +64,10 @@ impl fmt::Display for Histogram {
 
             let bar = "█".repeat(scale(*count));
 
-            let _ = write!(histogram, "\n{:>4} - {:<4} [{:>5}] {}", bar_min, bar_max, count, bar);
+            let _ = write!(histogram, "\n{bar_min:>4} - {bar_max:<4} [{count:>5}] {bar}");
         }
 
         write!(f, "{:^10} {:>8}", "Score", "Count")?;
-        write!(f, "{}", histogram)
+        write!(f, "{histogram}")
     }
 }

--- a/cli/src/prompt.rs
+++ b/cli/src/prompt.rs
@@ -17,7 +17,7 @@ pub fn prompt_threshold(name: &str) -> Result<Threshold, std::io::Error> {
         .validate_with(|input: &String| -> Result<(), String> {
             if input.eq_ignore_ascii_case("disabled") {
                 if ALWAYS_ENABLED_THRESHOLDS.contains(&name) {
-                    Err(format!("Cannot disable {} threshold", name))
+                    Err(format!("Cannot disable {name} threshold"))
                 } else {
                     Ok(())
                 }

--- a/cli/src/spinner.rs
+++ b/cli/src/spinner.rs
@@ -116,7 +116,7 @@ impl Spinner {
                     eprint!("{}", ansi::CLEAR_LINE);
                     eprint!("{}", dots.next().unwrap());
                     if let Some(msg) = msg.as_ref() {
-                        eprint!(" {}", msg)
+                        eprint!(" {msg}")
                     }
                     interval.tick().await;
                 },

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -119,7 +119,7 @@ fn current_platform() -> anyhow::Result<String> {
         "unsupported"
     };
 
-    let platform = format!("{}-{}", arch, os);
+    let platform = format!("{arch}-{os}");
     if SUPPORTED_PLATFORMS.contains(&platform.as_str()) {
         Ok(platform)
     } else {
@@ -174,7 +174,7 @@ impl ApplicationUpdater {
             Some(x) => Ok(x),
             _ => Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("Failed to download update file: {}", name),
+                format!("Failed to download update file: {name}"),
             )),
         }
     }
@@ -192,9 +192,9 @@ impl ApplicationUpdater {
 
         // Get the URL for each asset from the Github JSON response in `latest`.
         debug!("Finding the github assets in the Github JSON response");
-        let zip_asset = self.find_github_asset(&latest, &format!("{}.zip", archive_name))?;
+        let zip_asset = self.find_github_asset(&latest, &format!("{archive_name}.zip"))?;
         let sig_asset =
-            self.find_github_asset(&latest, &format!("{}.zip.signature", archive_name))?;
+            self.find_github_asset(&latest, &format!("{archive_name}.zip.signature"))?;
 
         debug!("Downloading the update files");
         let zip = self.download_github_asset(zip_asset).await?;


### PR DESCRIPTION
The latest clippy nightly version further encourages inlining format arguments by warning for every instance where it is missing. This lint will likely make its way to stable in the near future and is a sensible suggestion for consistency and brevity.