### PR TITLE
Bump to v4.3.0 - Fix sandbox executable path resolution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 4.3.0 - Fix sandbox executable path resolution
 * 4.2.0 - Single package submit
 * 4.1.0 - Group transfer; Extension REST API access
 * 4.0.1 - Use a lower version of GLIBC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "4.2.0"
+version = "4.3.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
The one-line summary makes it appear that this should be a bugfix release, but there was at least one feature added to make it a minor release.

Release-Version: v4.3.0
Release-Summary: Fix sandbox executable path resolution

