### PR TITLE
Add `phylum group delete` subcommand

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -80,6 +80,13 @@ pub(crate) fn group_create(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("groups")?)
 }
 
+/// DELETE /groups/<groupName>
+pub(crate) fn group_delete(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group]);
+    Ok(url)
+}
+
 /// GET /groups/<groupName>/projects
 pub fn group_project_summary(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -364,10 +364,17 @@ impl PhylumApi {
         self.get(endpoints::group_list(&self.config.connection.uri)?).await
     }
 
-    /// Get all groups the user is part of.
+    /// Create a new group.
     pub async fn create_group(&self, group_name: &str) -> Result<CreateGroupResponse> {
         let group = CreateGroupRequest { group_name: group_name.into() };
         self.post(endpoints::group_create(&self.config.connection.uri)?, group).await
+    }
+
+    /// Delete an existing group.
+    pub async fn delete_group(&self, group_name: &str) -> Result<()> {
+        let url = endpoints::group_delete(&self.config.connection.uri, group_name)?;
+        self.send_request_raw(Method::DELETE, url, None::<()>).await?;
+        Ok(())
     }
 
     /// Get members of a group.

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -355,6 +355,14 @@ pub fn add_subcommands(command: Command) -> Command {
                     ),
                 )
                 .subcommand(
+                    Command::new("delete").about("Delete a group").arg(
+                        Arg::new("group_name")
+                            .value_name("group_name")
+                            .help("Name for the group to be deleted")
+                            .required(true),
+                    ),
+                )
+                .subcommand(
                     Command::new("member").about("Manage group members").args(&[
                         Arg::new("group")
                             .short('g')

--- a/cli/src/commands/group.rs
+++ b/cli/src/commands/group.rs
@@ -13,6 +13,8 @@ use crate::{print_user_failure, print_user_success, print_user_warning};
 pub async fn handle_group(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         handle_group_create(api, matches).await
+    } else if let Some(matches) = matches.subcommand_matches("delete") {
+        handle_group_delete(api, matches).await
     } else if let Some(matches) = matches.subcommand_matches("transfer") {
         handle_group_transfer(api, matches).await
     } else if let Some(matches) = matches.subcommand_matches("member") {
@@ -44,6 +46,16 @@ pub async fn handle_group_create(api: &mut PhylumApi, matches: &ArgMatches) -> C
         },
         Err(err) => Err(err.into()),
     }
+}
+
+/// Handle `phylum group delete` subcommand.
+pub async fn handle_group_delete(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
+    let group_name = matches.get_one::<String>("group_name").unwrap();
+    api.delete_group(group_name).await?;
+
+    print_user_success!("Successfully deleted group {}", group_name);
+
+    Ok(ExitCode::Ok.into())
 }
 
 /// Handle `phylum group list` subcommand.

--- a/doc_templates/phylum_group_delete.rs
+++ b/doc_templates/phylum_group_delete.rs
@@ -1,0 +1,15 @@
+---
+title: phylum group delete
+category: 6255e67693d5200013b1fa3e
+parentDoc: 62866c2ce78584036d7cbbf7
+hidden: false
+---
+
+{PH-MARKDOWN}
+
+### Examples
+
+```sh
+# Delete an existing group named 'sample'
+$ phylum group delete sample
+```

--- a/docs/command_line_tool/phylum_group.md
+++ b/docs/command_line_tool/phylum_group.md
@@ -28,6 +28,7 @@ Usage: phylum group [OPTIONS] [COMMAND]
 
 * [phylum group list](./phylum_group_list)
 * [phylum group create](./phylum_group_create)
+* [phylum group delete](./phylum_group_delete)
 * [phylum group member](./phylum_group_member)
 * [phylum group transfer](./phylum_group_transfer)
 

--- a/docs/command_line_tool/phylum_group_delete.md
+++ b/docs/command_line_tool/phylum_group_delete.md
@@ -1,0 +1,27 @@
+---
+title: phylum group delete
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Delete a group
+
+```sh
+Usage: phylum group delete [OPTIONS] <group_name>
+```
+
+### Arguments
+
+<group_name>
+&emsp; Name for the group to be deleted
+
+### Options
+
+-v, --verbose...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+-q, --quiet...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+-h, --help
+&emsp; Print help


### PR DESCRIPTION
Add a subcommand which allows deletion of existing groups with the CLI.

Since the API's response for unknown groups is a 403 rather than a 404,
it's unfortunately not possible to provide a more descriptive error
messages when the group cannot be found without additional requests.

Closes #893.