### PR TITLE
Fix gem parser for dependencies without version

### DIFF
--- a/tests/fixtures/Gemfile.lock
+++ b/tests/fixtures/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
+      rspec-support
     rspec-mocks (3.11.2)
       diff-lcs (>= 1.2.0, < 2.0, != 1.2.3)
       rspec-support (~> 3.11.0)


### PR DESCRIPTION
The ruby parser expected a loose version for all dependencies and sub-dependencies. However it is not required for sub-dependencies to have any version at all.

To fix this, the loose version parser has been extended to allow for a completely empty string as an alternative to a version and the tests were modified to ensure this is tested for.

Closes #918.