### PR TITLE
Switch to `phylum init` for CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ brew install phylum
    phylum auth login
    ```
 
-1. [Create a new Phylum project](https://docs.phylum.io/docs/phylum_project_create) in your project directory
+1. [Setup your Phylum project](https://docs.phylum.io/docs/phylum_init) in your project directory
 
    ```
-   phylum project create <project-name>
+   phylum init
    ```
 
 1. [Submit your package lock file](https://docs.phylum.io/docs/phylum_analyze)
 
    ```
-   phylum analyze <package-lock-file.ext>
+   phylum analyze
    ```
 
 1. (Optional) View the analysis results in the [Phylum UI](https://app.phylum.io/auth/login)

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -5,8 +5,8 @@
 ### Examples
 
 ```sh
-# Analyze an npm lock file
-$ phylum analyze package-lock.json
+# Analyze your project's default lockfile
+$ phylum analyze
 
 # Analyze a Maven lock file with a verbose json response
 $ phylum analyze --json --verbose effective-pom.xml

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -59,8 +59,8 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]
 ### Examples
 
 ```sh
-# Analyze an npm lock file
-$ phylum analyze package-lock.json
+# Analyze your project's default lockfile
+$ phylum analyze
 
 # Analyze a Maven lock file with a verbose json response
 $ phylum analyze --json --verbose effective-pom.xml

--- a/docs/command_line_tool/quickstart.md
+++ b/docs/command_line_tool/quickstart.md
@@ -50,16 +50,16 @@ brew install phylum
    phylum auth login
    ```
 
-1. [Create a new Phylum project](https://docs.phylum.io/docs/phylum_project_create) in your project directory
+1. [Setup your Phylum project](https://docs.phylum.io/docs/phylum_init) in your project directory
 
    ```
-   phylum project create <project-name>
+   phylum init
    ```
 
 1. [Submit your package lock file](https://docs.phylum.io/docs/phylum_analyze)
 
    ```
-   phylum analyze <package-lock-file.ext>
+   phylum analyze
    ```
 
 1. (Optional) View the analysis results in the [Phylum UI](https://app.phylum.io/auth/login)

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -28,13 +28,13 @@ The Phylum CLI natively supports processing the lock/requirements files for seve
 After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_init), you can begin analysis by running:
 
 ```sh
-phylum analyze <package-lock-file.ext>
+phylum analyze
 ```
 
 The default response will provide you with a high-level overview of your packages, including the total project score, score distributions across all packages, whether or not this analysis was a pass or fail and the total number of packages still processing.
 
 ```
-$ phylum analyze package-lock.json
+$ phylum analyze
 ✅ Job ID: 3cd30a5b-eeee-4ba1-b8e1-276c61e6502c
 
 
@@ -63,13 +63,13 @@ $ phylum analyze package-lock.json
 You can get more detailed output from the analysis, to include specific issues and their severity, by using the `--verbose` flag:
 
 ```sh
-phylum analyze --verbose <package-lock-file.ext>
+phylum analyze --verbose
 ```
 
 If you prefer JSON formatted output, you can leverage the `--json` flag.
 
 ```sh
-phylum analyze --verbose --json <package-lock-file.ext> > output.json
+phylum analyze --verbose --json > output.json
 ```
 
 If the analysis failed to meet the project's thresholds, the command's exit code will be set to `100`.

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -25,7 +25,7 @@ The Phylum CLI natively supports processing the lock/requirements files for seve
 * Cargo
     * `Cargo.lock`
 
-After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_project) , you can begin analysis by running:
+After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_init), you can begin analysis by running:
 
 ```sh
 phylum analyze <package-lock-file.ext>

--- a/docs/knowledge_base/groups.md
+++ b/docs/knowledge_base/groups.md
@@ -10,7 +10,7 @@ Phylum groups allow users to view/submit projects and analysis jobs in a shared 
 2. [Create a project](https://docs.phylum.io/docs/phylum_project_create) using the `--group` option and your group name
 3. [Analyze](https://docs.phylum.io/docs/phylum_analyze) the desired lock file
 
-Any user that is a member of the group will be able to access the anlaysis results.
+Any user that is a member of the group will be able to access the analysis results.
 
 Group administration for adding/removing users, etc. can be found in the `Groups Admin` view on the [Phylum UI](https://app.phylum.io/auth/login).
 


### PR DESCRIPTION
Since `phylum init` provides a better user experience than manually creating projects yourself, we should recommend it over the other alternatives.

Closes #917.
