### PR TITLE
Create separate `phylum_project` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,6 +3147,7 @@ dependencies = [
  "once_cell",
  "open",
  "phylum_lockfile",
+ "phylum_project",
  "phylum_types",
  "predicates",
  "prettytable-rs",
@@ -3185,6 +3186,17 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "toml",
+]
+
+[[package]]
+name = "phylum_project"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "phylum_types",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
   "lockfile",
   "xtask",
   "clap_markdown",
+  "phylum_project",
 ]

--- a/clap_markdown/Cargo.toml
+++ b/clap_markdown/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clap_markdown"
 description = "Markdown documentation generator for clap"
-repository = "https://github.com/phylum-dev/clap-markdown"
+repository = "https://github.com/phylum-dev/cli"
 categories = ["command-line-interface"]
 keywords = ["clap", "cli", "generate", "markdown"]
 license = "GPL-3.0-or-later"

--- a/clap_markdown/src/lib.rs
+++ b/clap_markdown/src/lib.rs
@@ -103,7 +103,7 @@ impl Markdown {
             let name = cmd.get_name();
             let human_path = format!("{} {name}", parents.join(" "));
             let link_path = format!("{}_{name}", parents.join("_"));
-            let _ = writeln!(markdown, "* [{}](./{})", human_path, link_path);
+            let _ = writeln!(markdown, "* [{human_path}](./{link_path})");
         }
 
         Self { command: parents, content: markdown }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.6"
 maplit = "1.0.2"
 open = "3.0.1"
 phylum_lockfile = { path = "../lockfile" }
+phylum_project = { path = "../phylum_project" }
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 prettytable-rs = "0.10.0"
 rand = "0.8.4"

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Error, Result};
 use deno_runtime::deno_core::{op, OpDecl, OpState};
 use deno_runtime::permissions::Permissions;
+use phylum_project::ProjectConfig;
 use phylum_types::types::auth::{AccessToken, RefreshToken};
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::group::ListUserGroupsResponse;
@@ -33,7 +34,6 @@ use crate::auth::UserInfo;
 use crate::commands::extensions::permissions::{self, Permission};
 use crate::commands::extensions::state::ExtensionState;
 use crate::commands::parse;
-use crate::config::{self, ProjectConfig};
 #[cfg(unix)]
 use crate::dirs;
 
@@ -159,7 +159,7 @@ async fn analyze(
     let (project, group) = match (project, group) {
         (Some(project), group) => (api.get_project_id(&project, group.as_deref()).await?, None),
         (None, _) => {
-            if let Some(p) = config::get_current_project() {
+            if let Some(p) = phylum_project::get_current_project() {
                 (p.id, p.group_name)
             } else {
                 return Err(anyhow!("Failed to find a valid project configuration"));
@@ -245,7 +245,7 @@ async fn get_job_status(
 /// Show the user's currently linked project.
 #[op]
 fn get_current_project() -> Option<ProjectConfig> {
-    config::get_current_project()
+    phylum_project::get_current_project()
 }
 
 /// List all of the user's/group's project.

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -7,17 +7,17 @@ use anyhow::Context;
 use clap::ArgMatches;
 use dialoguer::{Confirm, FuzzySelect, Input, MultiSelect};
 use phylum_lockfile::LockfileFormat;
+use phylum_project::{LockfileConfig, PROJ_CONF_FILE};
 use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError, ResponseError};
 use crate::commands::{project, CommandResult, ExitCode};
-use crate::config::{self, LockfileConfig, PROJ_CONF_FILE};
-use crate::{print_user_success, print_user_warning};
+use crate::{config, print_user_success, print_user_warning};
 
 /// Handle `phylum init` subcommand.
 pub async fn handle_init(api: &mut PhylumApi, matches: &ArgMatches) -> CommandResult {
     // Prompt for confirmation if a linked project is already in this directory.
-    if !matches.get_flag("force") && config::find_project_conf(".", false).is_some() {
+    if !matches.get_flag("force") && phylum_project::find_project_conf(".", false).is_some() {
         print_user_warning!("Workspace is already linked to a Phylum project");
         let should_continue = Confirm::new()
             .with_prompt("Overwrite existing project configuration?")

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context, Result};
 use console::style;
 use log::LevelFilter;
+use phylum_project::LockfileConfig;
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::job::{Action, JobStatusResponse};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
@@ -11,10 +12,9 @@ use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError};
 use crate::commands::{parse, CommandResult, CommandValue, ExitCode};
-use crate::config::{self, LockfileConfig};
 use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;
-use crate::{print_user_success, print_user_warning};
+use crate::{config, print_user_success, print_user_warning};
 
 fn handle_status<T>(
     resp: Result<JobStatusResponse<T>, PhylumApiError>,
@@ -231,7 +231,7 @@ impl JobsProject {
     /// Assumes that the clap `matches` has a `project` and `group` arguments
     /// option.
     async fn new(api: &mut PhylumApi, matches: &clap::ArgMatches) -> Result<JobsProject> {
-        let current_project = config::get_current_project();
+        let current_project = phylum_project::get_current_project();
         let lockfiles = config::lockfiles(matches, current_project.as_ref())?;
 
         match matches.get_one::<String>("project") {

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -31,7 +31,7 @@ pub fn lockfile_types(add_auto: bool) -> Vec<&'static str> {
 }
 
 pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
-    let lockfiles = config::lockfiles(matches, config::get_current_project().as_ref())?;
+    let lockfiles = config::lockfiles(matches, phylum_project::get_current_project().as_ref())?;
 
     let mut pkgs: Vec<PackageDescriptor> = Vec::new();
 

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -3,11 +3,12 @@ use std::result::Result as StdResult;
 
 use anyhow::{anyhow, Context, Result};
 use console::style;
+use phylum_project::{ProjectConfig, PROJ_CONF_FILE};
 use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError, ResponseError};
 use crate::commands::{CommandResult, ExitCode};
-use crate::config::{get_current_project, save_config, ProjectConfig, PROJ_CONF_FILE};
+use crate::config::save_config;
 use crate::format::Format;
 use crate::prompt::prompt_threshold;
 use crate::{print_user_failure, print_user_success};
@@ -85,8 +86,11 @@ pub async fn handle_project(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             matches.get_one::<String>("name").cloned().unwrap_or_else(|| String::from("current"));
         let group_name = matches.get_one::<String>("group");
 
-        let proj =
-            if project_name == "current" { get_current_project().map(|p| p.name) } else { None };
+        let proj = if project_name == "current" {
+            phylum_project::get_current_project().map(|p| p.name)
+        } else {
+            None
+        };
 
         project_name = proj.unwrap_or(project_name);
         log::debug!("Setting thresholds for project `{}`", project_name);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -10,15 +10,12 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use anyhow::{anyhow, Result};
-use chrono::{DateTime, Local};
+use phylum_project::{LockfileConfig, ProjectConfig};
 use phylum_types::types::auth::RefreshToken;
-use phylum_types::types::common::ProjectId;
 use phylum_types::types::package::PackageType;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{dirs, print_user_warning};
-
-pub const PROJ_CONF_FILE: &str = ".phylum_project";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectionInfo {
@@ -90,80 +87,6 @@ where
     D: Deserializer<'de>,
 {
     Ok(Option::<bool>::deserialize(deserializer)?.unwrap_or_default())
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LockfileConfig {
-    pub path: PathBuf,
-    #[serde(rename = "type")]
-    pub lockfile_type: String,
-}
-
-impl LockfileConfig {
-    pub fn new(path: impl Into<PathBuf>, lockfile_type: String) -> LockfileConfig {
-        LockfileConfig { path: path.into(), lockfile_type }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ProjectConfig {
-    pub id: ProjectId,
-    pub name: String,
-    pub created_at: DateTime<Local>,
-    pub group_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    lockfile_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    lockfile_path: Option<String>,
-    #[serde(default)]
-    lockfiles: Vec<LockfileConfig>,
-    #[serde(skip)]
-    root: PathBuf,
-}
-
-impl ProjectConfig {
-    pub fn new(id: ProjectId, name: String, group_name: Option<String>) -> Self {
-        Self {
-            group_name,
-            name,
-            id,
-            root: PathBuf::from("."),
-            created_at: Local::now(),
-            lockfile_type: None,
-            lockfile_path: None,
-            lockfiles: Default::default(),
-        }
-    }
-
-    /// Get all lockfiles.
-    pub fn lockfiles(&self) -> Vec<LockfileConfig> {
-        // Return new lockfile format if present.
-        if !self.lockfiles.is_empty() {
-            return self
-                .lockfiles
-                .iter()
-                .map(|lockfile| {
-                    let path = self.root.join(&lockfile.path);
-                    LockfileConfig::new(path, lockfile.lockfile_type.clone())
-                })
-                .collect();
-        }
-
-        // Fallback to old format.
-        if let Some((path, lockfile_type)) =
-            self.lockfile_path.as_ref().zip(self.lockfile_type.as_ref())
-        {
-            return vec![LockfileConfig::new(self.root.join(path), lockfile_type.clone())];
-        }
-
-        // Default to no lockfiles.
-        Vec::new()
-    }
-
-    /// Update the lockfile.
-    pub fn set_lockfiles(&mut self, lockfiles: Vec<LockfileConfig>) {
-        self.lockfiles = lockfiles;
-    }
 }
 
 /// Atomically overwrite the configuration file.
@@ -251,38 +174,6 @@ pub fn read_configuration(path: &Path) -> Result<Config> {
     }
 
     Ok(config)
-}
-
-pub fn find_project_conf(
-    starting_directory: impl AsRef<Path>,
-    recurse_upwards: bool,
-) -> Option<PathBuf> {
-    let max_depth = if recurse_upwards { 32 } else { 1 };
-    let mut path = starting_directory.as_ref();
-
-    for _ in 0..max_depth {
-        let conf_path = path.join(PROJ_CONF_FILE);
-        if conf_path.is_file() {
-            return Some(conf_path);
-        }
-
-        path = path.parent()?;
-    }
-
-    if recurse_upwards {
-        log::warn!("Max depth exceeded; abandoning search for .phylum_project file");
-    }
-
-    None
-}
-
-pub fn get_current_project() -> Option<ProjectConfig> {
-    find_project_conf(".", true).and_then(|config_path| {
-        log::info!("Found project configuration file at {config_path:?}");
-        let mut config: ProjectConfig = parse_config(&config_path).ok()?;
-        config.root = config_path.parent()?.to_path_buf();
-        Some(config)
-    })
 }
 
 /// Get lockfiles from CLI, falling back to the current project when missing.

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -77,7 +77,7 @@ impl Parse for Cargo {
                 } else if source.starts_with("git+") {
                     PackageVersion::Git(source)
                 } else {
-                    return Err(anyhow!(format!("Unknown cargo package source: {:?}", source)));
+                    return Err(anyhow!(format!("Unknown cargo package source: {source:?}")));
                 };
 
                 Ok(Package { name: package.name, version })

--- a/lockfile/src/parsers/gradle_dep.rs
+++ b/lockfile/src/parsers/gradle_dep.rs
@@ -37,7 +37,7 @@ fn package(input: &str) -> StdResult<Package, nom::Err<VerboseError<&str>>> {
     let _ = alt((tag("="), eof))(input)?;
 
     Ok(Package {
-        name: format!("{}:{}", group_id, artifact_id),
+        name: format!("{group_id}:{artifact_id}"),
         version: PackageVersion::FirstParty(version.to_string()),
     })
 }

--- a/phylum_project/Cargo.toml
+++ b/phylum_project/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "phylum_project"
+description = "Phylum project configuration handling"
+repository = "https://github.com/phylum-dev/cli"
+version = "0.1.0"
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
+license = "GPL-3.0-or-later"
+edition = "2021"
+rust-version = "1.64.0"
+
+[dependencies]
+phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
+chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_yaml = "0.9.2"
+log = "0.4.6"

--- a/phylum_project/src/lib.rs
+++ b/phylum_project/src/lib.rs
@@ -1,0 +1,123 @@
+//! Phylum project configuration handling.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Local};
+use phylum_types::types::common::ProjectId;
+use serde::{Deserialize, Serialize};
+
+/// Project configuration file name.
+pub const PROJ_CONF_FILE: &str = ".phylum_project";
+
+/// Phylum project configuration.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectConfig {
+    pub id: ProjectId,
+    pub name: String,
+    pub created_at: DateTime<Local>,
+    pub group_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lockfile_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lockfile_path: Option<String>,
+    #[serde(default)]
+    lockfiles: Vec<LockfileConfig>,
+    #[serde(skip)]
+    root: PathBuf,
+}
+
+impl ProjectConfig {
+    /// Create a new project configuration.
+    pub fn new(id: ProjectId, name: String, group_name: Option<String>) -> Self {
+        Self {
+            group_name,
+            name,
+            id,
+            root: PathBuf::from("."),
+            created_at: Local::now(),
+            lockfile_type: None,
+            lockfile_path: None,
+            lockfiles: Default::default(),
+        }
+    }
+
+    /// Get all lockfiles of this project.
+    pub fn lockfiles(&self) -> Vec<LockfileConfig> {
+        // Return new lockfile format if present.
+        if !self.lockfiles.is_empty() {
+            return self
+                .lockfiles
+                .iter()
+                .map(|lockfile| {
+                    let path = self.root.join(&lockfile.path);
+                    LockfileConfig::new(path, lockfile.lockfile_type.clone())
+                })
+                .collect();
+        }
+
+        // Fallback to old format.
+        if let Some((path, lockfile_type)) =
+            self.lockfile_path.as_ref().zip(self.lockfile_type.as_ref())
+        {
+            return vec![LockfileConfig::new(self.root.join(path), lockfile_type.clone())];
+        }
+
+        // Default to no lockfiles.
+        Vec::new()
+    }
+
+    /// Update the project's lockfiles.
+    pub fn set_lockfiles(&mut self, lockfiles: Vec<LockfileConfig>) {
+        self.lockfiles = lockfiles;
+    }
+}
+
+/// Lockfile metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockfileConfig {
+    pub path: PathBuf,
+    #[serde(rename = "type")]
+    pub lockfile_type: String,
+}
+
+impl LockfileConfig {
+    pub fn new(path: impl Into<PathBuf>, lockfile_type: String) -> LockfileConfig {
+        LockfileConfig { path: path.into(), lockfile_type }
+    }
+}
+
+/// Get current project configuration file's path.
+pub fn find_project_conf(
+    starting_directory: impl AsRef<Path>,
+    recurse_upwards: bool,
+) -> Option<PathBuf> {
+    let max_depth = if recurse_upwards { 32 } else { 1 };
+    let mut path = starting_directory.as_ref();
+
+    for _ in 0..max_depth {
+        let conf_path = path.join(PROJ_CONF_FILE);
+        if conf_path.is_file() {
+            return Some(conf_path);
+        }
+
+        path = path.parent()?;
+    }
+
+    if recurse_upwards {
+        log::warn!("Max depth exceeded; abandoning search for .phylum_project file");
+    }
+
+    None
+}
+
+/// Get the current project's configuration.
+pub fn get_current_project() -> Option<ProjectConfig> {
+    find_project_conf(".", true).and_then(|config_path| {
+        log::info!("Found project configuration file at {config_path:?}");
+        let config_content = fs::read_to_string(&config_path).ok()?;
+        let mut config: ProjectConfig = serde_yaml::from_str(&config_content).ok()?;
+        config.root = config_path.parent()?.to_path_buf();
+        Some(config)
+    })
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -141,7 +141,7 @@ mod cli_args_test {
         let workdir = project_root().join("target").join("tmp").join("test-project");
         let mut args = vec!["run", "--quiet", "--bin", "phylum", "--"];
         args.extend(phylum_args);
-        let status = Command::new("cargo").current_dir(&workdir).args(&args).status()?;
+        let status = Command::new("cargo").current_dir(workdir).args(&args).status()?;
 
         if !status.success() {
             Err(Error::msg("cargo run failed"))


### PR DESCRIPTION
To ensure all Phylum projects using the `.phylum_project` file have a common understanding of its content, the parsing for this file has been extracted into a separate crate.

Closes #908.