### PR TITLE
Bump to v4.4.0 - group delete subcommand; multi-lockfile support in init; bug fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 4.4.0 - group delete subcommand; multi-lockfile support in init; bug fixes
 * 4.3.0 - Fix sandbox executable path resolution
 * 4.2.0 - Single package submit
 * 4.1.0 - Group transfer; Extension REST API access

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "4.3.0"
+version = "4.4.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release-Version: v4.4.0
Release-Summary: group delete subcommand; multi-lockfile support in init; bug fixes