### PR TITLE
Add multi-lockfile ecosystems to analysis summary

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -317,7 +317,7 @@ where
         .ecosystems
         .iter()
         .flat_map(|ecosystem| {
-            Some(match PackageType::from_str(&ecosystem).ok()? {
+            Some(match PackageType::from_str(ecosystem).ok()? {
                 PackageType::Npm => "NPM",
                 PackageType::RubyGems => "RubyGems",
                 PackageType::PyPi => "PyPI",
@@ -359,7 +359,7 @@ where
     let mut summary = details.iter().fold("".to_string(), |acc, x| {
         format!("{}\n{:>16}: {:<36} {:>24}: {:<36}", acc, x.0, x.1, x.2, x.3)
     });
-    summary = format!("{}\n{:>16}: {}", summary, ecosystems_title, ecosystems_value);
+    summary = format!("{summary}\n{ecosystems_title:>16}: {ecosystems_value}");
 
     let status = if resp.num_incomplete > 0 {
         format!("{:>16}: {}", "Status", style("INCOMPLETE").yellow())

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -312,16 +312,31 @@ fn response_to_table<T>(resp: &JobStatusResponse<T>) -> Table
 where
     T: Scored,
 {
-    let ecosystem = PackageType::from_str(&resp.ecosystem).unwrap_or(PackageType::Npm);
-    let ecosystem_label = match ecosystem {
-        PackageType::Npm => "NPM",
-        PackageType::RubyGems => "RubyGems",
-        PackageType::PyPi => "PyPI",
-        PackageType::Maven => "Maven",
-        PackageType::Nuget => "NuGet",
-        PackageType::Golang => "Golang",
-        PackageType::Cargo => "Cargo",
-    };
+    // Combine all ecosystems into a comma-separated string.
+    let ecosystems = resp
+        .ecosystems
+        .iter()
+        .flat_map(|ecosystem| {
+            Some(match PackageType::from_str(&ecosystem).ok()? {
+                PackageType::Npm => "NPM",
+                PackageType::RubyGems => "RubyGems",
+                PackageType::PyPi => "PyPI",
+                PackageType::Maven => "Maven",
+                PackageType::Nuget => "NuGet",
+                PackageType::Golang => "Golang",
+                PackageType::Cargo => "Cargo",
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut ecosystems_value = ecosystems.join(", ");
+
+    // Add fallback if no ecosystem could be identified.
+    if ecosystems_value.is_empty() {
+        ecosystems_value = "Unknown".into();
+    }
+
+    // Perform correct pluralization for ecosystems title.
+    let ecosystems_title = if ecosystems.len() >= 2 { "Ecosystems" } else { "Ecosystem" };
 
     let date_time =
         NaiveDateTime::from_timestamp_opt(resp.created_at / 1000, 0).unwrap_or_default();
@@ -344,7 +359,7 @@ where
     let mut summary = details.iter().fold("".to_string(), |acc, x| {
         format!("{}\n{:>16}: {:<36} {:>24}: {:<36}", acc, x.0, x.1, x.2, x.3)
     });
-    summary = format!("{}\n{:>16}: {}", summary, "Ecosystem", ecosystem_label);
+    summary = format!("{}\n{:>16}: {}", summary, ecosystems_title, ecosystems_value);
 
     let status = if resp.num_incomplete > 0 {
         format!("{:>16}: {}", "Status", style("INCOMPLETE").yellow())


### PR DESCRIPTION
Since multi-lockfile is capable of running an analysis on multiple ecosystems, the existing `Ecosystem` field was no longer accurate since it only contained a single ecosystem.

Instead when multiple ecosystems are detected, they're now specified in a comma-separated list.

Closes #924.