### PR TITLE
Fix poetry extension

### DIFF
--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -283,9 +283,6 @@ pub fn default_sandbox() -> SandboxResult<Birdcage> {
     add_exception(&mut birdcage, Exception::ExecuteAndRead("/opt/homebrew".into()))?;
     add_exception(&mut birdcage, Exception::ExecuteAndRead("/usr/local".into()))?;
 
-    // Allow `env` exec to resolve binary paths.
-    add_exception(&mut birdcage, Exception::ExecuteAndRead("/usr/bin/env".into()))?;
-
     // Allow access to DNS list.
     //
     // While this is required to send DNS requests for network queries, this does
@@ -295,6 +292,12 @@ pub fn default_sandbox() -> SandboxResult<Birdcage> {
     // Allow reading SSL certificates.
     add_exception(&mut birdcage, Exception::Read("/etc/ca-certificates".into()))?;
     add_exception(&mut birdcage, Exception::Read("/etc/ssl".into()))?;
+
+    // Allow `env` exec to resolve binary paths.
+    add_exception(&mut birdcage, Exception::ExecuteAndRead("/usr/bin/env".into()))?;
+
+    // Allow write access to null-sink.
+    add_exception(&mut birdcage, Exception::Write("/dev/null".into()))?;
 
     // Allow applications to read from `$PATH`.
     birdcage.add_exception(Exception::Environment("PATH".into()))?;

--- a/extensions/poetry/PhylumExt.toml
+++ b/extensions/poetry/PhylumExt.toml
@@ -3,8 +3,8 @@ description = "Poetry package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["poetry", "python", "python3"]
-read = true
-write = ["./", "~/.cache/pypoetry", "~/.local/share/virtualenv", "~/Library/Caches/pypoetry"]
+run = ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry"]
+write = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
+read = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv", "~/Library/Preferences/pypoetry", "~/.config/pypoetry", "/etc/passwd"]
 net = true
 unsandboxed_run = ["poetry"]

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -150,14 +150,35 @@ async function poetryCheckDryRun(
   console.log(`[${green("phylum")}] Updating lockfile…`);
 
   const status = PhylumApi.runSandboxed({
-      cmd: "poetry",
-      args: [subcommand, "-n", "--lock", ...args.map((s) => s.toString())],
-      exceptions: {
-          run: ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry"],
-          write: ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"],
-          read: ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv", "~/Library/Preferences/pypoetry", "~/.config/pypoetry", "/etc/passwd"],
-          net: true,
-      },
+    cmd: "poetry",
+    args: [subcommand, "-n", "--lock", ...args.map((s) => s.toString())],
+    exceptions: {
+      run: [
+        "./",
+        "/bin",
+        "/usr/bin",
+        "~/.pyenv",
+        "~/.local/bin/poetry",
+        "~/Library/Application Support/pypoetry",
+        "~/.local/share/pypoetry",
+      ],
+      write: [
+        "./",
+        "~/.cache/pypoetry",
+        "~/Library/Caches/pypoetry",
+        "~/.pyenv",
+      ],
+      read: [
+        "./",
+        "~/.cache/pypoetry",
+        "~/Library/Caches/pypoetry",
+        "~/.pyenv",
+        "~/Library/Preferences/pypoetry",
+        "~/.config/pypoetry",
+        "/etc/passwd",
+      ],
+      net: true,
+    },
   });
 
   // Ensure dry-run update was successful.


### PR DESCRIPTION
This patch updates the poetry extension to make use of the `--lock` flag for dry-running the package installation without executing any code.

Installation after analysis is done outside of the sandbox, since it seems to allow for near arbitrary code execution.

A more blacklist-based approach to deny some access (like $HOME) could likely be introduced in the future.

Closes #804.