### PR TITLE
Add option to specify multiple lockfiles on CLI

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -232,16 +232,17 @@ pub fn add_subcommands(command: Command) -> Command {
         .subcommand(Command::new("ping").about("Ping the remote system to verify it is available"))
         .subcommand(
             Command::new("parse").about("Parse a lockfile and output its packages as JSON").args(&[
-                Arg::new("LOCKFILE")
+                Arg::new("lockfile")
                     .value_name("LOCKFILE")
                     .value_hint(ValueHint::FilePath)
-                    .help("The package lock file to submit."),
+                    .help("The package lock file to submit.")
+                    .action(ArgAction::Append),
                 Arg::new("lockfile-type")
                     .short('t')
                     .long("lockfile-type")
                     .value_name("type")
                     .requires("LOCKFILE")
-                    .help("The type of the lock file (default: auto)")
+                    .help("The type of the lock files (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
             ]),
         )
@@ -275,16 +276,17 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_name("group_name")
                         .help("Specify a group to use for analysis")
                         .requires("project"),
-                    Arg::new("LOCKFILE")
+                    Arg::new("lockfile")
                         .value_name("LOCKFILE")
                         .value_hint(ValueHint::FilePath)
-                        .help("The package lock file to submit."),
+                        .help("The package lock file to submit.")
+                        .action(ArgAction::Append),
                     Arg::new("lockfile-type")
                         .short('t')
                         .long("lockfile-type")
                         .value_name("type")
                         .requires("LOCKFILE")
-                        .help("The type of the lock file (default: auto)")
+                        .help("The type of the lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 ]),
         )
@@ -445,14 +447,15 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('l')
                         .long("lockfile")
                         .value_name("LOCKFILE")
-                        .help("Project lockfile name"),
+                        .help("Project lockfile name")
+                        .action(ArgAction::Append),
                     Arg::new("lockfile-type")
                         .short('t')
                         .long("lockfile-type")
-                        .value_name("LOCKFILE_TYPE")
-                        .requires("lockfile")
-                        .help("Project lockfile type")
-                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(false))),
+                        .value_name("type")
+                        .requires("LOCKFILE")
+                        .help("The type of the lock files (default: auto)")
+                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                     Arg::new("force")
                         .short('f')
                         .long("force")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -241,7 +241,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('t')
                     .long("lockfile-type")
                     .value_name("type")
-                    .requires("LOCKFILE")
+                    .requires("lockfile")
                     .help("The type of the lock files (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
             ]),
@@ -285,7 +285,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("lockfile-type")
                         .value_name("type")
-                        .requires("LOCKFILE")
+                        .requires("lockfile")
                         .help("The type of the lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 ]),
@@ -453,7 +453,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("lockfile-type")
                         .value_name("type")
-                        .requires("LOCKFILE")
+                        .requires("lockfile")
                         .help("The type of the lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                     Arg::new("force")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -242,7 +242,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .long("lockfile-type")
                     .value_name("type")
                     .requires("lockfile")
-                    .help("The type of the lock files (default: auto)")
+                    .help("Lock file type used for all lock files (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
             ]),
         )
@@ -286,7 +286,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("lockfile-type")
                         .value_name("type")
                         .requires("lockfile")
-                        .help("The type of the lock files (default: auto)")
+                        .help("Lock file type used for all lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 ]),
         )
@@ -454,7 +454,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("lockfile-type")
                         .value_name("type")
                         .requires("lockfile")
-                        .help("The type of the lock files (default: auto)")
+                        .help("Lock file type used for all lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                     Arg::new("force")
                         .short('f')

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -231,20 +231,22 @@ pub fn add_subcommands(command: Command) -> Command {
         )
         .subcommand(Command::new("ping").about("Ping the remote system to verify it is available"))
         .subcommand(
-            Command::new("parse").about("Parse a lockfile and output its packages as JSON").args(&[
-                Arg::new("lockfile")
-                    .value_name("LOCKFILE")
-                    .value_hint(ValueHint::FilePath)
-                    .help("The package lock file to submit.")
-                    .action(ArgAction::Append),
-                Arg::new("lockfile-type")
-                    .short('t')
-                    .long("lockfile-type")
-                    .value_name("type")
-                    .requires("lockfile")
-                    .help("Lock file type used for all lock files (default: auto)")
-                    .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
-            ]),
+            Command::new("parse")
+                .about("Parse lock files and output their packages as JSON")
+                .args(&[
+                    Arg::new("lockfile")
+                        .value_name("LOCKFILE")
+                        .value_hint(ValueHint::FilePath)
+                        .help("The package lock files to submit")
+                        .action(ArgAction::Append),
+                    Arg::new("lockfile-type")
+                        .short('t')
+                        .long("lockfile-type")
+                        .value_name("type")
+                        .requires("lockfile")
+                        .help("Lock file type used for all lock files (default: auto)")
+                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
+                ]),
         )
         .subcommand(
             Command::new("analyze")
@@ -279,7 +281,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("lockfile")
                         .value_name("LOCKFILE")
                         .value_hint(ValueHint::FilePath)
-                        .help("The package lock file to submit.")
+                        .help("The package lock files to submit")
                         .action(ArgAction::Append),
                     Arg::new("lockfile-type")
                         .short('t')
@@ -447,7 +449,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('l')
                         .long("lockfile")
                         .value_name("LOCKFILE")
-                        .help("Project lockfile name")
+                        .help("Project-relative lock file path")
                         .action(ArgAction::Append),
                     Arg::new("lockfile-type")
                         .short('t')

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -182,12 +182,14 @@ pub fn lockfiles(
     project: Option<&ProjectConfig>,
 ) -> Result<Vec<LockfileConfig>> {
     let cli_lockfile_type = matches.try_get_one::<String>("lockfile-type").unwrap_or(None);
-    let cli_lockfile = matches.get_one::<String>("LOCKFILE");
+    let cli_lockfiles = matches.get_many::<String>("lockfile");
 
-    match cli_lockfile {
-        Some(cli_lockfile) => {
+    match cli_lockfiles {
+        Some(cli_lockfiles) => {
             let lockfile_type = cli_lockfile_type.cloned().unwrap_or_else(|| "auto".into());
-            Ok(vec![LockfileConfig::new(cli_lockfile, lockfile_type)])
+            Ok(cli_lockfiles
+                .map(|lockfile| LockfileConfig::new(lockfile, lockfile_type.clone()))
+                .collect())
         },
         None => {
             let lockfiles = project.map(|project| project.lockfiles()).unwrap_or_default();

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -22,4 +22,7 @@ $ phylum analyze -p sample -g sGroup app.csproj
 
 # Analyze a RubyGems lock file and return a verbose response with only critical malware
 $ phylum analyze --verbose --filter=crit,mal Gemfile.lock
+
+# Analyze the `Cargo.lock` and `lockfile` files as cargo lockfiles
+$ phylum analyze --lockfile-type cargo Cargo.lock lockfile
 ```

--- a/doc_templates/phylum_parse.md
+++ b/doc_templates/phylum_parse.md
@@ -6,5 +6,8 @@
 
 ```sh
 # Parse a lockfile
-$ phylum parse -t npm package-lock.json
+$ phylum parse package-lock.json
+
+# Parse the `Cargo.lock` and `lockfile` files as cargo lockfiles
+$ phylum parse --lockfile-type cargo Cargo.lock lockfile
 ```

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -7,13 +7,13 @@ hidden: false
 Submit a request for analysis to the processing system
 
 ```sh
-Usage: phylum analyze [OPTIONS] [LOCKFILE]
+Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 ```
 
 ### Arguments
 
 [LOCKFILE]
-&emsp; The package lock file to submit.
+&emsp; The package lock files to submit
 
 ### Options
 
@@ -44,7 +44,7 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]
 &emsp; Specify a group to use for analysis
 
 -t, --lockfile-type <type>
-&emsp; The type of the lock file (default: auto)
+&emsp; Lock file type used for all lock files (default: auto)
 &emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `auto`
 
 -v, --verbose...
@@ -76,4 +76,7 @@ $ phylum analyze -p sample -g sGroup app.csproj
 
 # Analyze a RubyGems lock file and return a verbose response with only critical malware
 $ phylum analyze --verbose --filter=crit,mal Gemfile.lock
+
+# Analyze the `Cargo.lock` and `lockfile` files as cargo lockfiles
+$ phylum analyze --lockfile-type cargo Cargo.lock lockfile
 ```

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -21,11 +21,11 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 &emsp; Group which will be the owner of the project
 
 -l, --lockfile <LOCKFILE>
-&emsp; Project lockfile name
+&emsp; Project-relative lock file path
 
--t, --lockfile-type <LOCKFILE_TYPE>
-&emsp; Project lockfile type
-&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`
+-t, --lockfile-type <type>
+&emsp; Lock file type used for all lock files (default: auto)
+&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `auto`
 
 -f, --force
 &emsp; Overwrite existing configurations without confirmation

--- a/docs/command_line_tool/phylum_parse.md
+++ b/docs/command_line_tool/phylum_parse.md
@@ -4,21 +4,21 @@ category: 6255e67693d5200013b1fa3e
 hidden: false
 ---
 
-Parse a lockfile and output its packages as JSON
+Parse lock files and output their packages as JSON
 
 ```sh
-Usage: phylum parse [OPTIONS] [LOCKFILE]
+Usage: phylum parse [OPTIONS] [LOCKFILE]...
 ```
 
 ### Arguments
 
 [LOCKFILE]
-&emsp; The package lock file to submit.
+&emsp; The package lock files to submit
 
 ### Options
 
 -t, --lockfile-type <type>
-&emsp; The type of the lock file (default: auto)
+&emsp; Lock file type used for all lock files (default: auto)
 &emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `auto`
 
 -v, --verbose...
@@ -34,5 +34,8 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]
 
 ```sh
 # Parse a lockfile
-$ phylum parse -t npm package-lock.json
+$ phylum parse package-lock.json
+
+# Parse the `Cargo.lock` and `lockfile` files as cargo lockfiles
+$ phylum parse --lockfile-type cargo Cargo.lock lockfile
 ```


### PR DESCRIPTION
This patch changes the `--lockfile` option in all places to allow for multiple occurrences, allowing proper multi-lockfile support for the entire CLI.

The `--lockfile-type` parameter itself is still only allowed once and applies to all other specified lockfiles. This should be fine considering it's only a last-ditch escape hatch since it should always be possible to just let the auto-parser figure things out.

Closes #906.