### PR TITLE
Add Phylum project file

### DIFF
--- a/.phylum_project
+++ b/.phylum_project
@@ -1,0 +1,7 @@
+id: 91324b39-08f7-4de5-8266-230404b43a06
+name: cli
+created_at: 2023-01-25T20:51:40.553394940+01:00
+group_name: null
+lockfiles:
+- path: Cargo.lock
+  type: cargo

--- a/.phylum_project
+++ b/.phylum_project
@@ -1,7 +1,7 @@
-id: 91324b39-08f7-4de5-8266-230404b43a06
+id: d84b0bb3-fb64-43cb-a473-dc96b54db662
 name: cli
-created_at: 2023-01-25T20:51:40.553394940+01:00
-group_name: null
+created_at: 2023-01-26T20:02:11.276987834+01:00
+group_name: integrations
 lockfiles:
 - path: Cargo.lock
   type: cargo


### PR DESCRIPTION
This adds the `.phylum_project` file with our lockfile information to ensure the GitHub App does not run analysis on all our test fixture lockfiles.