### PR TITLE
Fix install with poetry extension

### DIFF
--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -188,6 +188,8 @@ async function poetryCheckDryRun(
       console.error(`[${red("phylum")}] Lockfile update failed.\n`);
       await abort(status.code ?? 255);
     }
+
+    console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
   }
 
   const lockfileData = await PhylumApi.parseLockfile("./poetry.lock", "poetry");
@@ -196,7 +198,6 @@ async function poetryCheckDryRun(
   // regardless of success.
   await restoreBackup();
 
-  console.log(`[${green("phylum")}] Lockfile updated successfully.\n`);
   console.log(`[${green("phylum")}] Analyzing packages…`);
 
   if (lockfileData.packages.length === 0) {

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -147,44 +147,47 @@ async function poetryCheckDryRun(
   subcommand: string,
   args: string[],
 ): Promise<number> {
-  console.log(`[${green("phylum")}] Updating lockfile…`);
+  // Skip lockfile update on install, since it doesn't have the `--lock` flag.
+  if (subcommand !== "install") {
+    console.log(`[${green("phylum")}] Updating lockfile…`);
 
-  const status = PhylumApi.runSandboxed({
-    cmd: "poetry",
-    args: [subcommand, "-n", "--lock", ...args.map((s) => s.toString())],
-    exceptions: {
-      run: [
-        "./",
-        "/bin",
-        "/usr/bin",
-        "~/.pyenv",
-        "~/.local/bin/poetry",
-        "~/Library/Application Support/pypoetry",
-        "~/.local/share/pypoetry",
-      ],
-      write: [
-        "./",
-        "~/.cache/pypoetry",
-        "~/Library/Caches/pypoetry",
-        "~/.pyenv",
-      ],
-      read: [
-        "./",
-        "~/.cache/pypoetry",
-        "~/Library/Caches/pypoetry",
-        "~/.pyenv",
-        "~/Library/Preferences/pypoetry",
-        "~/.config/pypoetry",
-        "/etc/passwd",
-      ],
-      net: true,
-    },
-  });
+    const status = PhylumApi.runSandboxed({
+      cmd: "poetry",
+      args: [subcommand, "-n", "--lock", ...args.map((s) => s.toString())],
+      exceptions: {
+        run: [
+          "./",
+          "/bin",
+          "/usr/bin",
+          "~/.pyenv",
+          "~/.local/bin/poetry",
+          "~/Library/Application Support/pypoetry",
+          "~/.local/share/pypoetry",
+        ],
+        write: [
+          "./",
+          "~/.cache/pypoetry",
+          "~/Library/Caches/pypoetry",
+          "~/.pyenv",
+        ],
+        read: [
+          "./",
+          "~/.cache/pypoetry",
+          "~/Library/Caches/pypoetry",
+          "~/.pyenv",
+          "~/Library/Preferences/pypoetry",
+          "~/.config/pypoetry",
+          "/etc/passwd",
+        ],
+        net: true,
+      },
+    });
 
-  // Ensure dry-run update was successful.
-  if (!status.success) {
-    console.error(`[${red("phylum")}] Lockfile update failed.\n`);
-    await abort(status.code ?? 255);
+    // Ensure dry-run update was successful.
+    if (!status.success) {
+      console.error(`[${red("phylum")}] Lockfile update failed.\n`);
+      await abort(status.code ?? 255);
+    }
   }
 
   const lockfileData = await PhylumApi.parseLockfile("./poetry.lock", "poetry");


### PR DESCRIPTION
Since the `poetry install` subcommand does not have a `--lock` argument, it would cause the subcommand to fail. Since `install` should generally be based on an updated lockfile already anyway, it should be fine to run an analysis without first updating the lockfile.

However there are options allowing `install` to modify the lockfile, which is why a proper solution would likely involve parsing the `--dry-run` output instead.