### PR TITLE
Improve `phylum init` UX

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -159,7 +159,7 @@ async fn handle_commands() -> CommandResult {
         "analyze" | "batch" => {
             jobs::handle_submission(&mut Spinner::wrap(api).await?, &matches).await
         },
-        "init" => init::handle_init(&mut Spinner::wrap(api).await?, sub_matches).await,
+        "init" => init::handle_init(&Spinner::wrap(api).await?, sub_matches).await,
 
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),


### PR DESCRIPTION
Improve phylum init self-documentation

This changes the output of `phylum init` to be more descriptive of its
behavior, helping out inexperienced CLI users with setting up their
projects.

Closes https://github.com/phylum-dev/cli/issues/935.

---

Suggest available groups for phylum init

Previously the group input field was just a freetext field, which
created issues when the group did not exist already since groups are not
automatically created.

To resolve this, we send a request for available groups during startup
now and only allow selecting groups the user is part of.

Without any groups, the group selection process will be skipped
entirely.

The groups HTTP request is sent on startup since we have some startup
delay anyway and this way it will not harm the interactivity after this
initial startup period.

Closes https://github.com/phylum-dev/cli/issues/934.