### PR TITLE
Fix Go parser ignoring dependencies

### DIFF
--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -129,6 +129,7 @@ mod tests {
             assert!(pkgs.contains(&expected_pkg));
         }
     }
+
     #[test]
     fn parse_cargo_lock_v3() {
         let pkgs = Cargo.parse(include_str!("../../tests/fixtures/Cargo_v3.lock")).unwrap();

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -37,18 +37,21 @@ mod tests {
     #[test]
     fn parse_go_sum() {
         let pkgs = GoSum.parse(include_str!("../../tests/fixtures/go.sum")).unwrap();
-        assert_eq!(pkgs.len(), 675);
+        assert_eq!(pkgs.len(), 1711);
 
-        // check the first package in the example go.sum
-        assert_eq!(pkgs[0].name, "cloud.google.com/go");
-        assert_eq!(pkgs[0].version, PackageVersion::FirstParty("v0.72.0".into()));
+        let expected_pkgs = [
+            Package {
+                name: "cloud.google.com/go".into(),
+                version: PackageVersion::FirstParty("v0.72.0".into()),
+            },
+            Package {
+                name: "sourcegraph.com/sourcegraph/appdash".into(),
+                version: PackageVersion::FirstParty("v0.0.0-20190731080439-ebfcffb1b5c0".into()),
+            },
+        ];
 
-        // check the last package in the example go.sum
-        let last = pkgs.last().unwrap();
-        assert_eq!(last.name, "sourcegraph.com/sourcegraph/appdash");
-        assert_eq!(
-            last.version,
-            PackageVersion::FirstParty("v0.0.0-20190731080439-ebfcffb1b5c0".into())
-        );
+        for expected_pkg in expected_pkgs {
+            assert!(pkgs.contains(&expected_pkg));
+        }
     }
 }

--- a/tests/fixtures/go.sum
+++ b/tests/fixtures/go.sum
@@ -2382,6 +2382,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 


### PR DESCRIPTION
Previously the assumption was made that any line in the Go lockfile including `/go.mod` after its version was only included for the hash and would still have its version included without the `/go.mod` in a different line. This assumption was incorrect.

To ensure we don't ignore dependencies that are actually used, we now include all versions with and without the suffix and deduplicate that list after parsing.

This will include a lot more dependencies than what is actually used, but for security purposes over-reporting is much likely more desirable than under-reporting, considering we can't get an accurate list just by parsing the lockfile.

Closes #942.
