### PR TITLE
Bump to v4.6.1 - Fix Go parser ignoring dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 4.6.1 - Fix Go parser from ignoring dependencies
 * 4.6.0 - Improve init UX
 * 4.5.0 - Add multi-lockfile options to parse/analyze/init; fix poetry extension
 * 4.4.0 - group delete subcommand; multi-lockfile support in init; bug fixes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* 4.6.1 - Fix Go parser from ignoring dependencies
+* 4.6.1 - Fix Go parser ignoring dependencies
 * 4.6.0 - Improve init UX
 * 4.5.0 - Add multi-lockfile options to parse/analyze/init; fix poetry extension
 * 4.4.0 - group delete subcommand; multi-lockfile support in init; bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "4.6.0"
+version = "4.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "4.6.0"
+version = "4.6.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release-Version: v4.6.1
Release-Summary: Fix Go parser from ignoring dependencies