### PR TITLE
Fix project history endpoint

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -233,14 +233,6 @@ mod test {
     }
 
     #[test]
-    fn get_project_details_is_correct() {
-        assert_eq!(
-            get_project_history(API_URI, "acme/widgets").unwrap().as_str(),
-            format!("{API_URI}/{API_PATH}data/projects/name/acme%2Fwidgets"),
-        );
-    }
-
-    #[test]
     fn get_project_summary_is_correct() {
         assert_eq!(
             get_project_summary(API_URI).unwrap().as_str(),

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -46,10 +46,27 @@ pub fn post_submit_package(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/packages/submit")?)
 }
 
-/// GET /data/projects/name/<pkg_id>
-pub fn get_project_details(api_uri: &str, pkg_id: &str) -> Result<Url, BaseUriError> {
+/// GET /data/projects/<project_id>/history
+pub fn get_project_history(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;
-    url.path_segments_mut().unwrap().pop_if_empty().extend(["data", "projects", "name", pkg_id]);
+    url.path_segments_mut()
+        .unwrap()
+        .pop_if_empty()
+        .extend(["data", "projects", project_id, "history"]);
+    Ok(url)
+}
+
+/// GET /groups/<group_name>/projects/<project_id>/history
+pub fn get_group_project_history(
+    api_uri: &str,
+    project_id: &str,
+    group_name: &str,
+) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut()
+        .unwrap()
+        .pop_if_empty()
+        .extend(["groups", group_name, "projects", project_id, "history"]);
     Ok(url)
 }
 
@@ -218,7 +235,7 @@ mod test {
     #[test]
     fn get_project_details_is_correct() {
         assert_eq!(
-            get_project_details(API_URI, "acme/widgets").unwrap().as_str(),
+            get_project_history(API_URI, "acme/widgets").unwrap().as_str(),
             format!("{API_URI}/{API_PATH}data/projects/name/acme%2Fwidgets"),
         );
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -88,7 +88,12 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('p')
                     .long("project")
                     .value_name("project_name")
-                    .help("Project name used to filter jobs"),
+                    .help("Project to be queried"),
+                Arg::new("group")
+                    .short('g')
+                    .long("group")
+                    .value_name("group_name")
+                    .help("Group to be queried"),
             ]),
         )
         .subcommand(

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -82,8 +82,9 @@ pub async fn handle_history(api: &mut PhylumApi, matches: &clap::ArgMatches) -> 
             JobId::from_str(job_id).with_context(|| format!("{job_id:?} is not a valid Job ID"))?;
         action = get_job_status(api, &job_id, verbose, pretty_print, display_filter).await?;
     } else if let Some(project) = matches.get_one::<String>("project") {
-        let resp = api.get_project_details(project).await?.jobs;
-        resp.write_stdout(pretty_print);
+        let group = matches.get_one::<String>("group").map(String::as_str);
+        let history = api.get_project_history(project, group).await?;
+        history.write_stdout(pretty_print);
     } else {
         let resp = match api.get_status().await {
             Ok(resp) => resp,

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -19,6 +19,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::histogram::Histogram;
 use crate::print::{self, table_format};
+use crate::types::HistoryJob;
 
 /// Format type for CLI output.
 pub trait Format: Serialize {
@@ -229,6 +230,17 @@ impl Format for JobStatusResponse<PackageStatusExtended> {
 
         let _ = writeln!(writer, "{table_1}");
         let _ = writeln!(writer, "{table_2}");
+    }
+}
+
+impl Format for Vec<HistoryJob> {
+    fn pretty<W: Write>(&self, writer: &mut W) {
+        let table = format_table::<fn(&HistoryJob) -> String, _>(self, &[
+            ("Job ID", |job| job.id.clone()),
+            ("Label", |job| job.label.clone()),
+            ("Creation Time", |job| job.created.format("%FT%RZ").to_string()),
+        ]);
+        let _ = writeln!(writer, "{table}");
     }
 }
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -44,6 +45,14 @@ pub struct GithubRelease {
 pub struct GithubReleaseAsset {
     pub browser_download_url: String,
     pub name: String,
+}
+
+/// History job entry.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct HistoryJob {
+    pub id: String,
+    pub created: DateTime<Utc>,
+    pub label: String,
 }
 
 #[cfg(test)]

--- a/docs/command_line_tool/phylum_history.md
+++ b/docs/command_line_tool/phylum_history.md
@@ -32,7 +32,10 @@ Usage: phylum history [OPTIONS] [JOB_ID]
 &emsp; Produce output in json format (default: false)
 
 -p, --project <project_name>
-&emsp; Project name used to filter jobs
+&emsp; Project to be queried
+
+-g, --group <group_name>
+&emsp; Group to be queried
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)


### PR DESCRIPTION
This patch fixes a long-standing issue where querying for project-specific history using `phylum history --project <PROJECT>` would return an empty list. A new `--group` flag was also added to get history for a specific group's project.

The full history endpoint does not give any group information and as such cannot be used to retrieve this information. But projects and groups have a separate endpoint providing a less detailed list of historic jobs which can be used instead.

The new history for projects includes Job ID, Label, and Creation Time.

Closes #378.