### PR TITLE
Use --dry-run output for poetry extension

### DIFF
--- a/extensions/poetry/PhylumExt.toml
+++ b/extensions/poetry/PhylumExt.toml
@@ -4,7 +4,7 @@ entry_point = "main.ts"
 
 [permissions]
 run = ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry", "~/.local/pipx"]
-write = ["~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
+write = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
 read = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv", "~/Library/Preferences/pypoetry", "~/.config/pypoetry", "/etc/passwd"]
 net = true
 unsandboxed_run = ["poetry"]

--- a/extensions/poetry/PhylumExt.toml
+++ b/extensions/poetry/PhylumExt.toml
@@ -4,7 +4,7 @@ entry_point = "main.ts"
 
 [permissions]
 run = ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry"]
-write = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
+write = ["~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
 read = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv", "~/Library/Preferences/pypoetry", "~/.config/pypoetry", "/etc/passwd"]
 net = true
 unsandboxed_run = ["poetry"]

--- a/extensions/poetry/PhylumExt.toml
+++ b/extensions/poetry/PhylumExt.toml
@@ -3,7 +3,7 @@ description = "Poetry package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry"]
+run = ["./", "/bin", "/usr/bin", "~/.pyenv", "~/.local/bin/poetry", "~/Library/Application Support/pypoetry", "~/.local/share/pypoetry", "~/.local/pipx"]
 write = ["~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv"]
 read = ["./", "~/.cache/pypoetry", "~/Library/Caches/pypoetry", "~/.pyenv", "~/Library/Preferences/pypoetry", "~/.config/pypoetry", "/etc/passwd"]
 net = true

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -206,6 +206,10 @@ async function poetryCheckDryRun(
       version = version_split[1];
     }
 
+    // Truncate URI from versions:
+    // "1.2.3 https://github.com/demo/demo.git" -> "1.2.3"
+    version = version.split(" ")[0];
+
     packages.push({ name, version });
   }
 

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -106,7 +106,12 @@ async function poetryCheckDryRun(
 ) {
   const result = PhylumApi.runSandboxed({
     cmd: "poetry",
-    args: [subcommand, "-n", "--dry-run", ...args.map((s) => s.toString())],
+    args: [
+      subcommand,
+      "--no-interaction",
+      "--dry-run",
+      ...args.map((s) => s.toString()),
+    ],
     exceptions: {
       run: [
         "./",
@@ -139,7 +144,7 @@ async function poetryCheckDryRun(
   // Ensure dry-run update was successful.
   if (!result.success || result.stdout.length == 0) {
     console.error(`[${red("phylum")}] Failed to determine new packages.\n`);
-    return status.code ?? 255;
+    return result.code ?? 255;
   }
 
   // Parse dry-run output to look for new packages.

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -121,6 +121,7 @@ async function poetryCheckDryRun(
         "~/.local/bin/poetry",
         "~/Library/Application Support/pypoetry",
         "~/.local/share/pypoetry",
+        "~/.local/pipx",
       ],
       write: [
         "~/.cache/pypoetry",

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -144,14 +144,14 @@ async function poetryCheckDryRun(
   // Ensure dry-run update was successful.
   if (!result.success || result.stdout.length == 0) {
     console.error(`[${red("phylum")}] Failed to determine new packages.\n`);
-    return result.code ?? 255;
+    Deno.exit(result.code ?? 255);
   }
 
   // Parse dry-run output to look for new packages.
   const packages = [];
   const lines = result.stdout.split("\n");
   for (const line of lines) {
-    const installing_text = "Installing ";
+    const installing_text = "• Installing ";
     const installing_index = line.indexOf(installing_text);
 
     // Filter lines unrelated to new packages.
@@ -171,15 +171,14 @@ async function poetryCheckDryRun(
       version = version.substring(0, colon_index);
     }
 
-    // Ensure what we parsed is in a sensible format.
+    // Ensure the line is in the correct format.
     if (
       name.length === 0 ||
       version.length === 0 ||
       !version.startsWith("(") ||
       !version.endsWith(")")
     ) {
-      console.error(`[${red("phylum")}] Invalid poetry output: ${line}.\n`);
-      Deno.exit(125);
+      continue;
     }
 
     // Remove parenthesis from version.


### PR DESCRIPTION
This fixes some issues with the poetry ecosystem extension by switching from updating the lockfile and parsing it over to parsing the `--dry-run` flag's output instead.

The primary issue with the `--lock` flag is that the `poetry install` subcommand does not have such a flag, only `poetry add`.

Besides `poetry install`, this patch also removes any necessity to write to the project directory since `--dry-run` is immutable. This allows further lockdown of our sandbox.

Closes #931.
