### PR TITLE
Remove --force option from phylum analyze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#57172677e59b3e9198c26226b4240df3fd19ac6b"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#836edf5e49d009eba8560c9075ed490305140750"
 dependencies = [
  "chrono",
  "schemars",

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -297,7 +297,6 @@ impl PhylumApi {
         &self,
         req_type: &PackageType,
         package_list: &[PackageDescriptor],
-        is_user: bool,
         project: ProjectId,
         label: Option<String>,
         group_name: Option<String>,
@@ -305,7 +304,7 @@ impl PhylumApi {
         let req = SubmitPackageRequest {
             package_type: req_type.to_owned(),
             packages: package_list.to_vec(),
-            is_user,
+            is_user: true,
             project,
             label: label.unwrap_or_else(|| "uncategorized".to_string()),
             group_name,
@@ -496,7 +495,7 @@ mod tests {
         };
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
-        client.submit_request(&PackageType::Npm, &[pkg], true, project_id, label, None).await?;
+        client.submit_request(&PackageType::Npm, &[pkg], project_id, label, None).await?;
 
         // Request should have been submitted with a bearer token
         let bearer_token = token_holder.lock().unwrap().take();
@@ -526,7 +525,7 @@ mod tests {
         };
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
-        client.submit_request(&PackageType::Npm, &[pkg], true, project_id, label, None).await?;
+        client.submit_request(&PackageType::Npm, &[pkg], project_id, label, None).await?;
         Ok(())
     }
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -249,10 +249,6 @@ pub fn add_subcommands(command: Command) -> Command {
             Command::new("analyze")
                 .about("Submit a request for analysis to the processing system")
                 .args(&[
-                    Arg::new("force").action(ArgAction::SetTrue).short('F').long("force").help(
-                        "Force re-processing of packages (even if they already exist in the \
-                         system)",
-                    ),
                     Arg::new("label")
                         .short('l')
                         .long("label")
@@ -308,10 +304,6 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("type")
                         .value_name("type")
                         .help(r#"Package type ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#),
-                    Arg::new("force").action(ArgAction::SetTrue).short('F').long("force").help(
-                        "Force re-processing of packages (even if they already exist in the \
-                         system)",
-                    ),
                     Arg::new("label")
                         .short('l')
                         .long("label")

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -177,7 +177,7 @@ async fn analyze(
         .collect::<Vec<_>>();
 
     let job_id = api
-        .submit_request(&package_type, &packages, false, project, None, group.map(String::from))
+        .submit_request(&package_type, &packages, project, None, group.map(String::from))
         .await?;
 
     Ok(job_id)

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -114,7 +114,6 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
     let mut pretty_print = false;
     let mut display_filter = None;
     let mut action = Action::None;
-    let is_user; // is a user (non-batch) request
     let jobs_project;
     let label;
 
@@ -123,7 +122,6 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         verbose = log::max_level() > LevelFilter::Warn;
         pretty_print = !matches.get_flag("json");
         display_filter = matches.get_one::<String>("filter").and_then(|v| Filter::from_str(v).ok());
-        is_user = !matches.get_flag("force");
         synch = true;
 
         jobs_project = JobsProject::new(api, matches).await?;
@@ -165,7 +163,6 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
                 .map_err(|_| anyhow!("invalid package type: {}", package_type))?
         }
         label = matches.get_one::<String>("label");
-        is_user = !matches.get_flag("force");
 
         while !eof {
             match reader.read_line(&mut line) {
@@ -201,7 +198,6 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         .submit_request(
             &request_type,
             &packages,
-            is_user,
             jobs_project.project_id,
             label.map(String::from),
             jobs_project.group,

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -17,9 +17,6 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 ### Options
 
--F, --force
-&emsp; Force re-processing of packages (even if they already exist in the system)
-
 -l, --label <label>
 &emsp; Specify a label to use for analysis
 


### PR DESCRIPTION
Remove `--force` option from `phylum analyze` and `phylum batch`. This option was previously used to set the `is_user` value when submitting a job, but that value has no effect.