### PR TITLE
Remove `package_type()` from `Parse` trait

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -295,14 +295,15 @@ impl PhylumApi {
     /// Submit a new request to the system
     pub async fn submit_request(
         &self,
-        req_type: &PackageType,
         package_list: &[PackageDescriptor],
         project: ProjectId,
         label: Option<String>,
         group_name: Option<String>,
     ) -> Result<JobId> {
         let req = SubmitPackageRequest {
-            package_type: req_type.to_owned(),
+            // This package_type is ignored by the API, but it still validates it, so we have to put
+            // something here.
+            package_type: PackageType::Npm,
             packages: package_list.to_vec(),
             is_user: true,
             project,
@@ -495,7 +496,7 @@ mod tests {
         };
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
-        client.submit_request(&PackageType::Npm, &[pkg], project_id, label, None).await?;
+        client.submit_request(&[pkg], project_id, label, None).await?;
 
         // Request should have been submitted with a bearer token
         let bearer_token = token_holder.lock().unwrap().take();
@@ -525,7 +526,7 @@ mod tests {
         };
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
-        client.submit_request(&PackageType::Npm, &[pkg], project_id, label, None).await?;
+        client.submit_request(&[pkg], project_id, label, None).await?;
         Ok(())
     }
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -361,8 +361,12 @@ async fn parse_lockfile(
     // Attempt to parse as requested lockfile type.
     let parsed = parse::parse_lockfile(lockfile, lockfile_type.as_deref())?;
 
+    // PackageLock should report LockfileFormat and not PackageType. This is just a
+    // placeholder until that can be updated.
+    let package_type = parsed.packages.first().map(|p| p.package_type).unwrap_or(PackageType::Npm);
+
     Ok(PackageLock {
-        package_type: parsed.package_type,
+        package_type,
         packages: parsed.packages.into_iter().map(PackageSpecifier::from).collect(),
     })
 }

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Error, Result};
 use deno_runtime::deno_core::{op, OpDecl, OpState};
 use deno_runtime::permissions::Permissions;
+use phylum_lockfile::LockfileFormat;
 use phylum_project::ProjectConfig;
 use phylum_types::types::auth::{AccessToken, RefreshToken};
 use phylum_types::types::common::{JobId, ProjectId};
@@ -42,11 +43,16 @@ use crate::dirs;
 struct PackageSpecifier {
     name: String,
     version: String,
+    package_type: Option<PackageType>,
 }
 
 impl From<PackageDescriptor> for PackageSpecifier {
     fn from(descriptor: PackageDescriptor) -> Self {
-        Self { name: descriptor.name, version: descriptor.version }
+        Self {
+            name: descriptor.name,
+            version: descriptor.version,
+            package_type: Some(descriptor.package_type),
+        }
     }
 }
 
@@ -54,7 +60,7 @@ impl From<PackageDescriptor> for PackageSpecifier {
 #[derive(Serialize, Deserialize, Debug)]
 struct PackageLock {
     packages: Vec<PackageSpecifier>,
-    package_type: PackageType,
+    format: LockfileFormat,
 }
 
 /// New process to be launched.
@@ -148,7 +154,7 @@ struct ProcessOutput {
 #[op]
 async fn analyze(
     op_state: Rc<RefCell<OpState>>,
-    package_type: PackageType,
+    package_type: Option<PackageType>,
     packages: Vec<PackageSpecifier>,
     project: Option<String>,
     group: Option<String>,
@@ -169,16 +175,18 @@ async fn analyze(
 
     let packages = packages
         .into_iter()
-        .map(|package| PackageDescriptor {
-            package_type,
-            version: package.version,
-            name: package.name,
+        .map(|package| {
+            let package_type = package.package_type.or(package_type);
+            Ok(PackageDescriptor {
+                version: package.version,
+                name: package.name,
+                package_type: package_type
+                    .ok_or_else(|| anyhow!("Package does not have package type"))?,
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
-    let job_id = api
-        .submit_request(&package_type, &packages, project, None, group.map(String::from))
-        .await?;
+    let job_id = api.submit_request(&packages, project, None, group.map(String::from)).await?;
 
     Ok(job_id)
 }
@@ -361,13 +369,9 @@ async fn parse_lockfile(
     // Attempt to parse as requested lockfile type.
     let parsed = parse::parse_lockfile(lockfile, lockfile_type.as_deref())?;
 
-    // PackageLock should report LockfileFormat and not PackageType. This is just a
-    // placeholder until that can be updated.
-    let package_type = parsed.packages.first().map(|p| p.package_type).unwrap_or(PackageType::Npm);
-
     Ok(PackageLock {
-        package_type,
         packages: parsed.packages.into_iter().map(PackageSpecifier::from).collect(),
+        format: parsed.format,
     })
 }
 

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -138,7 +138,6 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
                 );
             }
 
-            request_type = res.package_type;
             packages.extend(res.packages.into_iter());
         }
     } else if let Some(matches) = matches.subcommand_matches("batch") {

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -140,7 +140,10 @@ pub async fn parse_lockfile() {
         .run()
         .success()
         .stdout(predicates::str::contains(
-            r#"{ packages: [ { name: "accepts", version: "1.3.8" } ], package_type: "npm" }"#,
+            r#"{
+  packages: [ { name: "accepts", version: "1.3.8", package_type: "npm" } ],
+  format: "yarn"
+}"#,
         ));
 }
 

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -190,7 +190,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     return;
   }
 
-  const jobId = await PhylumApi.analyze("npm", lockfile.packages);
+  const jobId = await PhylumApi.analyze(undefined, lockfile.packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
   if (jobStatus.pass && jobStatus.status === "complete") {

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -4,11 +4,12 @@
 type Package = {
   name: string;
   version: string;
+  package_type: string | undefined;
 };
 
 type Lockfile = {
-  package_type: string;
   packages: Package[];
+  format: string;
 };
 
 type ProcessOutput = {
@@ -75,14 +76,16 @@ export class PhylumApi {
    *
    * ```
    * [
-   *   { name: "accepts", version: "1.3.8" },
-   *   { name: "ms", version: "2.0.0" },
-   *   { name: "negotiator", version: "0.6.3" },
-   *   { name: "ms", version: "2.1.3" }
+   *   { name: "accepts", version: "1.3.8", package_type: "npm" },
+   *   { name: "ms", version: "2.0.0", package_type: "npm" },
+   *   { name: "negotiator", version: "0.6.3", package_type: "npm" },
+   *   { name: "ms", version: "2.1.3", package_type: "npm" }
    * ]
    * ```
    *
-   * @param package_type - Accepted package types are "npm", "pypi", "maven", "rubygems", "nuget", "cargo", and "golang"
+   * Accepted package types are "npm", "pypi", "maven", "rubygems", "nuget", "cargo", and "golang"
+   *
+   * @param package_type - DEPRECATED. Specify package_type in each package object instead.
    * @param packages - List of packages to analyze
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
    * @param group - Group name
@@ -90,7 +93,7 @@ export class PhylumApi {
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
-    package_type: string,
+    package_type: string | undefined,
     packages: Package[],
     project?: string,
     group?: string,

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -210,7 +210,7 @@ async function poetryCheckDryRun(
     // "1.2.3 https://github.com/demo/demo.git" -> "1.2.3"
     version = version.split(" ")[0];
 
-    packages.push({ name, version });
+    packages.push({ name, version, package_type: "pypi" });
   }
 
   // Abort if there's nothing to analyze.
@@ -220,7 +220,7 @@ async function poetryCheckDryRun(
   }
 
   // Run Phylum analysis on the packages.
-  const jobId = await PhylumApi.analyze("pypi", packages);
+  const jobId = await PhylumApi.analyze(undefined, packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
   if (jobStatus.pass && jobStatus.status === "complete") {

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -268,7 +268,7 @@ async function checkDryRun() {
     return;
   }
 
-  const jobId = await PhylumApi.analyze("npm", lockfile.packages);
+  const jobId = await PhylumApi.analyze(undefined, lockfile.packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
   if (jobStatus.pass && jobStatus.status === "complete") {

--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "phylum": "./extensions/phylum.ts"
+    "https://deno.phylum.io/phylum.ts": "./extensions/phylum.ts"
   }
 }

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -63,6 +63,7 @@ impl Parse for Cargo {
                         return Ok(Package {
                             name: package.name,
                             version: PackageVersion::Path(None),
+                            package_type: PackageType::Cargo,
                         })
                     },
                 };
@@ -80,13 +81,9 @@ impl Parse for Cargo {
                     return Err(anyhow!(format!("Unknown cargo package source: {source:?}")));
                 };
 
-                Ok(Package { name: package.name, version })
+                Ok(Package { name: package.name, version, package_type: PackageType::Cargo })
             })
             .collect()
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::Cargo
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
@@ -106,8 +103,13 @@ mod tests {
             Package {
                 name: "core-foundation".into(),
                 version: PackageVersion::FirstParty("0.6.4".into()),
+                package_type: PackageType::Cargo,
             },
-            Package { name: "adler32".into(), version: PackageVersion::FirstParty("1.0.4".into()) },
+            Package {
+                name: "adler32".into(),
+                version: PackageVersion::FirstParty("1.0.4".into()),
+                package_type: PackageType::Cargo,
+            },
         ];
 
         for expected_pkg in expected_pkgs {
@@ -123,6 +125,7 @@ mod tests {
         let expected_pkgs = [Package {
             name: "form_urlencoded".into(),
             version: PackageVersion::FirstParty("1.0.1".into()),
+            package_type: PackageType::Cargo,
         }];
 
         for expected_pkg in expected_pkgs {
@@ -139,26 +142,32 @@ mod tests {
             Package {
                 name: "Inflector".into(),
                 version: PackageVersion::FirstParty("0.11.4".into()),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "adler".into(),
                 version: PackageVersion::FirstParty("1.0.2".into()),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "aead".into(),
                 version: PackageVersion::FirstParty("0.5.1".into()),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "aes".into(),
                 version: PackageVersion::FirstParty("0.8.1".into()),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "landlock".into(),
                 version: PackageVersion::Git("git+https://github.com/phylum-dev/rust-landlock#b553736cefc2a740eda746e5730cf250b069a4c1".into()),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "xtask".into(),
                 version: PackageVersion::Path(None),
+                package_type: PackageType::Cargo,
             },
             Package {
                 name: "zstd-sys".into(),
@@ -166,6 +175,7 @@ mod tests {
                     registry: "https://phylum.io/foreign-registry-example".into(),
                     version: "1.6.3+zstd.1.5.2".into(),
                 }),
+                package_type: PackageType::Cargo,
             },
         ];
 

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -34,7 +34,11 @@ struct Project {
 
 impl From<PackageReference> for Package {
     fn from(pkg_ref: PackageReference) -> Self {
-        Self { name: pkg_ref.name, version: PackageVersion::FirstParty(pkg_ref.version) }
+        Self {
+            name: pkg_ref.name,
+            version: PackageVersion::FirstParty(pkg_ref.version),
+            package_type: PackageType::Nuget,
+        }
     }
 }
 
@@ -61,10 +65,6 @@ impl Parse for CSProj {
             Deserializer::new_from_reader(data.as_bytes()).non_contiguous_seq_elements(true);
         let parsed = Project::deserialize(&mut de)?;
         Ok(parsed.into())
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::Nuget
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use anyhow::{anyhow, Context};
 use nom::error::convert_error;
 use nom::Finish;
-use phylum_types::types::package::PackageType;
 
 use crate::parsers::go_sum;
 use crate::{Package, Parse};
@@ -20,10 +19,6 @@ impl Parse for GoSum {
         Ok(entries)
     }
 
-    fn package_type(&self) -> PackageType {
-        PackageType::Golang
-    }
-
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("go.sum"))
     }
@@ -31,6 +26,8 @@ impl Parse for GoSum {
 
 #[cfg(test)]
 mod tests {
+    use phylum_types::types::package::PackageType;
+
     use super::*;
     use crate::PackageVersion;
 
@@ -43,10 +40,12 @@ mod tests {
             Package {
                 name: "cloud.google.com/go".into(),
                 version: PackageVersion::FirstParty("v0.72.0".into()),
+                package_type: PackageType::Golang,
             },
             Package {
                 name: "sourcegraph.com/sourcegraph/appdash".into(),
                 version: PackageVersion::FirstParty("v0.0.0-20190731080439-ebfcffb1b5c0".into()),
+                package_type: PackageType::Golang,
             },
         ];
 

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -24,10 +24,6 @@ impl Parse for GradleLock {
         Ok(entries)
     }
 
-    fn package_type(&self) -> PackageType {
-        PackageType::Maven
-    }
-
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("gradle.lockfile"))
     }
@@ -56,10 +52,6 @@ impl Parse for Pom {
                 Ok(packages)
             },
         }
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::Maven
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
@@ -134,6 +126,7 @@ impl Pom {
                             &dep.artifact_id.clone().unwrap_or_default()
                         ),
                         version: PackageVersion::FirstParty(s.into()),
+                        package_type: PackageType::Maven,
                     })
                 })
             })
@@ -224,6 +217,7 @@ mod tests {
         let additional_dependency = Package {
             name: "io.phylum:fake-dependency".into(),
             version: PackageVersion::FirstParty("1.2.3".into()),
+            package_type: PackageType::Maven,
         };
 
         assert!(pkgs.contains(&additional_dependency));

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -86,7 +86,11 @@ impl Parse for PackageLock {
                     PackageVersion::Path(Some(resolved.into()))
                 };
 
-                packages.push(Package { version, name: name.into() });
+                packages.push(Package {
+                    version,
+                    name: name.into(),
+                    package_type: PackageType::Npm,
+                });
             }
             Ok(packages)
         } else if let Some(deps) = parsed.get("dependencies").and_then(|v| v.as_object()) {
@@ -97,16 +101,13 @@ impl Parse for PackageLock {
                     Ok(Package {
                         version: PackageVersion::FirstParty(get_version(keys, name)?),
                         name: name.into(),
+                        package_type: PackageType::Npm,
                     })
                 })
                 .collect()
         } else {
             Err(anyhow!("Failed to find dependencies"))
         }
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::Npm
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
@@ -217,14 +218,14 @@ impl Parse for YarnLock {
                 ));
             };
 
-            packages.push(Package { name: name.to_owned(), version });
+            packages.push(Package {
+                name: name.to_owned(),
+                version,
+                package_type: PackageType::Npm,
+            });
         }
 
         Ok(packages)
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::Npm
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
@@ -258,8 +259,16 @@ mod tests {
         assert_eq!(pkgs.len(), 54);
 
         let expected_pkgs = [
-            Package { name: "accepts".into(), version: PackageVersion::FirstParty("1.3.8".into()) },
-            Package { name: "vary".into(), version: PackageVersion::FirstParty("1.1.2".into()) },
+            Package {
+                name: "accepts".into(),
+                version: PackageVersion::FirstParty("1.3.8".into()),
+                package_type: PackageType::Npm,
+            },
+            Package {
+                name: "vary".into(),
+                version: PackageVersion::FirstParty("1.1.2".into()),
+                package_type: PackageType::Npm,
+            },
             Package {
                 name: "typescript".into(),
                 version: PackageVersion::Git(
@@ -267,10 +276,12 @@ mod tests {
                      9189e42b1c8b1a91906a245a24697da5e0c11a08"
                         .into(),
                 ),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "form-data".into(),
                 version: PackageVersion::FirstParty("2.3.3".into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "match-sorter".into(),
@@ -278,8 +289,13 @@ mod tests {
                     registry: "custom-registry.org".into(),
                     version: "3.1.1".into(),
                 }),
+                package_type: PackageType::Npm,
             },
-            Package { name: "test".into(), version: PackageVersion::Path(Some("../test".into())) },
+            Package {
+                name: "test".into(),
+                version: PackageVersion::Path(Some("../test".into())),
+                package_type: PackageType::Npm,
+            },
         ];
         for expected_pkg in expected_pkgs {
             assert!(pkgs.contains(&expected_pkg));
@@ -300,6 +316,7 @@ mod tests {
         assert_eq!(pkgs, vec![Package {
             name: "@yarnpkg/lockfile".to_string(),
             version: PackageVersion::FirstParty("1.1.0".into()),
+            package_type: PackageType::Npm,
         }]);
     }
 
@@ -341,38 +358,46 @@ mod tests {
             Package {
                 name: "accepts".into(),
                 version: PackageVersion::FirstParty("1.3.8".into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "mime-types".into(),
                 version: PackageVersion::FirstParty("2.1.35".into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "statuses".into(),
                 version: PackageVersion::FirstParty("1.5.0".into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "@fake/package".into(),
                 version: PackageVersion::FirstParty("1.2.3".into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "ethereumjs-abi".into(),
                 version: PackageVersion::Git("https://github.com/ethereumjs/ethereumjs-abi.git\
                     #commit=ee3994657fa7a427238e6ba92a84d0b529bbcde0"
                     .into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "@me/remote-patch".into(),
                 version: PackageVersion::Git("ssh://git@github.com:phylum/remote-patch\
                     #commit=d854c43ea177d1faeea56189249fff8c24a764bd"
                     .into()),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "xxx".into(),
                 version: PackageVersion::Path(None),
+                package_type: PackageType::Npm,
             },
             Package {
                 name: "testing".into(),
                 version: PackageVersion::Path(None),
+                package_type: PackageType::Npm,
             },
         ];
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -141,9 +141,6 @@ pub trait Parse {
     /// Parse from a string.
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>>;
 
-    /// Indicate the type of packages parsed by this parser.
-    fn package_type(&self) -> PackageType;
-
     /// Test if a file name could be a lock file supported by this parser.
     ///
     /// The file does not need to exist.
@@ -155,6 +152,7 @@ pub trait Parse {
 pub struct Package {
     pub name: String,
     pub version: PackageVersion,
+    pub package_type: PackageType,
 }
 
 /// Version for a lockfile's package.

--- a/lockfile/src/parsers/gem.rs
+++ b/lockfile/src/parsers/gem.rs
@@ -8,6 +8,7 @@ use nom::error::{VerboseError, VerboseErrorKind};
 use nom::multi::{many1, many_till};
 use nom::sequence::{delimited, tuple};
 use nom::Err as NomErr;
+use phylum_types::types::package::PackageType;
 
 use crate::parsers::{take_till_blank_line, Result};
 use crate::{Package, PackageVersion, ThirdPartyVersion};
@@ -95,7 +96,7 @@ impl<'a> Section<'a> {
                     })
                 };
 
-                Ok(Package { name, version })
+                Ok(Package { name, version, package_type: PackageType::RubyGems })
             })
             .collect::<StdResult<_, _>>()?;
 
@@ -127,6 +128,7 @@ impl<'a> Section<'a> {
         let package = Package {
             name: specs_packages.remove(0).name,
             version: PackageVersion::Git(version_uri),
+            package_type: PackageType::RubyGems,
         };
 
         Ok((input, vec![package]))
@@ -155,6 +157,7 @@ impl<'a> Section<'a> {
         let package = Package {
             name: specs_packages.remove(0).name,
             version: PackageVersion::Path(Some(path.into())),
+            package_type: PackageType::RubyGems,
         };
 
         Ok((input, vec![package]))

--- a/lockfile/src/parsers/go_sum.rs
+++ b/lockfile/src/parsers/go_sum.rs
@@ -4,6 +4,7 @@ use nom::character::complete::{alphanumeric1, line_ending, space0, space1};
 use nom::combinator::{opt, recognize};
 use nom::multi::many1;
 use nom::sequence::{preceded, tuple};
+use phylum_types::types::package::PackageType;
 
 use super::Result;
 use crate::{Package, PackageVersion};
@@ -27,6 +28,7 @@ fn package(input: &str) -> Result<&str, Package> {
     let package = Package {
         name: name.to_string(),
         version: PackageVersion::FirstParty(version.to_string()),
+        package_type: PackageType::Golang,
     };
 
     Ok((input, package))

--- a/lockfile/src/parsers/gradle_dep.rs
+++ b/lockfile/src/parsers/gradle_dep.rs
@@ -4,6 +4,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till};
 use nom::combinator::eof;
 use nom::error::VerboseError;
+use phylum_types::types::package::PackageType;
 
 use crate::parsers::Result;
 use crate::{Package, PackageVersion};
@@ -39,5 +40,6 @@ fn package(input: &str) -> StdResult<Package, nom::Err<VerboseError<&str>>> {
     Ok(Package {
         name: format!("{group_id}:{artifact_id}"),
         version: PackageVersion::FirstParty(version.to_string()),
+        package_type: PackageType::Maven,
     })
 }

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -8,6 +8,7 @@ use nom::error::{VerboseError, VerboseErrorKind};
 use nom::multi::{many0, many1, separated_list0};
 use nom::sequence::{delimited, pair, terminated};
 use nom::Err as NomErr;
+use phylum_types::types::package::PackageType;
 
 use crate::parsers::Result;
 use crate::{Package, PackageVersion};
@@ -49,7 +50,7 @@ fn package(input: &str) -> Result<&str, Package> {
             PackageVersion::DownloadUrl(uri_version.into())
         };
 
-        return Ok((input, Package { name, version }));
+        return Ok((input, Package { name, version, package_type: PackageType::PyPi }));
     }
 
     // Parse first-party dependencies.
@@ -59,7 +60,7 @@ fn package(input: &str) -> Result<&str, Package> {
     // Ensure line is empty after the dependency.
     line_done(input)?;
 
-    Ok((input, Package { name, version }))
+    Ok((input, Package { name, version, package_type: PackageType::PyPi }))
 }
 
 /// Recognize local package overrides like `-e /tmp/editable`.
@@ -105,7 +106,7 @@ fn editable(input: &str) -> Result<&str, Package> {
     // Ensure line is empty after the dependency.
     line_done(input)?;
 
-    Ok((input, Package { name, version }))
+    Ok((input, Package { name, version, package_type: PackageType::PyPi }))
 }
 
 /// Find URI dependencies.

--- a/lockfile/src/parsers/yarn.rs
+++ b/lockfile/src/parsers/yarn.rs
@@ -1,3 +1,5 @@
+use phylum_types::types::package::PackageType;
+
 use super::*;
 use crate::{Package, PackageVersion};
 
@@ -26,6 +28,7 @@ fn parse_entry(input: &str) -> Result<&str, Package> {
         (next_input, Package {
             name: name.to_string(),
             version: PackageVersion::FirstParty(version.to_string()),
+            package_type: PackageType::Npm,
         })
     })
 }

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -25,10 +25,6 @@ impl Parse for PyRequirements {
         Ok(entries)
     }
 
-    fn package_type(&self) -> PackageType {
-        PackageType::PyPi
-    }
-
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("requirements.txt"))
     }
@@ -68,13 +64,9 @@ impl Parse for PipFile {
                     }
                 };
 
-                Ok(Package { name, version })
+                Ok(Package { name, version, package_type: PackageType::PyPi })
             })
             .collect()
-    }
-
-    fn package_type(&self) -> PackageType {
-        PackageType::PyPi
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
@@ -118,10 +110,6 @@ impl Parse for Poetry {
         lock.packages.drain(..).map(Package::try_from).collect()
     }
 
-    fn package_type(&self) -> PackageType {
-        PackageType::PyPi
-    }
-
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("poetry.lock"))
     }
@@ -151,6 +139,7 @@ impl TryFrom<PoetryPackage> for Package {
                 return Ok(Self {
                     name: package.name,
                     version: PackageVersion::FirstParty(package.version),
+                    package_type: PackageType::PyPi,
                 });
             },
         };
@@ -177,7 +166,7 @@ impl TryFrom<PoetryPackage> for Package {
             source_type => return Err(anyhow!("Unknown package source_type: {source_type:?}")),
         };
 
-        Ok(Self { name: package.name, version })
+        Ok(Self { name: package.name, version, package_type: PackageType::PyPi })
     }
 }
 
@@ -210,38 +199,47 @@ mod tests {
             Package {
                 name: "flask".into(),
                 version: PackageVersion::FirstParty("2.2.2".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "requests".into(),
                 version: PackageVersion::FirstParty("2.28.1".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "werkzeug".into(),
                 version: PackageVersion::FirstParty("2.9.2".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "attr".into(),
                 version: PackageVersion::Path(Some("file:///tmp/attr".into())),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "numpy".into(),
                 version: PackageVersion::Path(Some("file:///tmp/testing/numpy-1.23.5-pp38-pypy38_pp73-win_amd64.whl".into())),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "git-for-pip-example".into(),
                 version: PackageVersion::Git("git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "tomli".into(),
                 version: PackageVersion::DownloadUrl("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "phylum".into(),
                 version: PackageVersion::Git("git+ssh://git@github.com/phylum-dev/phylum-ci.git#7d6d859ad368d1ab0a933f24679e3d3c08a40eac".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "editable".into(),
                 version: PackageVersion::Path(Some("/tmp/editable".into())),
+                package_type: PackageType::PyPi,
             },
         ];
 
@@ -276,25 +274,37 @@ mod tests {
         assert_eq!(pkgs.len(), 30);
 
         let expected_pkgs = [
-            Package { name: "jdcal".into(), version: PackageVersion::FirstParty("1.3".into()) },
+            Package {
+                name: "jdcal".into(),
+                version: PackageVersion::FirstParty("1.3".into()),
+                package_type: PackageType::PyPi,
+            },
             Package {
                 name: "certifi".into(),
                 version: PackageVersion::FirstParty("2017.7.27.1".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "unittest2".into(),
                 version: PackageVersion::FirstParty("1.1.0".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "django".into(),
                 version: PackageVersion::Git("https://github.com/django/django.git#1.11.4".into()),
+                package_type: PackageType::PyPi,
             },
-            Package { name: "e1839a8".into(), version: PackageVersion::Path(Some(".".into())) },
+            Package {
+                name: "e1839a8".into(),
+                version: PackageVersion::Path(Some(".".into())),
+                package_type: PackageType::PyPi,
+            },
             Package {
                 name: "e682b37".into(),
                 version: PackageVersion::DownloadUrl(
                     "https://github.com/divio/django-cms/archive/release/3.4.x.zip".into(),
                 ),
+                package_type: PackageType::PyPi,
             },
         ];
 
@@ -312,14 +322,17 @@ mod tests {
             Package {
                 name: "cachecontrol".into(),
                 version: PackageVersion::FirstParty("0.12.10".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "flask".into(),
                 version: PackageVersion::FirstParty("2.1.1".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "poetry".into(),
                 version: PackageVersion::Git("https://github.com/python-poetry/poetry.git#4bc181b06ff9780791bc9e3d5b11bb807ca29d70".into()),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "autopep8".into(),
@@ -327,18 +340,22 @@ mod tests {
                     registry: "https://example.com/api/pypi/python/simple".into(),
                     version: "1.5.6".into(),
                 }),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "directory-test".into(),
                 version: PackageVersion::Path(Some("directory_test".into())),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "requests".into(),
                 version: PackageVersion::Path(Some("requests/requests-2.27.1-py2.py3-none-any.whl".into())),
+                package_type: PackageType::PyPi,
             },
             Package {
                 name: "toml".into(),
                 version: PackageVersion::DownloadUrl("https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz".into()),
+                package_type: PackageType::PyPi,
             },
         ];
 
@@ -356,9 +373,18 @@ mod tests {
             Package {
                 name: "certifi".into(),
                 version: PackageVersion::FirstParty("2020.12.5".into()),
+                package_type: PackageType::PyPi,
             },
-            Package { name: "pywin32".into(), version: PackageVersion::FirstParty("227".into()) },
-            Package { name: "docker".into(), version: PackageVersion::FirstParty("4.3.1".into()) },
+            Package {
+                name: "pywin32".into(),
+                version: PackageVersion::FirstParty("227".into()),
+                package_type: PackageType::PyPi,
+            },
+            Package {
+                name: "docker".into(),
+                version: PackageVersion::FirstParty("4.3.1".into()),
+                package_type: PackageType::PyPi,
+            },
         ];
 
         for expected_pkg in expected_pkgs {

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use anyhow::{anyhow, Context};
 use nom::error::convert_error;
 use nom::Finish;
-use phylum_types::types::package::PackageType;
 
 use super::parsers::gem;
 use crate::{Package, Parse};
@@ -21,10 +20,6 @@ impl Parse for GemLock {
         Ok(entries)
     }
 
-    fn package_type(&self) -> PackageType {
-        PackageType::RubyGems
-    }
-
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Gemfile.lock"))
     }
@@ -32,6 +27,8 @@ impl Parse for GemLock {
 
 #[cfg(test)]
 mod tests {
+    use phylum_types::types::package::PackageType;
+
     use super::*;
     use crate::{PackageVersion, ThirdPartyVersion};
 
@@ -44,22 +41,27 @@ mod tests {
             Package {
                 name: "yaml".into(),
                 version: PackageVersion::Git("git@github.com:ruby/yaml.git#b89ff5a79c2abbf81612ffe9a6c184db347365c9".into()),
+                package_type: PackageType::RubyGems,
             },
             Package {
                 name: "main".into(),
                 version: PackageVersion::Git("https://gist.github.com/cd-work/bb850193cd4d1eff0d7021c9a3899882.git#24b38dc61f9e2ee241e1f5eba4fdba4b5ed1e737".into()),
+                package_type: PackageType::RubyGems,
             },
             Package {
                 name: "benchmark".into(),
                 version: PackageVersion::Git("https://github.com/ruby/benchmark.git#303ac8f28b9aad6abe95c86bc64ea891f77ac93e".into()),
+                package_type: PackageType::RubyGems,
             },
             Package {
                 name: "csv".into(),
                 version: PackageVersion::Path(Some("/tmp/csv".into())),
+                package_type: PackageType::RubyGems,
             },
             Package {
                 name: "wirble".into(),
                 version: PackageVersion::FirstParty("0.1.3".into()),
+                package_type: PackageType::RubyGems,
             },
             Package {
                 name: "rspec-mocks".into(),
@@ -67,6 +69,7 @@ mod tests {
                     registry: "http://rubygems.org/".into(),
                     version: "3.11.2".into(),
                 }),
+                package_type: PackageType::RubyGems,
             },
         ];
 


### PR DESCRIPTION
The `Parse` trait in the `lockfile` crate previously required a `package_type()` function that specified the package type for all packages returned by that parser. Going forward, we want to support lockfiles that contains multiple package types (e.g., SBOM).

This patch moves the `package_type` into the `Package` struct returned by the parser in order to support these future parsers.