### PR TITLE
Use remote URI for extension API

### DIFF
--- a/cli/src/commands/extensions/mod.rs
+++ b/cli/src/commands/extensions/mod.rs
@@ -26,7 +26,7 @@ pub mod permissions;
 pub mod state;
 
 const EXTENSION_SKELETON: &[u8] = b"\
-import { PhylumApi } from 'phylum';
+import { PhylumApi } from 'https://deno.phylum.io/phylum.ts';
 
 console.log('Hello, World!');
 ";

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -160,7 +160,7 @@ impl<'a> TestExtension<'a> {
         let main = extension_path.join("main.ts");
         fs::write(
             main,
-            format!("import {{ PhylumApi, ApiVersion }} from 'phylum';\n{code}").as_bytes(),
+            format!("import {{ PhylumApi, ApiVersion }} from 'https://deno.phylum.io/phylum.ts';\n{code}").as_bytes(),
         )
         .unwrap();
 

--- a/cli/tests/extensions/module_loader.rs
+++ b/cli/tests/extensions/module_loader.rs
@@ -45,20 +45,16 @@ fn module_with_traversal_fails_to_load() {
         .stderr(predicate::str::contains("importing from paths outside"));
 }
 
-// The fixture for this test attempts to load a module from a non-`deno.land`
-// URL.
+// Ensure our built-in module can be resolved.
 #[test]
-fn module_with_non_allowed_url_fails_to_load() {
+fn phylum_module_works() {
     let test_cli = TestCli::builder().build();
 
     test_cli
-        .install_extension(&fixtures_path().join("module-import").join("fail-remote"))
+        .install_extension(&fixtures_path().join("module-import").join("phylum-module"))
         .success();
 
-    test_cli
-        .run(&["module-import-fail-remote"])
-        .failure()
-        .stderr(predicate::str::contains("importing from domains other than"));
+    test_cli.run(&["phylum-module"]).success().stdout("v0\n");
 }
 
 // A symlink is directly created during the test, as no symlinks are committed

--- a/cli/tests/fixtures/extensions/api/main.ts
+++ b/cli/tests/fixtures/extensions/api/main.ts
@@ -1,4 +1,4 @@
-import { PhylumApi } from "phylum";
+import { PhylumApi, ApiVersion } from "https://deno.phylum.io/phylum.ts";
 
 const lockfile = await PhylumApi.parseLockfile("../tests/fixtures/poetry.lock", "poetry");
 console.log(lockfile.packages.length);

--- a/cli/tests/fixtures/extensions/module-import/fail-remote/PhylumExt.toml
+++ b/cli/tests/fixtures/extensions/module-import/fail-remote/PhylumExt.toml
@@ -1,3 +1,0 @@
-name = "module-import-fail-remote"
-description = "Test: fail to load unsupported remote URL"
-entry_point = "main.ts"

--- a/cli/tests/fixtures/extensions/module-import/fail-remote/main.ts
+++ b/cli/tests/fixtures/extensions/module-import/fail-remote/main.ts
@@ -1,3 +1,0 @@
-import * as jQuery from "https://code.jquery.com/jquery-3.6.0.slim.min.js"
-
-console.log(jQuery)

--- a/cli/tests/fixtures/extensions/module-import/phylum-module/PhylumExt.toml
+++ b/cli/tests/fixtures/extensions/module-import/phylum-module/PhylumExt.toml
@@ -1,0 +1,3 @@
+name = "phylum-module"
+description = "Test: successfully load Phylum's extension module"
+entry_point = "main.ts"

--- a/cli/tests/fixtures/extensions/module-import/phylum-module/main.ts
+++ b/cli/tests/fixtures/extensions/module-import/phylum-module/main.ts
@@ -1,0 +1,3 @@
+import { ApiVersion } from "https://deno.phylum.io/phylum.ts";
+
+console.log(ApiVersion.V0);

--- a/cli/tests/fixtures/extensions/permissions/correct-run-perms/main.ts
+++ b/cli/tests/fixtures/extensions/permissions/correct-run-perms/main.ts
@@ -1,4 +1,4 @@
-import { PhylumApi } from 'phylum';
+import { PhylumApi } from 'https://deno.phylum.io/phylum.ts';
 
 let cmd = PhylumApi.runSandboxed({
   cmd: 'echo',

--- a/docs/extensions/extension_example.md
+++ b/docs/extensions/extension_example.md
@@ -17,7 +17,7 @@ import { mapValues } from "https://deno.land/std@0.150.0/collections/map_values.
 import { distinct } from "https://deno.land/std@0.150.0/collections/distinct.ts";
 import { groupBy } from "https://deno.land/std@0.150.0/collections/group_by.ts";
 
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 // Ensure lockfile argument is present.
 if (Deno.args.length != 1) {
@@ -70,7 +70,7 @@ We'll go into more detail on what we need these for later.
 [deno_std]: https://deno.land/std
 
 ```ts
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 ```
 
 This is the import for the built-in Phylum API. You'll see this in most Phylum

--- a/docs/extensions/extension_rest_api.md
+++ b/docs/extensions/extension_rest_api.md
@@ -21,7 +21,7 @@ correct base URI. The following example retrieves projects owned by the user
 which do not belong to any group:
 
 ```ts
-import { PhylumApi, ApiVersion } from "phylum";
+import { PhylumApi, ApiVersion } from "https://deno.phylum.io/phylum.ts";
 
 // Create a fetch request to the `/data/projects/overview` endpoint.
 const reply = await PhylumApi.fetch(
@@ -43,7 +43,7 @@ project through the API:
 [Deno's `fetch` function]: https://deno.land/api@latest?s=fetch
 
 ```ts
-import { PhylumApi, ApiVersion } from "phylum";
+import { PhylumApi, ApiVersion } from "https://deno.phylum.io/phylum.ts";
 
 // Create a fetch request to the `/data/projects` endpoint.
 const reply = await PhylumApi.fetch(

--- a/docs/extensions/extension_sandboxing.md
+++ b/docs/extensions/extension_sandboxing.md
@@ -14,7 +14,7 @@ The following code provides an example on how you could sandbox `cat` to only
 allow access to files in the current working directory or below it:
 
 ```ts
-import { PhylumApi } from 'phylum';
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 // Ensure a file path is passed as the only argument.
 if (Deno.args.length !== 1) {

--- a/extensions/duplicates/main.ts
+++ b/extensions/duplicates/main.ts
@@ -2,7 +2,7 @@ import { mapValues } from "https://deno.land/std@0.150.0/collections/map_values.
 import { distinct } from "https://deno.land/std@0.150.0/collections/distinct.ts";
 import { groupBy } from "https://deno.land/std@0.150.0/collections/group_by.ts";
 
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 // Ensure lockfile argument is present.
 if (Deno.args.length != 1) {

--- a/extensions/find-permissions/main.ts
+++ b/extensions/find-permissions/main.ts
@@ -4,7 +4,7 @@ import {
   red,
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 // Print help.
 if (

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -3,7 +3,7 @@ import {
   red,
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 class FileBackup {
   readonly fileName: string;

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -1,4 +1,4 @@
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 import {
   green,
   red,

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -3,7 +3,7 @@ import {
   red,
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
-import { PhylumApi } from "phylum";
+import { PhylumApi } from "https://deno.phylum.io/phylum.ts";
 
 class FileBackup {
   readonly fileName: string;


### PR DESCRIPTION
This moves the extension API from a built-in module to a remote URI at https://phylum.io/phylum.ts, allowing non-phylum tools to resolve it automatically.

Since this introduced an additional remote dependency besides deno.land, it has also been taken as a chance to relax the import restrictions and allow for all remote URIs.

Closes #875.
Closes #864.