### PR TITLE
Improve sandboxed process failure message

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -34,7 +34,7 @@ use crate::api::{PhylumApiError, ResponseError};
 use crate::auth::UserInfo;
 use crate::commands::extensions::permissions::{self, Permission};
 use crate::commands::extensions::state::ExtensionState;
-use crate::commands::parse;
+use crate::commands::{parse, ExitCode};
 #[cfg(unix)]
 use crate::dirs;
 
@@ -399,7 +399,7 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
 
     // Add sandboxed command arguments.
     sandbox_args.push("--".into());
-    sandbox_args.push(cmd.into());
+    sandbox_args.push(cmd.as_str().into());
     for arg in &args {
         sandbox_args.push(arg.into());
     }
@@ -411,6 +411,11 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
         .stdout(stdout)
         .stderr(stderr)
         .output()?;
+
+    // Return explicit error when process start failed
+    if output.status.code().map_or(false, |code| code == ExitCode::SandboxStart) {
+        return Err(anyhow!("Process {cmd:?} failed to start"));
+    }
 
     Ok(ProcessOutput {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -415,7 +415,7 @@ fn run_sandboxed(op_state: Rc<RefCell<OpState>>, process: Process) -> Result<Pro
         .output()?;
 
     // Return explicit error when process start failed
-    if output.status.code().map_or(false, |code| code == ExitCode::SandboxStart) {
+    if output.status.code().map_or(false, |code| code == i32::from(&ExitCode::SandboxStart)) {
         return Err(anyhow!("Process {cmd:?} failed to start"));
     }
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -34,7 +34,9 @@ use crate::api::{PhylumApiError, ResponseError};
 use crate::auth::UserInfo;
 use crate::commands::extensions::permissions::{self, Permission};
 use crate::commands::extensions::state::ExtensionState;
-use crate::commands::{parse, ExitCode};
+use crate::commands::parse;
+#[cfg(unix)]
+use crate::commands::ExitCode;
 #[cfg(unix)]
 use crate::dirs;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -46,6 +46,8 @@ pub enum ExitCode {
     JsError,
     FailedThresholds,
     ConfirmationFailed,
+    SandboxStart,
+    SandboxStartCollision,
     Custom(i32),
 }
 
@@ -70,7 +72,21 @@ impl From<&ExitCode> for i32 {
             ExitCode::JsError => 16,
             ExitCode::ConfirmationFailed => 17,
             ExitCode::FailedThresholds => 100,
+            ExitCode::SandboxStart => 117,
+            ExitCode::SandboxStartCollision => 118,
             ExitCode::Custom(code) => *code,
         }
+    }
+}
+
+impl PartialEq<i32> for ExitCode {
+    fn eq(&self, code: &i32) -> bool {
+        i32::from(self).eq(code)
+    }
+}
+
+impl PartialEq<ExitCode> for i32 {
+    fn eq(&self, code: &ExitCode) -> bool {
+        self.eq(&i32::from(code))
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -78,15 +78,3 @@ impl From<&ExitCode> for i32 {
         }
     }
 }
-
-impl PartialEq<i32> for ExitCode {
-    fn eq(&self, code: &i32) -> bool {
-        i32::from(self).eq(code)
-    }
-}
-
-impl PartialEq<ExitCode> for i32 {
-    fn eq(&self, code: &ExitCode) -> bool {
-        self.eq(&i32::from(code))
-    }
-}

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -18,9 +18,21 @@ pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
     // Start subprocess.
     let cmd = matches.get_one::<String>("cmd").unwrap();
     let args: Vec<&String> = matches.get_many("args").unwrap_or_default().collect();
-    let status = Command::new(cmd).args(args).status()?;
+    let status = match Command::new(cmd).args(args).status() {
+        Ok(status) => status,
+        Err(err) => {
+            eprintln!("Process {cmd:?} failed to start: {err}");
+            return Ok(CommandValue::Code(ExitCode::SandboxStart));
+        },
+    };
 
-    if let Some(code) = status.code() {
+    if let Some(mut code) = status.code() {
+        // Remap exit code if it matches our sandbox start failure indicator, to ensure
+        // we can detect the failure reliably.
+        if code == ExitCode::SandboxStart {
+            code = i32::from(&ExitCode::SandboxStartCollision);
+        }
+
         Ok(CommandValue::Code(ExitCode::Custom(code)))
     } else if let Some(signal) = status.signal() {
         Err(anyhow!("Sandbox process failed with signal {signal}"))

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -29,7 +29,7 @@ pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
     if let Some(mut code) = status.code() {
         // Remap exit code if it matches our sandbox start failure indicator, to ensure
         // we can detect the failure reliably.
-        if code == ExitCode::SandboxStart {
+        if code == i32::from(&ExitCode::SandboxStart) {
             code = i32::from(&ExitCode::SandboxStartCollision);
         }
 

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -257,11 +257,15 @@ fn net_sandboxing_fail() {
     #[rustfmt::skip]
     test_cli
         .extension("
-            const output = PhylumApi.runSandboxed({
-                cmd: 'curl',
-                args: ['http://phylum.io'],
-            });
-            Deno.exit(output.code);
+            try {
+                const output = PhylumApi.runSandboxed({
+                    cmd: 'curl',
+                    args: ['http://phylum.io'],
+                });
+                Deno.exit(output.code);
+            } catch (e) {
+                Deno.exit(111);
+            }
         ")
         .build()
         .run()
@@ -309,11 +313,15 @@ fn fs_sandboxing_fail() {
 
     #[rustfmt::skip]
     let js = format!("
-        const output = PhylumApi.runSandboxed({{
-            cmd: 'cat',
-            args: ['{}'],
-        }});
-        Deno.exit(output.code);
+        try {{
+            const output = PhylumApi.runSandboxed({{
+                cmd: 'cat',
+                args: ['{}'],
+            }});
+            Deno.exit(output.code);
+        }} catch (e) {{
+            Deno.exit(111);
+        }}
     ", file.path().to_string_lossy());
 
     test_cli.extension(&js).build().run().failure();


### PR DESCRIPTION
This provides a little improvement over the traditional "No such file or directory (os error 2)" error that is usually printed when the process specified in `PhylumApi.runSandboxed` does not exist.

Before:

```
❗ Error: No such file or directory (os error 2)
```

After:

```
Process "poetry" failed to start: No such file or directory (os error 2)
Extension error: Uncaught (in promise) Error: Process "poetry" failed to start
        return Deno.core.ops.run_sandboxed(process);
                             ^
    at Function.runSandboxed (https://deno.phylum.io/phylum.ts:353:30)
    at poetryCheckDryRun (file:///home/chris/programming/phylum/cli/extensions/poetry/main.ts:91:30)
    at file:///home/chris/programming/phylum/cli/extensions/poetry/main.ts:79:7
```

Note that the first line in the "After" output will only be printed when STDOUT is not redirected.

Some extensions also always run `Deno.run` before
`PhylumApi.runSandboxed` with the same command. This will still print the old error since it is generated by Deno directly.

Closes #781.