### PR TITLE
lockfile paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "phylum_types",
  "serde",
  "serde_yaml",
+ "tempfile",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "phylum_types",
  "serde",
  "serde_yaml",
+ "uuid",
 ]
 
 [[package]]

--- a/phylum_project/Cargo.toml
+++ b/phylum_project/Cargo.toml
@@ -14,3 +14,6 @@ chrono = { version = "^0.4", default-features = false, features = ["serde", "clo
 serde = { version = "1.0.144", features = ["derive"] }
 serde_yaml = "0.9.2"
 log = "0.4.6"
+
+[dev-dependencies]
+uuid = "1.3.0"

--- a/phylum_project/Cargo.toml
+++ b/phylum_project/Cargo.toml
@@ -16,4 +16,5 @@ serde_yaml = "0.9.2"
 log = "0.4.6"
 
 [dev-dependencies]
+tempfile = "3.4.0"
 uuid = "1.3.0"

--- a/phylum_project/src/lib.rs
+++ b/phylum_project/src/lib.rs
@@ -99,14 +99,11 @@ pub fn find_project_conf(
     let mut path = starting_directory.as_ref().canonicalize().ok()?;
 
     for _ in 0..max_depth {
-        path.push(PROJ_CONF_FILE);
-        if path.is_file() {
-            return Some(path);
+        let conf_path = path.join(PROJ_CONF_FILE);
+        if conf_path.is_file() {
+            return Some(conf_path);
         }
 
-        // Remove conf file.
-        path.pop();
-        // Remove last directory component.
         if !path.pop() {
             return None;
         }


### PR DESCRIPTION
This PR fixes a couple issues I noticed while looking at the `phylum_project` crate.

1. `ProjectConfig::lockfiles()` returns different paths before and after the first serialization. This shouldn't be a problem for CLI because I doubt the configuration is ever used this way without first being serialized and whether or not the path starts with an extra `"./"` is not normally a problem when operating on real filesystems, so I doubt it's causing any problems today. I removed the extra `"./"`.
2. `get_current_project()` calls `find_project_conf(".", true)` and then `find_project_conf` uses `Path::parent()` to navigate to parent directories. `Path::parent()` gets the parent path, not the parent directory, because it operates only on the textual representation of the path without hitting the filesystem. The parent of `"."` is not `".."` so whether you pass `true` or not for the second parameter to `find_project_conf` doesn't matter. I changed `get_current_project()` to canonicalize paths. Alternatively, we could convert to an absolute path, but the behavior would be different wrt symlinks etc (eg the test I've written would not work).

Closes #973

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
