### PR TITLE
update phylum_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#6a51c1c5b695e644fce0af6497974db53b6afdd2"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#18fc152f46caf93a90122d8aec4de23cff4f45b0"
 dependencies = [
  "chrono",
  "schemars",

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -300,10 +300,11 @@ impl PhylumApi {
         label: Option<String>,
         group_name: Option<String>,
     ) -> Result<JobId> {
+        #[allow(deprecated)]
         let req = SubmitPackageRequest {
             // This package_type is ignored by the API, but it still validates it, so we have to put
             // something here.
-            package_type: PackageType::Npm,
+            package_type: Some(PackageType::Npm),
             packages: package_list.to_vec(),
             is_user: true,
             project,

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -116,6 +116,10 @@ impl Format for Vec<JobDescriptor> {
                 state = format!("{}", style("FAIL").red());
             }
 
+            let mut ecosystems = job.ecosystems.clone();
+            ecosystems.sort_unstable();
+            let ecosystems = job.ecosystems.join(",");
+
             let first_line = format!(
                 "{}",
                 format_args!(
@@ -132,7 +136,7 @@ impl Format for Vec<JobDescriptor> {
             let second_line = format!("             {}\n", job.msg);
             let third_line = format!(
                 "             {}{:>62}{:>29} dependencies",
-                job.ecosystem, "Crit:-/High:-/Med:-/Low:-", job.num_dependencies
+                ecosystems, "Crit:-/High:-/Med:-/Low:-", job.num_dependencies
             );
             jobs.push_str(first_line.as_str());
             jobs.push_str(second_line.as_str());


### PR DESCRIPTION
This PR updates phylum_types (phylum-dev/phylum-types#65) in preparation for removing the old single-ecosystem fields.

The deprecated field is still sent when making requests because the prod API still expects it to be there.

If a job in the history list has multiple ecosystems, they are displayed as a comma separated list. Previously, only a single ecosystem was being displayed.

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
