### PR TITLE
Use recursive lockfile search for `phylum init`

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,7 +1,7 @@
 //! Subcommand `phylum init`.
 
 use std::path::Path;
-use std::{env, fs, io, iter};
+use std::{env, io, iter};
 
 use anyhow::Context;
 use clap::parser::ValuesRef;
@@ -189,13 +189,10 @@ fn prompt_lockfiles(
 /// Ask for the lockfile names.
 fn prompt_lockfile_names() -> io::Result<Vec<String>> {
     // Find all known lockfiles in the currenty directory.
-    let mut lockfiles: Vec<_> = fs::read_dir("./")?
-        .flatten()
-        .filter(|entry| {
-            LockfileFormat::iter().any(|format| format.parser().is_path_lockfile(&entry.path()))
-        })
-        .flat_map(|entry| entry.file_name().to_str().map(str::to_owned))
-        .collect();
+    let mut lockfiles = config::find_lockfiles(".")
+        .iter()
+        .flat_map(|lockfile| Some(lockfile.path.to_str()?.to_owned()))
+        .collect::<Vec<_>>();
 
     // Prompt for selection if any lockfile was found.
     let prompt_lockfiles = !lockfiles.is_empty();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -196,12 +196,7 @@ pub fn lockfiles(
             let project_lockfiles = project.map(|project| project.lockfiles());
 
             // Fallback to walking the directory.
-            let lockfiles = project_lockfiles.unwrap_or_else(|| {
-                phylum_lockfile::find_lockfiles()
-                    .drain(..)
-                    .map(|(path, format)| LockfileConfig::new(path, format.to_string()))
-                    .collect()
-            });
+            let lockfiles = project_lockfiles.unwrap_or_else(|| find_lockfiles("."));
 
             // Ask for explicit lockfile if none were found.
             if lockfiles.is_empty() {
@@ -211,6 +206,14 @@ pub fn lockfiles(
             Ok(lockfiles)
         },
     }
+}
+
+/// Find lockfiles at or below the specified directory.
+pub fn find_lockfiles(directory: impl AsRef<Path>) -> Vec<LockfileConfig> {
+    phylum_lockfile::find_lockfiles_at(directory)
+        .drain(..)
+        .map(|(path, format)| LockfileConfig::new(path, format.to_string()))
+        .collect()
 }
 
 pub fn get_home_settings_path() -> Result<PathBuf> {

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -193,7 +193,16 @@ pub fn get_path_format<P: AsRef<Path>>(path: P) -> Option<LockfileFormat> {
 ///
 /// Paths excluded by gitignore are automatically ignored.
 pub fn find_lockfiles() -> Vec<(PathBuf, LockfileFormat)> {
-    let walker = WalkBuilder::new(".").max_depth(Some(MAX_LOCKFILE_DEPTH)).build();
+    find_lockfiles_at(".")
+}
+
+/// Find lockfiles at or below the specified root directory.
+///
+/// Walks the directory tree and returns all paths recognized as lockfiles.
+///
+/// Paths excluded by gitignore are automatically ignored.
+pub fn find_lockfiles_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileFormat)> {
+    let walker = WalkBuilder::new(root).max_depth(Some(MAX_LOCKFILE_DEPTH)).build();
     walker
         .into_iter()
         .flatten()


### PR DESCRIPTION
This uses the existing logic in the lockfiles crate to search for lockfiles when running `phylum init` without providing the lockfiles. This ensures consistency between the recursive lockfile search used without project and the project creation.
