### PR TITLE
Fix `phylum project link` overwriting project file

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -56,7 +56,7 @@ pub async fn handle_init(api: &PhylumApi, matches: &ArgMatches) -> CommandResult
             let uuid = project::lookup_project(api, &project, group.as_deref())
                 .await
                 .context(format!("Could not find project {project:?}"))?;
-            ProjectConfig::new(uuid, project.into(), group)
+            ProjectConfig::new(uuid, project, group)
         },
         project_config => project_config.context("Unable to create project")?,
     };

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -215,7 +215,7 @@ pub async fn lookup_project(
     group: Option<&str>,
 ) -> StdResult<ProjectId, PhylumApiError> {
     let uuid = api
-        .get_project_id(project, group.as_deref())
+        .get_project_id(project, group)
         .await
         .context("A project with that name does not exist")?;
     Ok(uuid)

--- a/phylum_project/src/lib.rs
+++ b/phylum_project/src/lib.rs
@@ -67,6 +67,13 @@ impl ProjectConfig {
         Vec::new()
     }
 
+    /// Update the config's project.
+    pub fn update_project(&mut self, project_id: ProjectId, name: String, group: Option<String>) {
+        self.id = project_id;
+        self.name = name;
+        self.group_name = group;
+    }
+
     /// Update the project's lockfiles.
     pub fn set_lockfiles(&mut self, lockfiles: Vec<LockfileConfig>) {
         self.lockfiles = lockfiles;


### PR DESCRIPTION
Resolve an issue where `phylum project link <PROJECT>` would create a new config file, discarding all information stored in the `.phylum_project` file beyond the project information (i.e. lockfile data).

To ensure all auxiliary information is kept, the existing project is loaded when available and only the project-specific keys are overwritten.

Closes #994.