### PR TITLE
Make `phylum package` type argument mandatory

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -182,7 +182,8 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('t')
                     .long("package-type")
                     .value_name("type")
-                    .help(r#"The type of the package ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#),
+                    .help(r#"The type of the package ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#)
+                    .required(true),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)
                     .short('j')

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -173,16 +173,21 @@ pub fn add_subcommands(command: Command) -> Command {
         )
         .subcommand(
             Command::new("package").about("Retrieve the details of a specific package").args(&[
-                Arg::new("name").value_name("name").help("The name of the package.").required(true),
+                Arg::new("package-type")
+                    .index(1)
+                    .value_name("type")
+                    .help("Package ecosystem type")
+                    .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo"])
+                    .required(true),
+                Arg::new("name")
+                    .index(2)
+                    .value_name("name")
+                    .help("The name of the package.")
+                    .required(true),
                 Arg::new("version")
+                    .index(3)
                     .value_name("version")
                     .help("The version of the package.")
-                    .required(true),
-                Arg::new("package-type")
-                    .short('t')
-                    .long("package-type")
-                    .value_name("type")
-                    .help(r#"The type of the package ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#)
                     .required(true),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)

--- a/cli/src/commands/packages.rs
+++ b/cli/src/commands/packages.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use clap::ArgMatches;
-use phylum_types::types::package::{PackageSpecifier, PackageSubmitResponse, PackageType};
+use phylum_types::types::package::{PackageSpecifier, PackageSubmitResponse};
 use reqwest::StatusCode;
 
 use crate::api::PhylumApi;
@@ -11,17 +11,11 @@ use crate::filter::{Filter, FilterIssues};
 use crate::format::Format;
 use crate::print_user_warning;
 
-fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<PackageSpecifier> {
+fn parse_package(matches: &ArgMatches) -> Result<PackageSpecifier> {
     // Read required options.
     let name = matches.get_one::<String>("name").unwrap().to_string();
     let version = matches.get_one::<String>("version").unwrap().to_string();
-
-    // If a package type was provided on the command line, prefer that
-    // to the global setting
-    let registry = match matches.get_one::<String>("package-type") {
-        Some(package_type) => package_type.clone(),
-        None => request_type.to_string(),
-    };
+    let registry = matches.get_one::<String>("package-type").unwrap().to_string();
 
     Ok(PackageSpecifier { name, version, registry })
 }
@@ -30,7 +24,7 @@ fn parse_package(matches: &ArgMatches, request_type: PackageType) -> Result<Pack
 pub async fn handle_get_package(api: &mut PhylumApi, matches: &clap::ArgMatches) -> CommandResult {
     let pretty_print = !matches.get_flag("json");
 
-    let pkg = parse_package(matches, api.config().request_type)?;
+    let pkg = parse_package(matches)?;
     let resp = match api.submit_package(&pkg).await {
         Ok(resp) => resp,
         Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => {

--- a/docs/command_line_tool/phylum_package.md
+++ b/docs/command_line_tool/phylum_package.md
@@ -7,7 +7,7 @@ hidden: false
 Retrieve the details of a specific package
 
 ```sh
-Usage: phylum package [OPTIONS] <name> <version>
+Usage: phylum package [OPTIONS] --package-type <type> <name> <version>
 ```
 
 ### Arguments

--- a/docs/command_line_tool/phylum_package.md
+++ b/docs/command_line_tool/phylum_package.md
@@ -7,10 +7,14 @@ hidden: false
 Retrieve the details of a specific package
 
 ```sh
-Usage: phylum package [OPTIONS] --package-type <type> <name> <version>
+Usage: phylum package [OPTIONS] <type> <name> <version>
 ```
 
 ### Arguments
+
+<type>
+&emsp; Package ecosystem type
+&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
 
 <name>
 &emsp; The name of the package.
@@ -19,9 +23,6 @@ Usage: phylum package [OPTIONS] --package-type <type> <name> <version>
 &emsp; The version of the package.
 
 ### Options
-
--t, --package-type <type>
-&emsp; The type of the package ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")
 
 -j, --json
 &emsp; Produce output in json format (default: false)


### PR DESCRIPTION
Previously with the `--package-type` missing, the global configuration file's request type would be used instead. Realistically this would mean that `npm` was always used as a fallback without an ecosystem specified.

To ensure users don't get incorrect results when requesting non-npm packages, the package type option is now mandatory.

Closes #996.