### PR TITLE
Remove request type from global config

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -292,7 +292,8 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("type")
                         .value_name("type")
-                        .help(r#"Package type ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#),
+                        .help(r#"Package type ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#)
+                        .required(true),
                     Arg::new("label")
                         .short('l')
                         .long("label")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -292,7 +292,8 @@ pub fn add_subcommands(command: Command) -> Command {
                         .short('t')
                         .long("type")
                         .value_name("type")
-                        .help(r#"Package type ("npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo")"#)
+                        .help("Package ecosystem type")
+                        .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo"])
                         .required(true),
                     Arg::new("label")
                         .short('l')

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -75,9 +75,7 @@ pub fn add_subcommands(command: Command) -> Command {
     let mut app = command
         .subcommand(
             Command::new("history").about("Return information about historical jobs").args(&[
-                Arg::new("JOB_ID")
-                    .value_name("JOB_ID")
-                    .help("The job id to query"),
+                Arg::new("JOB_ID").value_name("JOB_ID").help("The job id to query"),
                 Arg::new("json")
                     .action(ArgAction::SetTrue)
                     .short('j')
@@ -153,7 +151,7 @@ pub fn add_subcommands(command: Command) -> Command {
                             .value_name("group_name")
                             .help("Group owning the project"),
                     ]),
-                )
+                ),
         )
         .subcommand(
             Command::new("package").about("Retrieve the details of a specific package").args(&[
@@ -178,7 +176,11 @@ pub fn add_subcommands(command: Command) -> Command {
                     .short('j')
                     .long("json")
                     .help("Produce output in json format (default: false)"),
-                Arg::new("filter").short('f').long("filter").value_name("filter").help(FILTER_ABOUT),
+                Arg::new("filter")
+                    .short('f')
+                    .long("filter")
+                    .value_name("filter")
+                    .help(FILTER_ABOUT),
             ]),
         )
         .subcommand(
@@ -199,11 +201,12 @@ pub fn add_subcommands(command: Command) -> Command {
                 .subcommand(
                     Command::new("status").about("Return the current authentication status"),
                 )
-                .subcommand(Command::new("set-token").about("Set the current authentication token").arg(
-                    Arg::new("token")
-                        .action(ArgAction::Set)
-                        .required(false)
-                        .help("Authentication token to store (read from stdin if omitted)")
+                .subcommand(
+                    Command::new("set-token").about("Set the current authentication token").arg(
+                        Arg::new("token")
+                            .action(ArgAction::Set)
+                            .required(false)
+                            .help("Authentication token to store (read from stdin if omitted)"),
                     ),
                 )
                 .subcommand(
@@ -218,9 +221,8 @@ pub fn add_subcommands(command: Command) -> Command {
         )
         .subcommand(Command::new("ping").about("Ping the remote system to verify it is available"))
         .subcommand(
-            Command::new("parse")
-                .about("Parse lock files and output their packages as JSON")
-                .args(&[
+            Command::new("parse").about("Parse lock files and output their packages as JSON").args(
+                &[
                     Arg::new("lockfile")
                         .value_name("LOCKFILE")
                         .value_hint(ValueHint::FilePath)
@@ -233,7 +235,8 @@ pub fn add_subcommands(command: Command) -> Command {
                         .requires("lockfile")
                         .help("Lock file type used for all lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
-                ]),
+                ],
+            ),
         )
         .subcommand(
             Command::new("analyze")
@@ -293,12 +296,11 @@ pub fn add_subcommands(command: Command) -> Command {
                         .long("type")
                         .value_name("type")
                         .help("Package ecosystem type")
-                        .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo"])
+                        .value_parser([
+                            "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
+                        ])
                         .required(true),
-                    Arg::new("label")
-                        .short('l')
-                        .long("label")
-                        .help("Label to use for analysis"),
+                    Arg::new("label").short('l').long("label").help("Label to use for analysis"),
                     Arg::new("project")
                         .short('p')
                         .long("project")
@@ -345,98 +347,92 @@ pub fn add_subcommands(command: Command) -> Command {
                 )
                 .subcommand(
                     Command::new("member")
-                    .about("Manage group members")
-                    .args(&[
-                        Arg::new("group")
+                        .about("Manage group members")
+                        .args(&[Arg::new("group")
                             .short('g')
                             .long("group")
                             .value_name("GROUP")
                             .help("Group to list the members for")
-                            .required(true),
-                    ])
-                    .subcommand_required(true)
-                    .subcommand(
-                        Command::new("list").about("List group members").args(&[
-                            Arg::new("json")
-                                .action(ArgAction::SetTrue)
-                                .short('j')
-                                .long("json")
-                                .help("Produce member list in json format (default: false)"),
-                        ]),
-                    )
-                    .subcommand(
-                        Command::new("add").about("Add user to group").args(&[
-                            Arg::new("user")
-                                .value_name("USER")
-                                .help("User(s) to be added")
-                                .action(ArgAction::Append)
-                                .required(true),
-                        ]),
-                    )
-                    .subcommand(
-                        Command::new("remove")
-                            .alias("rm")
-                            .about("Remove user from group")
-                            .args(&[
-                                Arg::new("user")
+                            .required(true)])
+                        .subcommand_required(true)
+                        .subcommand(
+                            Command::new("list").about("List group members").args(&[Arg::new(
+                                "json",
+                            )
+                            .action(ArgAction::SetTrue)
+                            .short('j')
+                            .long("json")
+                            .help("Produce member list in json format (default: false)")]),
+                        )
+                        .subcommand(
+                            Command::new("add").about("Add user to group").args(&[Arg::new(
+                                "user",
+                            )
+                            .value_name("USER")
+                            .help("User(s) to be added")
+                            .action(ArgAction::Append)
+                            .required(true)]),
+                        )
+                        .subcommand(
+                            Command::new("remove")
+                                .alias("rm")
+                                .about("Remove user from group")
+                                .args(&[Arg::new("user")
                                     .value_name("USER")
                                     .help("User(s) to be removed")
                                     .action(ArgAction::Append)
-                                    .required(true),
-                            ]),
-                    )
+                                    .required(true)]),
+                        ),
                 )
                 .subcommand(
-                    Command::new("transfer").about("Transfer group ownership between users").args(&[
-                        Arg::new("group")
-                            .short('g')
-                            .long("group")
-                            .value_name("GROUP")
-                            .help("Group to transfer")
-                            .required(true),
-                        Arg::new("user")
-                            .value_name("USER")
-                            .help("User the group ownership will be transferred to")
-                            .required(true),
-                        Arg::new("force")
-                            .short('f')
-                            .long("force")
-                            .help("Do not prompt for confirmation")
-                            .action(ArgAction::SetTrue),
-                    ])
-                )
+                    Command::new("transfer").about("Transfer group ownership between users").args(
+                        &[
+                            Arg::new("group")
+                                .short('g')
+                                .long("group")
+                                .value_name("GROUP")
+                                .help("Group to transfer")
+                                .required(true),
+                            Arg::new("user")
+                                .value_name("USER")
+                                .help("User the group ownership will be transferred to")
+                                .required(true),
+                            Arg::new("force")
+                                .short('f')
+                                .long("force")
+                                .help("Do not prompt for confirmation")
+                                .action(ArgAction::SetTrue),
+                        ],
+                    ),
+                ),
         )
         .subcommand(
-            Command::new("init")
-                .about("Setup a new Phylum project")
-                .args(&[
-                    Arg::new("project")
-                        .value_name("PROJECT_NAME")
-                        .help("Phylum project name"),
-                    Arg::new("group")
-                        .short('g')
-                        .long("group")
-                        .value_name("GROUP_NAME")
-                        .help("Group which will be the owner of the project"),
-                    Arg::new("lockfile")
-                        .short('l')
-                        .long("lockfile")
-                        .value_name("LOCKFILE")
-                        .help("Project-relative lock file path")
-                        .action(ArgAction::Append),
-                    Arg::new("lockfile-type")
-                        .short('t')
-                        .long("lockfile-type")
-                        .value_name("type")
-                        .requires("lockfile")
-                        .help("Lock file type used for all lock files (default: auto)")
-                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
-                    Arg::new("force")
-                        .short('f')
-                        .long("force")
-                        .help("Overwrite existing configurations without confirmation")
-                        .action(ArgAction::SetTrue),
-                ]),
+            Command::new("init").about("Setup a new Phylum project").args(&[
+                Arg::new("project").value_name("PROJECT_NAME").help("Phylum project name"),
+                Arg::new("group")
+                    .short('g')
+                    .long("group")
+                    .value_name("GROUP_NAME")
+                    .help("Group which will be the owner of the project"),
+                Arg::new("lockfile")
+                    .short('l')
+                    .long("lockfile")
+                    .value_name("LOCKFILE")
+                    .help("Project-relative lock file path")
+                    .action(ArgAction::Append),
+                Arg::new("lockfile-type")
+                    .short('t')
+                    .long("lockfile-type")
+                    .value_name("type")
+                    .requires("lockfile")
+                    .help("Lock file type used for all lock files (default: auto)")
+                    .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
+                Arg::new("force")
+                    .short('f')
+                    .long("force")
+                    .help("Overwrite existing configurations without confirmation")
+                    .action(ArgAction::SetTrue),
+            ]),
         )
         .subcommand(extensions::command());
 

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -118,10 +118,10 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
             Box::new(io::BufReader::new(io::stdin()))
         };
 
-        let request_type = match matches.get_one::<String>("type") {
-            Some(package_type) => PackageType::from_str(package_type)
-                .map_err(|_| anyhow!("invalid package type: {}", package_type))?,
-            None => api.config().request_type,
+        let request_type = {
+            let package_type = matches.get_one::<String>("type").unwrap();
+            PackageType::from_str(package_type)
+                .map_err(|_| anyhow!("invalid package type: {}", package_type))?
         };
 
         label = matches.get_one::<String>("label");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,7 +12,6 @@ use std::{env, fs};
 use anyhow::{anyhow, Result};
 use phylum_project::{LockfileConfig, ProjectConfig};
 use phylum_types::types::auth::RefreshToken;
-use phylum_types::types::package::PackageType;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{dirs, print_user_warning};
@@ -49,7 +48,6 @@ impl AuthInfo {
 pub struct Config {
     pub connection: ConnectionInfo,
     pub auth_info: AuthInfo,
-    pub request_type: PackageType,
     pub last_update: Option<usize>,
     #[serde(skip)]
     ignore_certs_cli: bool,
@@ -62,7 +60,6 @@ impl Default for Config {
         Config {
             connection: ConnectionInfo { uri: "https://api.phylum.io".into() },
             auth_info: AuthInfo::default(),
-            request_type: PackageType::Npm,
             ignore_certs_cli: false,
             ignore_certs: false,
             last_update: None,
@@ -229,9 +226,10 @@ mod tests {
 
     const CONFIG_TOKEN: &str = "FAKE TOKEN";
     const ENV_TOKEN: &str = "ENV TOKEN";
+    const LOCALHOST: &str = "http://127.0.0.1";
 
     fn write_test_config(path: &Path) {
-        let con = ConnectionInfo { uri: "http://127.0.0.1".into() };
+        let con = ConnectionInfo { uri: LOCALHOST.into() };
 
         let auth = AuthInfo {
             offline_access: Some(RefreshToken::new(CONFIG_TOKEN)),
@@ -241,7 +239,6 @@ mod tests {
         let config = Config {
             connection: con,
             auth_info: auth,
-            request_type: PackageType::Npm,
             ignore_certs_cli: false,
             ignore_certs: false,
             last_update: None,
@@ -260,7 +257,7 @@ mod tests {
         let tempfile = NamedTempFile::new().unwrap();
         write_test_config(tempfile.path());
         let config: Config = parse_config(tempfile.path()).unwrap();
-        assert_eq!(config.request_type, PackageType::Npm);
+        assert_eq!(config.connection.uri, LOCALHOST);
     }
 
     #[test]


### PR DESCRIPTION
Following up on #997, this patch completely removes the request type from the global config. This also makes the `--type` parameter mandatory in the (rarely used) `phylum batch` command.

It turns out that rustfmt was ignoring a large block in `app.rs` due to the use of a raw string literal. As a part of this change, I removed the raw string literal. So you can see a significant reformatting of `app.rs`