### PR TITLE
Bump to v4.8.0 - SPDX file support; Official pip extension

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* 4.8.0 - SPDX file support; Official pip extension
 * 4.7.0 - Automatic lockfile detection
 * 4.6.1 - Fix Go parser ignoring dependencies
 * 4.6.0 - Improve init UX

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "4.7.0"
+version = "4.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "4.7.0"
+version = "4.8.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release-Version: v4.8.0
Release-Summary: SPDX file support; Official pip extension

## DRAFT

Delaying until #993 is merged