### PR TITLE
Add base option to `phylum analyze`

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -275,6 +275,13 @@ pub fn add_subcommands(command: Command) -> Command {
                         .requires("lockfile")
                         .help("Lock file type used for all lock files (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
+                    Arg::new("base")
+                        .short('b')
+                        .long("base")
+                        .value_name("FILE")
+                        .value_hint(ValueHint::FilePath)
+                        .help("Previous list of dependencies for analyzing the delta")
+                        .hide(true),
                 ]),
         )
         .subcommand(


### PR DESCRIPTION
This patch adds the new `--base` option which allows passing a file
which contains a list of packages that will be ignored for analysis.
This can be used to analyze the delta between two package lists.

The expected file format is identical to the output of `phylum parse`,
so a base can be obtained using `phylum parse > base.json` and then
analyzed using `phylum analyze --base base.json`.

The option is hidden and not intended to be used by endusers, mainly to
avoid having to document the exact required file format.

Closes #1003.