### PR TITLE
Add `ignoredPackages` parameter to extension API

### DIFF
--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -139,12 +139,10 @@ pub async fn parse_lockfile() {
         .build()
         .run()
         .success()
-        .stdout(predicates::str::contains(
-            r#"{
-  packages: [ { name: "accepts", version: "1.3.8", package_type: "npm" } ],
-  format: "yarn"
-}"#,
-        ));
+        .stdout(
+            "{ packages: [ { name: \"accepts\", version: \"1.3.8\", type: \"npm\" } ], format: \
+             \"yarn\" }\n",
+        );
 }
 
 #[tokio::test]
@@ -154,8 +152,8 @@ pub async fn get_job_status() {
     let project = create_project().await;
     let analyze = format!(
         "
-        const pkg = {{ name: 'typescript', version: '4.7.4'}};
-        const jobId = await PhylumApi.analyze('npm', [pkg], {project:?});
+        const pkg = {{ name: 'typescript', version: '4.7.4', type: 'npm' }};
+        const jobId = await PhylumApi.analyze([pkg], {project:?});
         console.log(await PhylumApi.getJobStatus(jobId));"
     );
 

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -190,12 +190,15 @@ async function checkDryRun(subcommand: string, args: string[]) {
     return;
   }
 
-  const jobId = await PhylumApi.analyze(undefined, lockfile.packages);
+  const jobId = await PhylumApi.analyze(lockfile.packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
-  if (jobStatus.pass && jobStatus.status === "complete") {
-    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
-  } else if (jobStatus.pass) {
+  if (!jobStatus.is_failure && jobStatus.is_complete) {
+    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
+  } else if (!jobStatus.is_failure) {
+    console.warn(
+      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
+    );
     console.warn(
       `[${
         yellow(
@@ -206,7 +209,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     Deno.exit(126);
   } else {
     console.error(
-      `[${red("phylum")}] The operation caused a threshold failure.\n`,
+      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
     );
     Deno.exit(127);
   }

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -4,7 +4,7 @@ const DenoCore = Deno[Deno.internal].core;
 type Package = {
   name: string;
   version: string;
-  package_type: string | undefined;
+  type: string;
 };
 
 type Lockfile = {
@@ -76,16 +76,15 @@ export class PhylumApi {
    *
    * ```
    * [
-   *   { name: "accepts", version: "1.3.8", package_type: "npm" },
-   *   { name: "ms", version: "2.0.0", package_type: "npm" },
-   *   { name: "negotiator", version: "0.6.3", package_type: "npm" },
-   *   { name: "ms", version: "2.1.3", package_type: "npm" }
+   *   { name: "accepts", version: "1.3.8", type: "npm" },
+   *   { name: "ms", version: "2.0.0", type: "npm" },
+   *   { name: "negotiator", version: "0.6.3", type: "npm" },
+   *   { name: "ms", version: "2.1.3", type: "npm" }
    * ]
    * ```
    *
    * Accepted package types are "npm", "pypi", "maven", "rubygems", "nuget", "cargo", and "golang"
    *
-   * @param package_type - DEPRECATED. Specify package_type in each package object instead.
    * @param packages - List of packages to analyze
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
    * @param group - Group name
@@ -93,14 +92,12 @@ export class PhylumApi {
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
-    package_type: string | undefined,
     packages: Package[],
     project?: string,
     group?: string,
   ): Promise<string> {
     return DenoCore.opAsync(
       "analyze",
-      package_type,
       packages,
       project,
       group,
@@ -142,6 +139,9 @@ export class PhylumApi {
   /**
    * Get job results.
    *
+   * @param jobId - ID of the analysis job, see `PhylumApi.analyze`.
+   * @param ignoredPackages - List of packages which will be ignored in the report.
+   *
    * @returns Job analysis results
    *
    * Job analysis results example:
@@ -154,8 +154,11 @@ export class PhylumApi {
    * }
    * ```
    */
-  static getJobStatus(jobId: string): Promise<Record<string, unknown>> {
-    return DenoCore.opAsync("get_job_status", jobId);
+  static getJobStatus(
+    jobId: string,
+    ignoredPackages?: Package[],
+  ): Promise<Record<string, unknown>> {
+    return DenoCore.opAsync("get_job_status", jobId, ignoredPackages);
   }
 
   /**
@@ -319,12 +322,12 @@ export class PhylumApi {
    * Lockfile dependencies example:
    * ```
    * {
-   *   package_type: "npm",
+   *   format: "npm",
    *   packages: [
-   *     { name: "accepts", version: "1.3.8" },
-   *     { name: "ms", version: "2.0.0" },
-   *     { name: "negotiator", version: "0.6.3" },
-   *     { name: "ms", version: "2.1.3" }
+   *     { name: "accepts", version: "1.3.8", type: "npm" },
+   *     { name: "ms", version: "2.0.0", type: "npm" },
+   *     { name: "negotiator", version: "0.6.3", type: "npm" },
+   *     { name: "ms", version: "2.1.3", type: "npm" }
    *   ]
    * }
    * ```

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -210,7 +210,7 @@ async function poetryCheckDryRun(
     // "1.2.3 https://github.com/demo/demo.git" -> "1.2.3"
     version = version.split(" ")[0];
 
-    packages.push({ name, version, package_type: "pypi" });
+    packages.push({ name, version, type: "pypi" });
   }
 
   // Abort if there's nothing to analyze.
@@ -220,12 +220,15 @@ async function poetryCheckDryRun(
   }
 
   // Run Phylum analysis on the packages.
-  const jobId = await PhylumApi.analyze(undefined, packages);
+  const jobId = await PhylumApi.analyze(packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
-  if (jobStatus.pass && jobStatus.status === "complete") {
-    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
-  } else if (jobStatus.pass) {
+  if (!jobStatus.is_failure && jobStatus.is_complete) {
+    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
+  } else if (!jobStatus.is_failure) {
+    console.warn(
+      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
+    );
     console.warn(
       `[${
         yellow(
@@ -236,7 +239,7 @@ async function poetryCheckDryRun(
     Deno.exit(123);
   } else {
     console.error(
-      `[${red("phylum")}] The operation caused a threshold failure.\n`,
+      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
     );
     Deno.exit(122);
   }

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -268,12 +268,15 @@ async function checkDryRun() {
     return;
   }
 
-  const jobId = await PhylumApi.analyze(undefined, lockfile.packages);
+  const jobId = await PhylumApi.analyze(lockfile.packages);
   const jobStatus = await PhylumApi.getJobStatus(jobId);
 
-  if (jobStatus.pass && jobStatus.status === "complete") {
-    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
-  } else if (jobStatus.pass) {
+  if (!jobStatus.is_failure && jobStatus.is_complete) {
+    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
+  } else if (!jobStatus.is_failure) {
+    console.warn(
+      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
+    );
     console.warn(
       `[${
         yellow(
@@ -284,7 +287,7 @@ async function checkDryRun() {
     Deno.exit(126);
   } else {
     console.error(
-      `[${red("phylum")}] The operation caused a threshold failure.\n`,
+      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
     );
     Deno.exit(127);
   }


### PR DESCRIPTION
This exposes the functionality of adding a list of ignored package
descriptors to the extension API.

Since this is a breaking change either way, the patch also takes the
opportunity to streamline the existing APIs and use one unified package
descriptor struct for all APIs.