### PR TITLE
Reformat `phylum history` output

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -117,12 +117,11 @@ impl Format for Vec<JobDescriptor> {
         let _ = writeln!(writer, "Last {} runs\n", self.len());
 
         for job in self {
-            let status = if job.num_incomplete > 0 {
-                style("INCOMPLETE").yellow().to_string()
-            } else if !job.pass {
-                style("FAIL").red().to_string()
-            } else {
-                style("PASS").green().to_string()
+            let status = match (job.num_incomplete, job.pass) {
+                (0, false) => style("FAILED").red().to_string(),
+                (_, false) => style("INCOMPLETE WITH FAILURE").red().to_string(),
+                (0, true) => style("SUCCESS").green().to_string(),
+                (_, true) => style("INCOMPLETE").yellow().to_string(),
             };
 
             let date = job


### PR DESCRIPTION
The format of the `phylum history` command was very hard to read and littered with unlabeled or useless information. This patch brings a new simplified format.

The new format avoids long lines, but it does so by using more lines (currently 8 lines per job). This is a necessary trade-off. I first tried a table format, but the lines were 150+ characters long.

## Sample output
![phylum-history](https://user-images.githubusercontent.com/616067/230220088-0156cf4f-ef2a-4b47-b2f7-4a2b6e1428f6.png)