### PR TITLE
Allow `phylum pip install -e .` on macOS

### DIFF
--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -99,6 +99,7 @@ async function checkDryRun() {
     exceptions: {
       run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
       write: [
+        "./",
         "~/Library/Caches",
         "~/.pyenv",
         "~/.cache",


### PR DESCRIPTION
The command still does not work on Linux because it uses a cross-device link, which requires a newer version of landlock to support

Ref: #990