### PR TITLE
ci: switch `ubuntu-22.04` to `ubuntu-latest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,7 @@ jobs:
         run: deno check --no-lock extensions/**/*.ts
 
   shellcheck:
-    # TODO: Update to `ubuntu-latest` once `ubuntu-22.04` support is stabilized.
-    #       https://github.com/phylum-dev/cli/issues/467
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Script Style Check


### PR DESCRIPTION
`ubuntu-latest` is now the same as `ubuntu-22.04`. The specific version was previously used to ensure a newer version of `shellcheck` was installed and available on the runner, so that a particular command option would be available. `ubuntu-latest`, even if it progresses, should still have at least that version of `shellcheck` installed.

Closes #467

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - N/A
- [x] ~Have you updated all affected documentation?~
  - N/A