### PR TITLE
Handle null label in `phylum history --project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Handle null job labels in `phylum history --project`
+
 ## [5.0.0] - 2023-04-13
 
 ### Added

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -207,7 +207,7 @@ impl Format for Vec<HistoryJob> {
     fn pretty<W: Write>(&self, writer: &mut W) {
         let table = format_table::<fn(&HistoryJob) -> String, _>(self, &[
             ("Job ID", |job| job.id.clone()),
-            ("Label", |job| job.label.clone()),
+            ("Label", |job| job.label.clone().unwrap_or_default()),
             ("Creation Time", |job| job.created.format("%FT%RZ").to_string()),
         ]);
         let _ = writeln!(writer, "{table}");

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -53,7 +53,7 @@ pub struct GithubReleaseAsset {
 pub struct HistoryJob {
     pub id: String,
     pub created: DateTime<Utc>,
-    pub label: String,
+    pub label: Option<String>,
 }
 
 /// Request body for `/data/jobs/{job_id}/policy/evaluate`.


### PR DESCRIPTION
The [job submission endpoint][1] does not allow null labels, but it does allow empty string. And when an empty label is submitted, it becomes a `null` label in the [project history endpoint][2].

[1]: https://api.phylum.io/api/v0/swagger/index.html#/Jobs/start_job
[2]: https://api.phylum.io/api/v0/swagger/index.html#/Projects/history_endpoint

This patch accounts for the potential `null` value in this field.