### PR TITLE
Revert "Temporarily disable get_package_details test (#1039)"

### DIFF
--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -39,8 +39,7 @@ pub async fn get_refresh_token() {
         .stdout(predicates::str::contains("ey"));
 }
 
-// Temporarily disabled due to staging issues
-// #[tokio::test]
+#[tokio::test]
 pub async fn get_package_details() {
     let test_cli = TestCli::builder().with_config(None).build();
 


### PR DESCRIPTION
This reverts commit e8785f76720637f08bfcc16c8d287bb0ca65a90c.

Merge this whenever staging is fixed and the test passes again