### PR TITLE
Bump to v5.0.1 - Fix `phylum history --project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [5.0.1] - 2023-04-20
+
 ### Fixed
 - Handle null job labels in `phylum history --project`
 
@@ -477,7 +479,8 @@ before, the existing project ID will be re-linked.
 ## 0.0.1 
 - Initial release.
 
-[unreleased]: https://github.com/phylum-dev/cli/compare/v5.0.0...HEAD
+[unreleased]: https://github.com/phylum-dev/cli/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/phylum-dev/cli/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/phylum-dev/cli/compare/v4.8.0...v5.0.0
 [4.8.0]: https://github.com/phylum-dev/cli/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/phylum-dev/cli/compare/v4.6.1...v4.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 5.0.1 - 2023-04-20
+
 ## 5.0.0 - 2023-04-13
 
 ### Added


### PR DESCRIPTION
Release-Version: v5.0.1
Release-Summary: Fix `phylum history --project`