### PR TITLE
fix: `name` field of GitHub release not populated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,6 @@ jobs:
           script: |
             const fs = require("node:fs");
 
-            const name = process.env.GITHUB_REF_NAME;
             const body = fs.readFileSync("RELEASE-NOTES.txt", { encoding: "utf-8" });
 
             const response = await github.rest.repos.createRelease({
@@ -190,7 +189,7 @@ jobs:
               repo: context.repo.repo,
               tag_name: process.env.GITHUB_REF_NAME,
               prerelease: ${{ contains(github.ref, 'rc') }},
-              name: name,
+              name: process.env.GITHUB_REF_NAME,
               body: body,
             });
             console.log(response);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,7 @@ jobs:
           script: |
             const fs = require("node:fs");
 
+            const name = process.env.GITHUB_REF_NAME;
             const body = fs.readFileSync("RELEASE-NOTES.txt", { encoding: "utf-8" });
 
             const response = await github.rest.repos.createRelease({
@@ -189,6 +190,7 @@ jobs:
               repo: context.repo.repo,
               tag_name: process.env.GITHUB_REF_NAME,
               prerelease: ${{ contains(github.ref, 'rc') }},
+              name: name,
               body: body,
             });
             console.log(response);


### PR DESCRIPTION
The `name` field was not populated for the CLI v5.0.1 release, which caused `phylum update` commands from any release to fail. The `name` field is expected to be a `String` in the `GithubRelease` type and fails when there is no value (`null` instead of a `String`). The regression happened when the `generate_release_notes` option in the API call to create a release was removed in favor of specifying a `body` directly.

The documentation for this API
(https://docs.github.com/en/rest/releases/releases#create-a-release) states that:

> `generate_release_notes` boolean
> Whether to automatically generate the name and body for this release.
> If `name` is specified, the specified name will be used; otherwise, a
> name will be automatically generated. If `body` is specified, the body
> will be pre-pended to the automatically generated notes.

This change adds the `name` field, to go alongside the existing `body` field.

No CHANGELOG entry was added because the issue is no longer present for the currently released versions of the CLI. It was only an issue for the brief time after v5.0.1 was released and before the `name` field was added manually through the GitHub UI.
