### PR TITLE
fix: `pip` parser fails for some lines containing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `pip` parser fails for some lines containing comments
+
 ## [5.0.1] - 2023-04-20
 
 ### Fixed
@@ -355,7 +358,7 @@ before, the existing project ID will be re-linked.
 
 ### BREAKING CHANGES
 - Follow XDG directories spec by @cd-work (#251)
-  * Existing installs will have config file moved automatically
+  - Existing installs will have config file moved automatically
 
 ### Added
 - Add `uninstall` subcommand to phylum by @cd-work (#239)
@@ -381,8 +384,8 @@ before, the existing project ID will be re-linked.
 - Parse package extras in Python requirements.txt files by @kylewillmon (#271)
 - Rename projects subcommand to project by @kylewillmon (#282)
 - Improved scripting support
-  * Remove checkmark from `auth token` command by @cd-work (#261)
-  * Set appropriate exit codes on failure by @cd-work (#260)
+  - Remove checkmark from `auth token` command by @cd-work (#261)
+  - Set appropriate exit codes on failure by @cd-work (#260)
 
 ### Fixed
 - Format "Last updated" field with ISO 8601 by @cd-work (#257)
@@ -461,22 +464,22 @@ before, the existing project ID will be re-linked.
 ## 1.0.0 - 2021-08-02
 - Add formatted output; refactor subcommands; many other changes for improved usability
 
-## 0.0.7 
+## 0.0.7
 - Adding synch submit requests
 
-## 0.0.5 
+## 0.0.5
 - Add support for projects and project labels / decrease verbosity of package status
 
-## 0.0.4 
+## 0.0.4
 - Minor update to API response format; add `--threshold` argument to `status` command
 
-## 0.0.3 
+## 0.0.3
 - Update response format of the `status` command to match API changes.
 
-## 0.0.2 
+## 0.0.2
 - Add support for listing / submitting heuristics.
 
-## 0.0.1 
+## 0.0.1
 - Initial release.
 
 [unreleased]: https://github.com/phylum-dev/cli/compare/v5.0.1...HEAD

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -16,9 +16,10 @@ use crate::{Package, PackageVersion};
 pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
     let mut pkgs = Vec::new();
 
-    // Iterate over all non-empty lines.
-    for line in
-        input.lines().filter(|line| !line.trim().starts_with('#') && !line.trim().is_empty())
+    for line in input
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.starts_with('#') && !line.is_empty())
     {
         let (_, line) = recognize(alt((take_until(" #"), not_line_ending)))(line)?;
         let (_, pkg) = package(line)?;

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -17,7 +17,10 @@ pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
     let mut pkgs = Vec::new();
 
     // Iterate over all non-empty lines.
-    for line in input.lines().filter(|line| !line.starts_with('#') && !line.trim().is_empty()) {
+    for line in
+        input.lines().filter(|line| !line.trim().starts_with('#') && !line.trim().is_empty())
+    {
+        let (_, line) = recognize(alt((take_until(" #"), not_line_ending)))(line)?;
         let (_, pkg) = package(line)?;
         pkgs.push(pkg);
     }

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -193,9 +193,24 @@ mod tests {
         let pkgs = PyRequirements
             .parse(include_str!("../../tests/fixtures/requirements-locked.txt"))
             .unwrap();
-        assert_eq!(pkgs.len(), 9);
+        assert_eq!(pkgs.len(), 12);
 
         let expected_pkgs = [
+            Package {
+                name: "alembic".into(),
+                version: PackageVersion::FirstParty("1.10.3".into()),
+                package_type: PackageType::PyPi,
+            },
+            Package {
+                name: "amqp".into(),
+                version: PackageVersion::FirstParty("5.0.9".into()),
+                package_type: PackageType::PyPi,
+            },
+            Package {
+                name: "attrs".into(),
+                version: PackageVersion::FirstParty("20.2.0".into()),
+                package_type: PackageType::PyPi,
+            },
             Package {
                 name: "flask".into(),
                 version: PackageVersion::FirstParty("2.2.2".into()),

--- a/tests/fixtures/requirements-locked.txt
+++ b/tests/fixtures/requirements-locked.txt
@@ -1,3 +1,5 @@
+# The full `pip` requirements file format is documented here:
+# https://pip.pypa.io/en/stable/reference/requirements-file-format/
 
 # This is a comment.
 
@@ -10,7 +12,8 @@ amqp==5.0.9
 
 attrs==20.2.0   # This is an inline comment
 
-flask==2.2.2
+# The requirement specifier does not have to be at the beginning of the line
+    flask==2.2.2
 
 requests[security,tests]==2.28.1
 

--- a/tests/fixtures/requirements-locked.txt
+++ b/tests/fixtures/requirements-locked.txt
@@ -1,6 +1,15 @@
 
 # This is a comment.
 
+# The next two packages are examples of output from using `pip-tools` to run a command like:
+# pip-compile requirements/requirements.in
+alembic==1.10.3
+    # via -r requirements/requirements.in
+amqp==5.0.9
+    # via kombu
+
+attrs==20.2.0   # This is an inline comment
+
 flask==2.2.2
 
 requests[security,tests]==2.28.1


### PR DESCRIPTION
The `pip` "Requirements File Format" is documented here: https://pip.pypa.io/en/stable/reference/requirements-file-format/

It allows for line continuations and a host of arguments to `pip install`, which this change does not address. Instead, this change accounts for lines containing comments where the comment character (`#`) is not the first character of the line. The comment line could be indented or comments can be inline (e.g., after a valid requirement). Both types of comments were added to the test fixture.

When updating the `CHANGELOG.md`, saving the file in the IDE caused an automatic reformatting of some lines...to remove trailing whitespace and ensure consistency for the list markers (`-` everywhere instead of `*`).

Fixes #1044


## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
