### PR TITLE
Add generator for manifest to lockfile conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - CLI will look for the corresponding lockfile when analyzing a manifest file
+- Allow analyzing manifest files by generating lockfiles on-demand
 
 ### Fixed
 - Handle null job labels in `phylum history --project`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [5.0.1] - 2023-04-20
 
+### Added
+- CLI will look for the corresponding lockfile when analyzing a manifest file
+
 ### Fixed
 - Handle null job labels in `phylum history --project`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- CLI will look for the corresponding lockfile when analyzing a manifest file
+- Allow analyzing manifest files by generating lockfiles on-demand
+
 ### Fixed
 - `pip` parser fails for some lines containing comments
 
 ## [5.0.1] - 2023-04-20
-
-### Added
-- CLI will look for the corresponding lockfile when analyzing a manifest file
-- Allow analyzing manifest files by generating lockfiles on-demand
 
 ### Fixed
 - Handle null job labels in `phylum history --project`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfile_generator"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3219,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ignore",
+ "lockfile_generator",
  "log",
  "nom",
  "packageurl",
@@ -3222,6 +3230,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
   "xtask",
   "clap_markdown",
   "phylum_project",
+  "lockfile_generator",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "1.4.0"
 log = "0.4.6"
 maplit = "1.0.2"
 open = "4.0.0"
-phylum_lockfile = { path = "../lockfile" }
+phylum_lockfile = { path = "../lockfile", features = ["generator"] }
 phylum_project = { path = "../phylum_project" }
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 prettytable-rs = "0.10.0"

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -102,7 +102,7 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
             if pretty_print {
                 print_user_success!(
                     "Successfully parsed lockfile {:?} as type: {}",
-                    lockfile.path,
+                    res.path,
                     res.format.name()
                 );
             }

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -1,19 +1,20 @@
 //! `phylum parse` command for lockfile parsing
 
-use std::fs::read_to_string;
-use std::io;
-use std::path::Path;
+use std::path::PathBuf;
+use std::{fs, io};
 
 use anyhow::{anyhow, Context, Result};
 use phylum_lockfile::{
     get_path_format, LockfileFormat, Package, PackageVersion, ThirdPartyVersion,
 };
 use phylum_types::types::package::PackageDescriptor;
+use walkdir::WalkDir;
 
 use crate::commands::{CommandResult, ExitCode};
-use crate::config;
+use crate::{config, print_user_warning};
 
 pub struct ParsedLockfile {
+    pub path: PathBuf,
     pub format: LockfileFormat,
     pub packages: Vec<PackageDescriptor>,
 }
@@ -45,20 +46,42 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 
 /// Parse a package lockfile.
 pub fn parse_lockfile(
-    path: impl AsRef<Path>,
+    path: impl Into<PathBuf>,
     lockfile_type: Option<&str>,
 ) -> Result<ParsedLockfile> {
     // Try and determine lockfile format.
-    let path = path.as_ref();
+    let mut path = path.into();
     let format = lockfile_type
         .filter(|lockfile_type| lockfile_type != &"auto")
         .map(|lockfile_type| lockfile_type.parse::<LockfileFormat>().unwrap())
-        .or_else(|| get_path_format(path));
+        .or_else(|| get_path_format(&path))
+        .or_else(|| {
+            let canonicalized = fs::canonicalize(&path).ok()?;
+            let manifest_dir = canonicalized.parent()?;
+
+            // Find matching format and lockfile in manifest's directory.
+            let (format, lockfile_path) = LockfileFormat::iter()
+                .filter(|format| format.parser().is_path_manifest(&path))
+                .find_map(|format| {
+                    let lockfile_path = WalkDir::new(manifest_dir)
+                        .into_iter()
+                        .flatten()
+                        .find(|entry| format.parser().is_path_lockfile(entry.path()))?;
+                    Some((format, lockfile_path))
+                })?;
+
+            // Switch manifest to lockfile path.
+            let lockfile_path = lockfile_path.path().to_owned();
+            print_user_warning!("{path:?} is not a lockfile, using {lockfile_path:?} instead");
+            path = lockfile_path;
+
+            Some(format)
+        });
 
     match format {
         // Parse with identified parser.
         Some(format) => {
-            let data = read_to_string(path)?;
+            let data = fs::read_to_string(&path)?;
             let parser = format.parser();
 
             let packages = parser
@@ -66,7 +89,7 @@ pub fn parse_lockfile(
                 .with_context(|| format!("Failed to parse lockfile {path:?}"))?;
             let packages = filter_packages(packages);
 
-            Ok(ParsedLockfile { packages, format })
+            Ok(ParsedLockfile { path, packages, format })
         },
         // Attempt to parse with all parsers until success.
         None => try_get_packages(path),
@@ -74,8 +97,8 @@ pub fn parse_lockfile(
 }
 
 /// Attempt to get packages from an unknown lockfile type
-fn try_get_packages(path: &Path) -> Result<ParsedLockfile> {
-    let data = read_to_string(path)?;
+fn try_get_packages(path: PathBuf) -> Result<ParsedLockfile> {
+    let data = fs::read_to_string(&path)?;
 
     for format in LockfileFormat::iter() {
         let parser = format.parser();
@@ -84,7 +107,7 @@ fn try_get_packages(path: &Path) -> Result<ParsedLockfile> {
 
             let packages = filter_packages(packages);
 
-            return Ok(ParsedLockfile { packages, format });
+            return Ok(ParsedLockfile { path, packages, format });
         }
     }
 
@@ -159,7 +182,7 @@ mod tests {
         ];
 
         for (file, expected_format) in test_cases {
-            let parsed = try_get_packages(Path::new(file)).unwrap();
+            let parsed = try_get_packages(PathBuf::from(file)).unwrap();
             assert_eq!(parsed.format, expected_format, "{}", file);
         }
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -193,7 +193,7 @@ pub fn lockfiles(
             let project_lockfiles = project.map(|project| project.lockfiles());
 
             // Fallback to walking the directory.
-            let lockfiles = project_lockfiles.unwrap_or_else(|| find_lockfiles("."));
+            let lockfiles = project_lockfiles.unwrap_or_else(|| find_lockable_files("."));
 
             // Ask for explicit lockfile if none were found.
             if lockfiles.is_empty() {
@@ -205,9 +205,9 @@ pub fn lockfiles(
     }
 }
 
-/// Find lockfiles at or below the specified directory.
-pub fn find_lockfiles(directory: impl AsRef<Path>) -> Vec<LockfileConfig> {
-    phylum_lockfile::find_lockfiles_at(directory)
+/// Find lockfiles and manifests at or below the specified directory.
+fn find_lockable_files(directory: impl AsRef<Path>) -> Vec<LockfileConfig> {
+    phylum_lockfile::find_lockable_files_at(directory)
         .drain(..)
         .map(|(path, format)| LockfileConfig::new(path, format.to_string()))
         .collect()

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -31,7 +31,7 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -25,7 +25,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -f, --force
 &emsp; Overwrite existing configurations without confirmation

--- a/docs/command_line_tool/phylum_parse.md
+++ b/docs/command_line_tool/phylum_parse.md
@@ -19,7 +19,7 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `yarn`, `npm`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `pipenv`, `poetry`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -30,6 +30,23 @@ The Phylum CLI natively supports processing lockfiles for several ecosystems, na
   * `*.spdx.yml`
   * `*.spdx`
 
+When the ecosystem's package manager is available, it can also automatically
+generate lockfiles for the following manifest files:
+
+* npm
+    * `package.json` using either `npm` or `yarn`
+* PyPi
+    * `requirements.txt` using `pip-compile`
+    * `Pipfile` using `pipenv`
+    * `pyproject.toml` using `poetry`
+* Maven
+    * `pom.xml` using `mvn`
+    * `build.gradle` using `gradle`
+* Golang
+    * `go.sum` using `go`
+* Cargo
+    * `Cargo.toml` using `cargo`
+
 After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_init), you can begin analysis by running:
 
 ```sh

--- a/lockfile/Cargo.toml
+++ b/lockfile/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Phylum, Inc. <engineering@phylum.io>"]
 edition = "2021"
 rust-version = "1.63.0"
 
+[features]
+default = []
+generator = ["lockfile_generator"]
+
 [dependencies]
 anyhow = "1.0.44"
 ignore = "0.4.20"
@@ -19,3 +23,5 @@ serde_yaml = "0.9.2"
 serde-xml-rs = "0.5.1"
 toml = "0.5.8"
 thiserror = "1.0.40"
+walkdir = "2.3.2"
+lockfile_generator = { path = "../lockfile_generator", optional = true }

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -2,6 +2,10 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::anyhow;
+#[cfg(feature = "generator")]
+use lockfile_generator::cargo::Cargo as CargoGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use phylum_types::types::package::PackageType;
 use serde::Deserialize;
 
@@ -92,6 +96,11 @@ impl Parse for Cargo {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Cargo.toml"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&CargoGenerator)
     }
 }
 

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -89,6 +89,10 @@ impl Parse for Cargo {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Cargo.lock"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("Cargo.toml"))
+    }
 }
 
 #[cfg(test)]

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -70,6 +70,10 @@ impl Parse for CSProj {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.extension() == Some(OsStr::new("csproj"))
     }
+
+    fn is_path_manifest(&self, _path: &Path) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -2,6 +2,8 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
 
@@ -25,6 +27,11 @@ impl Parse for GoSum {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("go.mod"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        None // TODO
     }
 }
 

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -22,6 +22,10 @@ impl Parse for GoSum {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("go.sum"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("go.mod"))
+    }
 }
 
 #[cfg(test)]

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -2,6 +2,12 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use lockfile_generator::gradle::Gradle as GradleGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::maven::Maven as MavenGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
 use phylum_types::ecosystems::maven::{Dependency, Plugin, Project};
@@ -30,6 +36,11 @@ impl Parse for GradleLock {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("build.gradle"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&GradleGenerator)
     }
 }
 
@@ -64,6 +75,11 @@ impl Parse for Pom {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("pom.xml"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&MavenGenerator)
     }
 }
 

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -27,6 +27,10 @@ impl Parse for GradleLock {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("gradle.lockfile"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("build.gradle"))
+    }
 }
 
 impl Parse for Pom {
@@ -56,6 +60,10 @@ impl Parse for Pom {
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("effective-pom.xml"))
+    }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("pom.xml"))
     }
 }
 

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -2,6 +2,12 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use lockfile_generator::npm::Npm as NpmGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::yarn::Yarn as YarnGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
 use phylum_types::types::package::PackageType;
@@ -118,6 +124,11 @@ impl Parse for PackageLock {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("package.json"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&NpmGenerator)
     }
 }
 
@@ -240,6 +251,11 @@ impl Parse for YarnLock {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("package.json"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&YarnGenerator)
     }
 }
 

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -115,6 +115,10 @@ impl Parse for PackageLock {
         file_name == Some(OsStr::new("package-lock.json"))
             || file_name == Some(OsStr::new("npm-shrinkwrap.json"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("package.json"))
+    }
 }
 
 /// Check if a YAML file is a valid v2 yarn lockfile.
@@ -232,6 +236,10 @@ impl Parse for YarnLock {
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("yarn.lock"))
+    }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("package.json"))
     }
 }
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -151,6 +151,12 @@ pub trait Parse {
     ///
     /// The file does not need to exist.
     fn is_path_lockfile(&self, path: &Path) -> bool;
+
+    /// Test if a file name could be a manifest file corresponding to this
+    /// parser.
+    ///
+    /// The file does not need to exist.
+    fn is_path_manifest(&self, path: &Path) -> bool;
 }
 
 /// Single package parsed from a lockfile.

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -3,6 +3,14 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use lockfile_generator::pip::Pip as PipGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::poetry::Poetry as PoetryGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::python_requirements::PythonRequirements as PythonRequirementsGenerator;
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
 use phylum_types::types::package::PackageType;
@@ -29,8 +37,13 @@ impl Parse for PyRequirements {
         path.file_name() == Some(OsStr::new("requirements.txt"))
     }
 
-    fn is_path_manifest(&self, _path: &Path) -> bool {
-        false
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("requirements.txt"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&PythonRequirementsGenerator)
     }
 }
 
@@ -80,6 +93,11 @@ impl Parse for PipFile {
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Pipfile"))
     }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&PipGenerator)
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -124,6 +142,11 @@ impl Parse for Poetry {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("pyproject.toml"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        Some(&PoetryGenerator)
     }
 }
 

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -28,6 +28,10 @@ impl Parse for PyRequirements {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("requirements.txt"))
     }
+
+    fn is_path_manifest(&self, _path: &Path) -> bool {
+        false
+    }
 }
 
 impl Parse for PipFile {
@@ -72,6 +76,10 @@ impl Parse for PipFile {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Pipfile.lock"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("Pipfile"))
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -112,6 +120,10 @@ impl Parse for Poetry {
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("poetry.lock"))
+    }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("pyproject.toml"))
     }
 }
 

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -2,6 +2,8 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
 
@@ -26,6 +28,11 @@ impl Parse for GemLock {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Gemfile"))
+    }
+
+    #[cfg(feature = "generator")]
+    fn generator(&self) -> Option<&'static dyn Generator> {
+        None
     }
 }
 

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context};
 #[cfg(feature = "generator")]
+use lockfile_generator::bundler::Bundler as BundlerGenerator;
+#[cfg(feature = "generator")]
 use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
@@ -32,7 +34,7 @@ impl Parse for GemLock {
 
     #[cfg(feature = "generator")]
     fn generator(&self) -> Option<&'static dyn Generator> {
-        None
+        Some(&BundlerGenerator)
     }
 }
 

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -23,6 +23,10 @@ impl Parse for GemLock {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("Gemfile.lock"))
     }
+
+    fn is_path_manifest(&self, path: &Path) -> bool {
+        path.file_name() == Some(OsStr::new("Gemfile"))
+    }
 }
 
 #[cfg(test)]

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context};
@@ -163,11 +164,15 @@ impl Parse for Spdx {
         Ok(packages)
     }
 
-    fn is_path_lockfile(&self, path: &std::path::Path) -> bool {
+    fn is_path_lockfile(&self, path: &Path) -> bool {
         path.ends_with(".spdx.json")
             || path.ends_with(".spdx.yaml")
             || path.ends_with(".spdx.yml")
             || path.ends_with(".spdx")
+    }
+
+    fn is_path_manifest(&self, _path: &Path) -> bool {
+        false
     }
 }
 

--- a/lockfile_generator/Cargo.toml
+++ b/lockfile_generator/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lockfile_generator"
+version = "0.1.0"
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
+license = "GPL-3.0-or-later"
+edition = "2021"
+rust-version = "1.68.0"
+
+[dependencies]
+thiserror = "1.0.40"

--- a/lockfile_generator/src/bundler.rs
+++ b/lockfile_generator/src/bundler.rs
@@ -1,0 +1,19 @@
+//! Ruby bundler ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Bundler;
+
+impl Generator for Bundler {
+    fn lockfile_name(&self) -> &'static str {
+        "Gemfile.lock"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("bundle");
+        command.args(["lock"]);
+        command
+    }
+}

--- a/lockfile_generator/src/cargo.rs
+++ b/lockfile_generator/src/cargo.rs
@@ -1,0 +1,19 @@
+//! Rust cargo ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Cargo;
+
+impl Generator for Cargo {
+    fn lockfile_name(&self) -> &'static str {
+        "Cargo.lock"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("cargo");
+        command.args(["generate-lockfile"]);
+        command
+    }
+}

--- a/lockfile_generator/src/go.rs
+++ b/lockfile_generator/src/go.rs
@@ -1,0 +1,19 @@
+//! Go ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Go;
+
+impl Generator for Go {
+    fn lockfile_name(&self) -> &'static str {
+        "go.sum"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("go");
+        command.args(["get", "-d"]);
+        command
+    }
+}

--- a/lockfile_generator/src/gradle.rs
+++ b/lockfile_generator/src/gradle.rs
@@ -1,0 +1,19 @@
+//! Java gradle ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Gradle;
+
+impl Generator for Gradle {
+    fn lockfile_name(&self) -> &'static str {
+        "gradle.lockfile"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("gradle");
+        command.args(["dependencies", "--write-locks"]);
+        command
+    }
+}

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -1,0 +1,113 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::{fs, io};
+
+pub mod cargo;
+pub mod go;
+pub mod gradle;
+pub mod maven;
+pub mod npm;
+pub mod pip;
+pub mod poetry;
+pub mod python_requirements;
+pub mod yarn;
+
+/// Lockfile generation.
+pub trait Generator {
+    /// Lockfile file name.
+    fn lockfile_name(&self) -> &'static str;
+
+    /// Command for generating the lockfile.
+    fn command(&self) -> Command;
+
+    /// Generate the lockfile for a project.
+    ///
+    /// This will ignore all existing lockfiles and create a new lockfile based
+    /// on the current project configuration.
+    fn generate_lockfile(&self, project_path: &Path) -> Result<String> {
+        // Move existing lockfile so we do not overwrite it.
+        let lockfile_path = project_path.join(self.lockfile_name());
+        let _relocator = if lockfile_path.exists() {
+            Some(FileRelocator::new(lockfile_path.clone())?)
+        } else {
+            None
+        };
+
+        // Generate lockfile at the target location.
+        let mut command = self.command();
+        command.current_dir(project_path);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+
+        // Provide better error message, including the failed program's name.
+        let mut child = command.spawn().map_err(|err| {
+            let program = command.get_program().to_string_lossy().into_owned();
+            Error::ProcessCreation(program, err)
+        })?;
+
+        // Ensure generation was successful.
+        let status = child.wait()?;
+        if !status.success() {
+            return Err(Error::NonZeroExit);
+        }
+
+        // Ensure lockfile was created.
+        if !lockfile_path.exists() {
+            return Err(Error::NoLockfileGenerated);
+        }
+
+        // Read lockfile contents.
+        let lockfile = fs::read_to_string(&lockfile_path)?;
+
+        // Cleanup lockfile.
+        fs::remove_file(lockfile_path)?;
+
+        Ok(lockfile)
+    }
+}
+
+/// Temporarily move a file to a different location.
+///
+/// This utility moves a file to a backup location in the same directory and
+/// automatically restores it to its original location on drop.
+struct FileRelocator {
+    original_path: PathBuf,
+    backup_path: OsString,
+}
+
+impl Drop for FileRelocator {
+    fn drop(&mut self) {
+        // We can't do anything about failure here, but the original file should stay
+        // around allowing users to still resolve these issues manually.
+        let _ = fs::rename(&self.backup_path, &self.original_path);
+    }
+}
+
+impl FileRelocator {
+    fn new(path: PathBuf) -> Result<Self> {
+        // Relocate the file.
+        let mut backup_path = path.clone().into_os_string();
+        backup_path.push(".phylum_bak");
+        fs::rename(&path, &backup_path)?;
+
+        Ok(Self { original_path: path, backup_path })
+    }
+}
+
+/// Lockfile generation result.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Lockfile generation error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("failed to run command {0:?}: {1}")]
+    ProcessCreation(String, io::Error),
+    #[error("package manager exited with non-zero status")]
+    NonZeroExit,
+    #[error("no lockfile was generated")]
+    NoLockfileGenerated,
+}

--- a/lockfile_generator/src/maven.rs
+++ b/lockfile_generator/src/maven.rs
@@ -1,0 +1,19 @@
+//! Java maven ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Maven;
+
+impl Generator for Maven {
+    fn lockfile_name(&self) -> &'static str {
+        "effective-pom.xml"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("mvn");
+        command.args(["help:effective-pom", &format!("-Doutput={}", self.lockfile_name())]);
+        command
+    }
+}

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -1,0 +1,19 @@
+//! JavaScript npm ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Npm;
+
+impl Generator for Npm {
+    fn lockfile_name(&self) -> &'static str {
+        "package-lock.json"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("npm");
+        command.args(["install", "--package-lock-only", "--ignore-scripts"]);
+        command
+    }
+}

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -11,6 +11,10 @@ impl Generator for Npm {
         "package-lock.json"
     }
 
+    fn conflicting_files(&self) -> Vec<&'static str> {
+        vec![self.lockfile_name(), "npm-shrinkwrap.json", "yarn.lock"]
+    }
+
     fn command(&self) -> Command {
         let mut command = Command::new("npm");
         command.args(["install", "--package-lock-only", "--ignore-scripts"]);

--- a/lockfile_generator/src/pip.rs
+++ b/lockfile_generator/src/pip.rs
@@ -1,0 +1,19 @@
+//! Python pipenv ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Pip;
+
+impl Generator for Pip {
+    fn lockfile_name(&self) -> &'static str {
+        "Pipfile.lock"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("pipenv");
+        command.args(["lock"]);
+        command
+    }
+}

--- a/lockfile_generator/src/poetry.rs
+++ b/lockfile_generator/src/poetry.rs
@@ -1,0 +1,19 @@
+//! Python poetry ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Poetry;
+
+impl Generator for Poetry {
+    fn lockfile_name(&self) -> &'static str {
+        "poetry.lock"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("poetry");
+        command.args(["lock"]);
+        command
+    }
+}

--- a/lockfile_generator/src/python_requirements.rs
+++ b/lockfile_generator/src/python_requirements.rs
@@ -1,0 +1,19 @@
+//! Python pip ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct PythonRequirements;
+
+impl Generator for PythonRequirements {
+    fn lockfile_name(&self) -> &'static str {
+        "requirements-locked.txt"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("pip-compile");
+        command.args(["-o", self.lockfile_name()]);
+        command
+    }
+}

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -1,0 +1,19 @@
+//! JavaScript yarn ecosystem.
+
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Yarn;
+
+impl Generator for Yarn {
+    fn lockfile_name(&self) -> &'static str {
+        "yarn.lock"
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("yarn");
+        command.args(["install", "--mode=update-lockfile"]);
+        command
+    }
+}


### PR DESCRIPTION
This patch adds the new `lockfile_generator` crate to the project, which
takes in a project directory and attempts to non-mutably generate a
lockfile for it.

This crate is used by the CLI's lockfile parser to automatically
generate a lockfile if the lockfile path it has received is a manifest
file rather than a lockfile.

The type of analysis required is determined in the following steps.

1) Format determination:
 - Try to determine lockfile type from CLI arguments
 - Try to determine lockfile type from lockfile name
 - Try to determine lockfile type from manifest name:
    - Find a format for the manifest that already has a lockfile
    - Fallback to first format that matches the manifest

2) Lockfile analysis:
 - If 1) did not hit the manifest fallback path, we analyze the lockfile
   with the detected format's parser.

3) Lockfile generation:
 - Check if original non-lockfile path is a manifest
 - Check if there is a generator available for the format
 - Generate lockfile at manifest's location using the format's generator
 - Analyze the generated lockfile

The split in analysis -> manifest determination -> analysis is necessary
since some formats have files that are commonly used as both lockfiles
and manifests (requirements.txt), thus it is necessary to first attempt
a lockfile analysis before being able to re-attempt parsing the
generated lockfile.

Closes https://github.com/phylum-dev/cli/issues/1046.