### PR TITLE
refactor: use `tag_name` instead of `name` to identify releases

### DIFF
--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -38,10 +38,6 @@ impl FromStr for Role {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct GithubRelease {
-    // The `name` entry stores the GitHub Release name,
-    // which could be set to something other than the version.
-    // Using the `tag_name` entry is better since the tags
-    // are much more tightly coupled with the release version.
     pub tag_name: String,
     pub assets: Vec<GithubReleaseAsset>,
 }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -38,7 +38,11 @@ impl FromStr for Role {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct GithubRelease {
-    pub name: String,
+    // The `name` entry stores the GitHub Release name,
+    // which could be set to something other than the version.
+    // Using the `tag_name` entry is better since the tags
+    // are much more tightly coupled with the release version.
+    pub tag_name: String,
     pub assets: Vec<GithubReleaseAsset>,
 }
 


### PR DESCRIPTION
The `name` entry stores the GitHub Release name, which could be set to something other than the version. Using the `tag_name` entry is better since the tags are much more tightly coupled with the release version. A check of the 30 most recent CLI releases showed that the `name` and `tag_name` values were identical for every release. This means there is no worry that this change will break updates from older releases to newer ones.
