### PR TITLE
Run test workflow in merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   # Allow running this workflow manually from the Actions tab
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
This allows us to enable [merge queues][1] for this repository.

[1]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions