### PR TITLE
Add npm-shrinkwrap.json support

### DIFF
--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -7,6 +7,7 @@ hidden: false
 The Phylum CLI natively supports processing lockfiles for several ecosystems, namely:
 * npm
   * `package-lock.json`
+  * `npm-shrinkwrap.json`
   * `yarn.lock` (Version 1 + 2)
 * RubyGems
   * `Gemfile.lock`

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -111,7 +111,9 @@ impl Parse for PackageLock {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("package-lock.json"))
+        let file_name = path.file_name();
+        file_name == Some(OsStr::new("package-lock.json"))
+            || file_name == Some(OsStr::new("npm-shrinkwrap.json"))
     }
 }
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -231,6 +231,7 @@ mod tests {
             ("Gemfile.lock", LockfileFormat::Gem),
             ("yarn.lock", LockfileFormat::Yarn),
             ("package-lock.json", LockfileFormat::Npm),
+            ("npm-shrinkwrap.json", LockfileFormat::Npm),
             ("sample.csproj", LockfileFormat::Msbuild),
             ("gradle.lockfile", LockfileFormat::Gradle),
             ("effective-pom.xml", LockfileFormat::Maven),


### PR DESCRIPTION
This adds support for recognizing the `npm-shrinkwrap.json` file as an alternative to the `package-lock.json`.

The file is treated like any other lockfile and if present, the `package-lock.json` will still be analyzed. This should not cause any issues and ensure all potentially used dependencies are analyzed.

Closes #1054.
