### PR TITLE
Remove `merge_group` trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
   # Allow running this workflow manually from the Actions tab
   workflow_dispatch:
   pull_request:
-  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Reverts phylum-dev/cli#1051

We have decided to hold off on using merge queues for now because GitHub does not allow control over how each PR is merged in to the queue (except on a repo-level). We use "Squash and merge" heavily in this repo and often rewrite the commit message during the merge.

_Future note: phylum-dev/cli#1051 should have also removed the `push: branches: [main]` trigger as this was causing CI to run on the same commits that `merge_queue` had already triggered. If we decide to revisit merge queues, we should disable the `push` trigger_