### PR TITLE
Use `npm-shrinkwrap.json` for npm extension

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -33,16 +33,17 @@ npm install my-package  # This will be checked by Phylum!
 
 ## How it works
 
-When invoking `phylum npm`, subcommands that would modify the `package.json` or
-`package-lock.json` files will trigger a Phylum analysis.
+When invoking `phylum npm`, subcommands that would modify the `package.json`,
+`npm-shrinkwrap.json`, or `package-lock.json` files will trigger a Phylum
+analysis.
 
 - If the analysis is successful, the corresponding changes will be applied.
 - If the analysis is unsuccessful because some of the new dependencies don't
   meet the required project thresholds, the command will fail.
 - If the analysis is waiting for Phylum to process one or more of the submitted
   packages, the command will fail and the changes will _not_ be applied.
-- Commands that modify neither `package.json` nor `package-lock.json` will be
-  passed through to `npm` directly.
+- Commands that modify neither `package.json`, `npm-shrinkwrap.json`, nor
+  `package-lock.json` will be passed through to `npm` directly.
 
 [phylum]: https://phylum.io
 [phylum-cli]: https://github.com/phylum-dev/cli

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -89,6 +89,8 @@ if (!root) {
 // Store initial package manager file state.
 const packageLockBackup = new FileBackup(root + "/package-lock.json");
 await packageLockBackup.backup();
+const shrinkwrapBackup = new FileBackup(root + "/npm-shrinkwrap.json");
+await shrinkwrapBackup.backup();
 const manifestBackup = new FileBackup(root + "/package.json");
 await manifestBackup.backup();
 
@@ -185,9 +187,16 @@ async function checkDryRun(subcommand: string, args: string[]) {
     await abort(status.code);
   }
 
+  // Use `npm-shrinkwrap.json` if it is present.
+  let lockfilePath = "./package-lock.json";
+  try {
+      await Deno.stat("./npm-shrinkwrap.json");
+      lockfilePath = "./npm-shrinkwrap.json";
+  } catch (_e) {}
+
   let lockfile;
   try {
-    lockfile = await PhylumApi.parseLockfile("./package-lock.json", "npm");
+    lockfile = await PhylumApi.parseLockfile(lockfilePath, "npm");
   } catch (_e) {
     console.warn(`[${yellow("phylum")}] No lockfile created.\n`);
     return;

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -192,7 +192,9 @@ async function checkDryRun(subcommand: string, args: string[]) {
   try {
     await Deno.stat("./npm-shrinkwrap.json");
     lockfilePath = "./npm-shrinkwrap.json";
-  } catch (_e) {}
+  } catch (_e) {
+    //
+  }
 
   let lockfile;
   try {

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -190,8 +190,8 @@ async function checkDryRun(subcommand: string, args: string[]) {
   // Use `npm-shrinkwrap.json` if it is present.
   let lockfilePath = "./package-lock.json";
   try {
-      await Deno.stat("./npm-shrinkwrap.json");
-      lockfilePath = "./npm-shrinkwrap.json";
+    await Deno.stat("./npm-shrinkwrap.json");
+    lockfilePath = "./npm-shrinkwrap.json";
   } catch (_e) {}
 
   let lockfile;


### PR DESCRIPTION
This will make use of the `npm-shrinkwrap.json` instead of the `package-lock.json` when it is available in an NPM project.
