### PR TITLE
Use --no-self-update for rustup on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable --profile minimal -c clippy
+          rustup toolchain install --no-self-update stable --profile minimal -c clippy
           rustup default stable
 
       - name: Install Rust nightly toolchain
         if: github.event_name != 'schedule'
-        run: rustup toolchain install nightly --profile minimal -c rustfmt
+        run: rustup toolchain install --no-self-update nightly --profile minimal -c rustfmt
 
       - name: Format check
         if: github.event_name != 'schedule'


### PR DESCRIPTION
Self-update on Windows is hard... And rustup occasionally fails to self-update. There is a [related issue][1] to fix this behavior, but until then, using `--no-self-update` is a decent workaround.

[1]: https://github.com/rust-lang/rustup/issues/2441