### PR TITLE
Fix path exists check in FileRelocator

### DIFF
--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -94,7 +94,7 @@ impl Drop for FileRelocator {
 
 impl FileRelocator {
     fn new(path: PathBuf) -> Result<Option<Self>> {
-        if path.exists() {
+        if !path.exists() {
             return Ok(None);
         }
 


### PR DESCRIPTION
The relocator should skip files that don't exist, but was accidentally only skipping the files that do exist...