### PR TITLE
Add `phylum status` command

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -441,6 +441,13 @@ pub fn add_subcommands(command: Command) -> Command {
                     .action(ArgAction::SetTrue),
             ]),
         )
+        .subcommand(
+            Command::new("status").about("Get Phylum project details").args(&[Arg::new("json")
+                .action(ArgAction::SetTrue)
+                .short('j')
+                .long("json")
+                .help("Produce output in json format (default: false)")]),
+        )
         .subcommand(extensions::command());
 
     #[cfg(unix)]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -13,7 +13,7 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, extensions, group, init, jobs, packages, parse, project, CommandResult, ExitCode,
+    auth, extensions, group, init, jobs, packages, parse, project, status, CommandResult, ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;
@@ -152,6 +152,7 @@ async fn handle_commands() -> CommandResult {
             jobs::handle_submission(&mut Spinner::wrap(api).await?, &matches).await
         },
         "init" => init::handle_init(&Spinner::wrap(api).await?, sub_matches).await,
+        "status" => status::handle_status(sub_matches).await,
 
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod parse;
 pub mod project;
 #[cfg(unix)]
 pub mod sandbox;
+pub mod status;
 #[cfg(feature = "selfmanage")]
 pub mod uninstall;
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,0 +1,53 @@
+//! Subcommand `phylum status`.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Local};
+use clap::ArgMatches;
+use phylum_project::LockfileConfig;
+use phylum_types::types::common::ProjectId;
+use serde::Serialize;
+
+use crate::commands::{CommandResult, ExitCode};
+use crate::config;
+use crate::format::Format;
+
+pub async fn handle_status(matches: &ArgMatches) -> CommandResult {
+    let pretty_print = !matches.get_flag("json");
+    let status = PhylumStatus::new(matches);
+    status.write_stdout(pretty_print);
+    Ok(ExitCode::Ok)
+}
+
+#[derive(Serialize, Default)]
+pub struct PhylumStatus {
+    pub lockfiles: Vec<LockfileConfig>,
+    pub project: Option<String>,
+    pub group: Option<String>,
+    pub root: Option<PathBuf>,
+
+    // JSON-only fields:
+    created_at: Option<DateTime<Local>>,
+    id: Option<ProjectId>,
+}
+
+impl PhylumStatus {
+    fn new(matches: &ArgMatches) -> Self {
+        let mut status = PhylumStatus::default();
+        let project = phylum_project::get_current_project();
+
+        // Add lockfiles.
+        status.lockfiles = config::lockfiles(matches, project.as_ref()).unwrap_or_default();
+
+        // Popuplate project details.
+        if let Some(project) = project {
+            status.created_at = Some(project.created_at);
+            status.root = Some(project.root().clone());
+            status.project = Some(project.name);
+            status.group = project.group_name;
+            status.id = Some(project.id);
+        }
+
+        status
+    }
+}

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -39,7 +39,7 @@ impl PhylumStatus {
         // Add lockfiles.
         status.lockfiles = config::lockfiles(matches, project.as_ref()).unwrap_or_default();
 
-        // Popuplate project details.
+        // Populate project details.
         if let Some(project) = project {
             status.created_at = Some(project.created_at);
             status.root = Some(project.root().clone());

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -179,16 +179,16 @@ pub fn lockfiles(
     project: Option<&ProjectConfig>,
 ) -> Result<Vec<LockfileConfig>> {
     let cli_lockfile_type = matches.try_get_one::<String>("lockfile-type").unwrap_or(None);
-    let cli_lockfiles = matches.get_many::<String>("lockfile");
+    let cli_lockfiles = matches.try_get_many::<String>("lockfile");
 
     match cli_lockfiles {
-        Some(cli_lockfiles) => {
+        Ok(Some(cli_lockfiles)) => {
             let lockfile_type = cli_lockfile_type.cloned().unwrap_or_else(|| "auto".into());
             Ok(cli_lockfiles
                 .map(|lockfile| LockfileConfig::new(lockfile, lockfile_type.clone()))
                 .collect())
         },
-        None => {
+        _ => {
             // Try the project file first.
             let project_lockfiles = project.map(|project| project.lockfiles());
 

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -79,14 +79,6 @@ impl Format for PhylumStatus {
         }
     }
 }
-// pub struct PhylumStatus {
-//     pub lockfiles: Vec<LockfileConfig>,
-//     pub project: Option<String>,
-//     pub group: Option<String>,
-//     pub root: Option<PathBuf>,
-//     // pub created_at: DateTime<Local>,
-//     // pub id: ProjectId,
-// }
 
 impl Format for PolicyEvaluationResponse {
     fn pretty<W: Write>(&self, writer: &mut W) {

--- a/docs/command_line_tool/phylum.md
+++ b/docs/command_line_tool/phylum.md
@@ -45,6 +45,7 @@ Usage: phylum [OPTIONS] [COMMAND]
 * [phylum version](./phylum_version)
 * [phylum group](./phylum_group)
 * [phylum init](./phylum_init)
+* [phylum status](./phylum_status)
 * [phylum extension](./phylum_extension)
 * [phylum uninstall](./phylum_uninstall)
 * [phylum update](./phylum_update)

--- a/docs/command_line_tool/phylum_status.md
+++ b/docs/command_line_tool/phylum_status.md
@@ -1,0 +1,25 @@
+---
+title: phylum status
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Get Phylum project details
+
+```sh
+Usage: phylum status [OPTIONS]
+```
+
+### Options
+
+-j, --json
+&emsp; Produce output in json format (default: false)
+
+-v, --verbose...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+-q, --quiet...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+-h, --help
+&emsp; Print help

--- a/phylum_project/src/lib.rs
+++ b/phylum_project/src/lib.rs
@@ -78,6 +78,11 @@ impl ProjectConfig {
     pub fn set_lockfiles(&mut self, lockfiles: Vec<LockfileConfig>) {
         self.lockfiles = lockfiles;
     }
+
+    /// Get project's root directory.
+    pub fn root(&self) -> &PathBuf {
+        &self.root
+    }
 }
 
 /// Lockfile metadata.


### PR DESCRIPTION
This patch introduces a new subcommand which allows printing information
about the current project and lockfiles.

Closes #842.
Closes #982.