### PR TITLE
Use Deno.Command instead of Deno.run

### DIFF
--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -107,7 +107,8 @@ fn incorrect_run_permission() {
     #[rustfmt::skip]
     test_cli
         .extension("
-            const output = await Deno.run({ cmd: ['echo', 'hello'] });
+            const cmd = new Deno.Command('echo', { args: ['hello'] });
+            const output = await cmd.spawn().status;
             Deno.exit(output.code);
         ")
         .with_permissions(Permissions {
@@ -127,7 +128,8 @@ fn correct_run_permission() {
     #[rustfmt::skip]
     test_cli
         .extension("
-            const output = await Deno.run({ cmd: ['echo', 'hello'] });
+            const cmd = new Deno.Command('echo', { args: ['hello'] });
+            const output = await cmd.spawn().status;
             Deno.exit(output.code);
         ")
         .with_permissions(Permissions {

--- a/docs/extensions/extension_manifest.md
+++ b/docs/extensions/extension_manifest.md
@@ -182,7 +182,7 @@ Unsandboxed run permissions list executable paths which can be executed without
 **any** sandboxing restrictions. This means they can execute arbitrary code even
 beyond the requested manifest permissions.
 
-This permission is required for executing paths with `Deno.run`.
+This permission is required for executing paths with `Deno.Command`.
 
 See [run](#run) for more details.
 

--- a/docs/extensions/extension_sandboxing.md
+++ b/docs/extensions/extension_sandboxing.md
@@ -59,7 +59,7 @@ allows for a boolean value.
 ## Limitations
 
 The `PhylumApi.runSandboxed` method is the only recommended means of spawning
-child processes from an extension. The `Deno.run` method should be avoided
+child processes from an extension. The `Deno.Command` method should be avoided
 in order to prevent extensions from escaping the sandbox, and will be disabled
 in a future version.
 

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -69,8 +69,8 @@ if (
     "udpate".startsWith(Deno.args[0])
   )
 ) {
-  const cmd = Deno.run({ cmd: ["npm", ...Deno.args] });
-  const status = await cmd.status();
+  const cmd = new Deno.Command("npm", { args: Deno.args });
+  const status = await cmd.spawn().status;
   Deno.exit(status.code);
 }
 
@@ -105,13 +105,13 @@ try {
 console.log(`[${green("phylum")}] Installing without build scripts…`);
 
 // Install packages without executing build scripts.
-const cmd = Deno.run({
-  cmd: ["npm", ...Deno.args, "--ignore-scripts"],
+const cmd = new Deno.Command("npm", {
+  args: [...Deno.args, "--ignore-scripts"],
   stdout: "inherit",
   stderr: "inherit",
   stdin: "inherit",
 });
-const status = await cmd.status();
+const status = await cmd.spawn().status;
 
 // Ensure install worked. Failure is still "safe" for the user.
 if (!status.success) {
@@ -167,9 +167,8 @@ if (!output.success) {
 async function checkDryRun(subcommand: string, args: string[]) {
   console.log(`[${green("phylum")}] Updating lockfile…`);
 
-  const cmd = Deno.run({
-    cmd: [
-      "npm",
+  const cmd = new Deno.Command("npm", {
+    args: [
       subcommand,
       "--package-lock-only",
       "--ignore-scripts",
@@ -179,7 +178,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     stderr: "inherit",
     stdin: "inherit",
   });
-  const status = await cmd.status();
+  const status = await cmd.spawn().status;
 
   // Ensure lockfile update was successful.
   if (!status.success) {

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -42,8 +42,8 @@ if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
 
 // Ignore all commands that shouldn't be intercepted.
 if (Deno.args.length == 0 || subcommand != "install") {
-  const cmd = Deno.run({ cmd: ["pip3", ...Deno.args] });
-  const status = await cmd.status();
+  const cmd = new Deno.Command("pip3", { args: Deno.args });
+  const status = await cmd.spawn().status;
   Deno.exit(status.code);
 }
 

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -72,8 +72,8 @@ if (
   Deno.args.length == 0 ||
   !["add", "update", "install"].includes(Deno.args[0])
 ) {
-  const cmd = Deno.run({ cmd: ["poetry", ...Deno.args] });
-  const status = await cmd.status();
+  const cmd = new Deno.Command("poetry", { args: Deno.args });
+  const status = await cmd.spawn().status;
   Deno.exit(status.code);
 }
 
@@ -95,8 +95,8 @@ if (!root) {
 await poetryCheckDryRun(Deno.args[0], Deno.args.slice(1));
 
 // Execute install without sandboxing after successful analysis.
-const cmd = Deno.run({ cmd: ["poetry", ...Deno.args] });
-const status = await cmd.status();
+const cmd = new Deno.Command("poetry", { args: Deno.args });
+const status = await cmd.spawn().status;
 Deno.exit(status.code);
 
 // Analyze new packages.

--- a/extensions/poetry/tests.ts
+++ b/extensions/poetry/tests.ts
@@ -30,16 +30,15 @@ class Phylum {
   }
 
   async run(args: string[], cwd?: string) {
-    const process = Deno.run({
-      cmd: ["phylum", ...args],
+    const process = new Deno.Command("phylum", {
+      args,
       env: { XDG_DATA_HOME: this.tempDir },
       cwd,
       stdout: "inherit",
       stderr: "inherit",
     });
 
-    const status = await process.status();
-    process.close();
+    const status = await process.spawn().status;
 
     return status;
   }

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -129,8 +129,8 @@ if (
   Deno.args.length == 0 ||
   !["add", "install", "up", "dedupe"].includes(Deno.args[0])
 ) {
-  const cmd = Deno.run({ cmd: ["yarn", ...Deno.args] });
-  const status = await cmd.status();
+  const cmd = new Deno.Command("yarn", { args: Deno.args });
+  const status = await cmd.spawn().status;
   Deno.exit(status.code);
 }
 


### PR DESCRIPTION
`Deno.run` is deprecated as of deno v1.33.0. This patch updates our extensions to use the preferred `Deno.Command` API