### PR TITLE
Improve Birdcage errors on Linux

### DIFF
--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -3,7 +3,10 @@
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{anyhow, Result};
+#[cfg(target_os = "linux")]
+use anyhow::{Context, Error};
+#[cfg(target_os = "linux")]
 use birdcage::error::Error as SandboxError;
 use birdcage::{Birdcage, Exception, Sandbox};
 use clap::ArgMatches;

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -56,7 +56,7 @@ fn lock_process(matches: &ArgMatches) -> Result<()> {
         Ok(birdcage) => birdcage,
         #[cfg(target_os = "linux")]
         Err(err @ SandboxError::Ruleset(_)) => {
-            return Err(Error::from(err)).context("sandbox requires Linux 5.13+");
+            return Err(Error::from(err)).context("sandbox requires Linux kernel 5.13+");
         },
         Err(err) => return Err(err.into()),
     };

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -3,7 +3,8 @@
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Error, Result};
+use birdcage::error::Error as SandboxError;
 use birdcage::{Birdcage, Exception, Sandbox};
 use clap::ArgMatches;
 
@@ -44,8 +45,18 @@ pub async fn handle_sandbox(matches: &ArgMatches) -> CommandResult {
 /// Lock down the current process.
 #[cfg(unix)]
 fn lock_process(matches: &ArgMatches) -> Result<()> {
-    let mut birdcage =
-        if matches.get_flag("strict") { Birdcage::new()? } else { permissions::default_sandbox()? };
+    let birdcage =
+        if matches.get_flag("strict") { Birdcage::new() } else { permissions::default_sandbox() };
+
+    // Provide additional error context.
+    let mut birdcage = match birdcage {
+        Ok(birdcage) => birdcage,
+        #[cfg(target_os = "linux")]
+        Err(err @ SandboxError::Ruleset(_)) => {
+            return Err(Error::from(err)).context("sandbox requires Linux 5.13+");
+        },
+        Err(err) => return Err(err.into()),
+    };
 
     // Apply filesystem exceptions.
     for path in matches.get_many::<String>("allow-read").unwrap_or_default() {


### PR DESCRIPTION
This patch provides a more verbose error message when creating the sandbox fails on Linux.

While it is possible that this error occurs while on Linux kernel 5.13+, this is the most likely culprit, so it is the most realistic way a user can figure out a solution by themselves.