### PR TITLE
Remove release summary

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -18,9 +18,6 @@ printf "version (w/o a leading 'v'): "
 read -r version
 TAG=v${version}
 
-printf "One line summary: "
-read -r summary
-
 today=$(date '+%Y-%m-%d')
 printf "\nUpdating CHANGELOG, bumping version, running 'cargo check', and adding files for commit ...\n\n"
 sed -i'.bak' "s/\(## \[Unreleased\]\)/\1\n\n## \[${version}\] - ${today}/" CHANGELOG.md
@@ -39,7 +36,7 @@ sed -i'.bak' "s/\(## Unreleased\)/\1\n\n## ${version} - ${today}/" extensions/CH
 rm extensions/CHANGELOG.md.bak
 git add extensions/CHANGELOG.md
 
-commit_message="Bump to ${TAG} - ${summary}"
+commit_message="Bump to ${TAG}"
 printf "\nFiles to be added and committed with message: \"%s\"\n\n" "${commit_message}"
 git status
 
@@ -50,7 +47,6 @@ git commit -F - <<EOF
 ${commit_message}
 
 Release-Version: ${TAG}
-Release-Summary: ${summary}
 EOF
 
 git log --pretty=fuller -1

--- a/tag.sh
+++ b/tag.sh
@@ -26,7 +26,6 @@ if [ -z "${TAG_COMMIT}" ]; then
 fi
 
 TAG=$(git log --pretty="format:%(trailers:key=release-version,valueonly)" -1 "${TAG_COMMIT}")
-SUMMARY=$(git log --pretty="format:%(trailers:key=release-summary,valueonly)" -1 "${TAG_COMMIT}")
 
 if git show "tags/${TAG}" > /dev/null 2>&1; then
     echo "Tag ${TAG} already exists!" >&2
@@ -52,7 +51,7 @@ if [ -z "${SKIP_ORIGIN_HEAD_CHECK:-}" ]; then
     fi
 fi
 
-git tag --sign -m "${TAG} - ${SUMMARY}" "${TAG}" "${TAG_COMMIT}"
+git tag --sign -m "Phylum CLI ${TAG}" "${TAG}" "${TAG_COMMIT}"
 
 printf "\nOutput of the command: git show %s\n" "${TAG}"
 git show "${TAG}"


### PR DESCRIPTION
Now that we have a more detailed changelog, the one line summary is only used for the release commit and the tag message. But those aren't great places to explain a release.