### PR TITLE
Use `skip-build` mode for yarn lockfile generation

### DIFF
--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -239,7 +239,7 @@ async function checkDryRun() {
 
   const status = PhylumApi.runSandboxed({
     cmd: "yarn",
-    args: [...Deno.args, "--mode=update-lockfile"],
+    args: [...Deno.args, "--mode=skip-build", "--mode=update-lockfile"],
     exceptions: {
       read: true,
       write: ["~/.cache/node", "~/.cache/yarn", "~/.yarn", "./", "/tmp"],

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -13,7 +13,7 @@ impl Generator for Yarn {
 
     fn command(&self) -> Command {
         let mut command = Command::new("yarn");
-        command.args(["install", "--mode=update-lockfile"]);
+        command.args(["install", "--mode=skip-build", "--mode=update-lockfile"]);
         command
     }
 }


### PR DESCRIPTION
This patch adds the `--mode=skip-build` argument to the already existing `--mode=update-lockfile` argument when generating lockfiles for yarn.

While the output is identical for both commands, adding the `skip-build` mode does speed up generation time and thus likely provides benefits even with the lockfile mode already provided.
