### PR TITLE
docs: update `yarn` extension usage

### DIFF
--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -21,14 +21,14 @@ phylum extension install cli/extensions/yarn
 Prepend `phylum` to your `yarn` command invocations:
 
 ```console
-phylum yarn install my-package  # This will be checked by Phylum!
+phylum yarn add my-package  # This will be checked by Phylum!
 ```
 
 Or set up an alias in your shell to make it transparent:
 
 ```console
 alias yarn="phylum yarn"
-yarn install my-package  # This will be checked by Phylum!
+yarn add my-package  # This will be checked by Phylum!
 ```
 
 ## How it works


### PR DESCRIPTION
The command used in the `yarn` extension docs for usage was not correct. It specified `yarn install my-package`, which results in an error:

`Unknown Syntax Error: Extraneous positional argument ("<my-package>")`

Indeed, the docs for [yarn install](https://yarnpkg.com/cli/install) do not indicate a package to be specified on the command line. The correct command is `yarn add`, which does take a package on the command line.
