### PR TITLE
Improve generator process creation error

### DIFF
--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{fs, io};
@@ -52,13 +51,8 @@ pub trait Generator {
 
         // Provide better error message, including the failed program's name.
         let mut child = command.spawn().map_err(|err| {
-            // Collect program and args for error message.
-            let mut cmdline = format!("{:?}", command.get_program());
-            for arg in command.get_args() {
-                let _ = write!(cmdline, " {arg:?}");
-            }
-
-            Error::ProcessCreation(cmdline, err)
+            let program = format!("{:?}", command.get_program());
+            Error::ProcessCreation(program, err)
         })?;
 
         // Ensure generation was successful.

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -117,7 +117,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
-    #[error("failed to run command {0}: {1}")]
+    #[error("failed to spawn command {0}: {1}")]
     ProcessCreation(String, io::Error),
     #[error("package manager exited with non-zero status")]
     NonZeroExit,


### PR DESCRIPTION
This patch changes the error generated during lockfile generation when the ecosystem's package manager subprocess could not be spawned successfully.

Instead of printing the full debug formatting of the command, just the program and its argument are printed.

Closes #1084.

---

New error message example:

```
Generating lockfile for manifest "./requirements.txt" using Pip…
❗ Error: failed to spawn command "pip-compile": No such file or directory (os error 2)
```
