### PR TITLE
Fix npm install from other node_modules

### DIFF
--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -53,6 +53,10 @@ impl Parse for PackageLock {
                 // Since we care more about the name of a local dependency than its package, we
                 // discard the version here and include the package later when it's mentioned by
                 // name.
+                if !name.starts_with("node_modules/") {
+                    continue;
+                }
+
                 let name = match name.rsplit_once("node_modules/") {
                     Some((_, name)) => name,
                     None => continue,
@@ -282,7 +286,7 @@ mod tests {
         let pkgs =
             PackageLock.parse(include_str!("../../tests/fixtures/package-lock.json")).unwrap();
 
-        assert_eq!(pkgs.len(), 54);
+        assert_eq!(pkgs.len(), 55);
 
         let expected_pkgs = [
             Package {
@@ -320,6 +324,11 @@ mod tests {
             Package {
                 name: "test".into(),
                 version: PackageVersion::Path(Some("../test".into())),
+                package_type: PackageType::Npm,
+            },
+            Package {
+                name: "parentlink".into(),
+                version: PackageVersion::Path(Some("../node_modules/parentlink".into())),
                 package_type: PackageType::Npm,
             },
         ];

--- a/tests/fixtures/package-lock.json
+++ b/tests/fixtures/package-lock.json
@@ -20,6 +20,14 @@
       "resolved": "../test",
       "link": true
     },
+    "../node_modules/parentlink": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/parentlink": {
+      "resolved": "../node_modules/parentlink",
+      "link": true
+    },
     "node_modules/typescript": {
       "version": "4.9.0",
       "resolved": "git+ssh://git@github.com/Microsoft/TypeScript.git#9189e42b1c8b1a91906a245a24697da5e0c11a08",


### PR DESCRIPTION
Some projects install packages from a top level `node_modules` folder, resulting in dependencies like this one:

```
  "typescript": "file:../node_modules/typescript",
```

This was confusing our `package-lock.json` parser and causing an error such as: `Dependency 'typescript' is missing "resolved" key`

_Note_: While this patch fixes the error, this is still a filesystem dependency and will not be analyzed. Projects that use this pattern must ensure that they also submit the top-level `package-lock.json` (which contains details about where the package came from) in order to avoid missing dependencies.