### PR TITLE
docs: update manifest generation list and language

### DIFF
--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -30,9 +30,9 @@ The Phylum CLI natively supports processing lockfiles for several ecosystems, na
   * `*.spdx.yml`
   * `*.spdx`
 
-Lockfiles can also automatically be generated for the certain manifest files.
+Lockfiles can also automatically be generated for certain manifest files.
 Doing so requires that a specific tool is installed and available in the environment.
-The current list of supported manifests, with their required lockfile generator tool are:
+The current list of supported manifests, with their required lockfile generation tool are:
 
 * npm
   * `package.json` using either `npm` or `yarn`

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -9,12 +9,12 @@ The Phylum CLI natively supports processing lockfiles for several ecosystems, na
   * `package-lock.json`
   * `npm-shrinkwrap.json`
   * `yarn.lock` (Version 1 + 2)
-* RubyGems
-  * `Gemfile.lock`
 * PyPI
   * `requirements.txt`
   * `Pipfile.lock`
   * `poetry.lock` (Version 1 + 2)
+* RubyGems
+  * `Gemfile.lock`
 * NuGet
   * `*.csproj`
 * Maven
@@ -30,22 +30,31 @@ The Phylum CLI natively supports processing lockfiles for several ecosystems, na
   * `*.spdx.yml`
   * `*.spdx`
 
-When the ecosystem's package manager is available, it can also automatically
-generate lockfiles for the following manifest files:
+Lockfiles can also automatically be generated for the certain manifest files.
+Doing so requires that a specific tool is installed and available in the environment.
+The current list of supported manifests, with their required lockfile generator tool are:
 
 * npm
-    * `package.json` using either `npm` or `yarn`
-* PyPi
-    * `requirements.txt` using `pip-compile`
-    * `Pipfile` using `pipenv`
-    * `pyproject.toml` using `poetry`
+  * `package.json` using either `npm` or `yarn`
+* PyPI
+  * `requirements*.txt` using `pip-compile`
+  * `requirements.in` using `pip-compile`
+  * `setup.py` using `pip-compile`
+  * `setup.cfg` using `pip-compile`
+  * `pyproject.toml` using `pip-compile`
+    * When lockfile type is `pip`
+  * `Pipfile` using `pipenv`
+  * `pyproject.toml` using `poetry`
+    * When lockfile type is `poetry`
+* RubyGems
+  * `Gemfile` using `bundle`
 * Maven
-    * `pom.xml` using `mvn`
-    * `build.gradle` using `gradle`
+  * `pom.xml` using `mvn`
+  * `build.gradle` using `gradle`
 * Golang
-    * `go.sum` using `go`
+  * `go.mod` using `go`
 * Cargo
-    * `Cargo.toml` using `cargo`
+  * `Cargo.toml` using `cargo`
 
 After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_init), you can begin analysis by running:
 

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -35,7 +35,10 @@ Doing so requires that a specific tool is installed and available in the environ
 The current list of supported manifests, with their required lockfile generation tool are:
 
 * npm
-  * `package.json` using either `npm` or `yarn`
+  * `package.json` using `npm`
+    * When lockfile type is `npm`
+  * `package.json` using `yarn`
+    * When lockfile type is `yarn`
 * PyPI
   * `requirements*.txt` using `pip-compile`
   * `requirements.in` using `pip-compile`


### PR DESCRIPTION
Some manifests were listed incorrectly. Some were missing. They have been updated to the current state. The language around the manifest generation was also updated to make it more clear that the tools used to perform the lockfile generation are required to be installed and available in the environment where the CLI is run. Finally, the list of lockfiles was updated to follow the same sequence as the manifest files. The output from the `phylum analyze` command on this document is still wrong but changing it now was purposefully eschewed.
