### PR TITLE
Improve lockfile generator help output

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -96,7 +96,7 @@ pub fn parse_lockfile(
     eprintln!("Generating lockfile for manifest {path:?} using {format:?}…");
 
     // Generate a new lockfile.
-    let generated_lockfile = generator.generate_lockfile(&path)?;
+    let generated_lockfile = generator.generate_lockfile(&path).context("Lockfile generation failed! For details, see: https://docs.phylum.io/docs/lockfile-generation")?;
 
     // Parse the generated lockfile.
     let packages = parse_lockfile_content(&generated_lockfile, parser)?;

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -30,34 +30,9 @@ The Phylum CLI natively supports processing lockfiles for several ecosystems, na
   * `*.spdx.yml`
   * `*.spdx`
 
-Lockfiles can also automatically be generated for certain manifest files.
-Doing so requires that a specific tool is installed and available in the environment.
-The current list of supported manifests, with their required lockfile generation tool are:
+Lockfiles can also automatically be generated for certain manifest files. See [lockfile-generation][] for details.
 
-* npm
-  * `package.json` using `npm`
-    * When lockfile type is `npm`
-  * `package.json` using `yarn`
-    * When lockfile type is `yarn`
-* PyPI
-  * `requirements*.txt` using `pip-compile`
-  * `requirements.in` using `pip-compile`
-  * `setup.py` using `pip-compile`
-  * `setup.cfg` using `pip-compile`
-  * `pyproject.toml` using `pip-compile`
-    * When lockfile type is `pip`
-  * `Pipfile` using `pipenv`
-  * `pyproject.toml` using `poetry`
-    * When lockfile type is `poetry`
-* RubyGems
-  * `Gemfile` using `bundle`
-* Maven
-  * `pom.xml` using `mvn`
-  * `build.gradle` using `gradle`
-* Golang
-  * `go.mod` using `go`
-* Cargo
-  * `Cargo.toml` using `cargo`
+[lockfile-generation]: https://docs.phylum.io/docs/lockfile-generation
 
 After setting up a Phylum [project](https://docs.phylum.io/docs/phylum_init), you can begin analysis by running:
 

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -4,31 +4,25 @@ category: 6255e67693d5200013b1fa41
 hidden: false
 ---
 
-The Phylum CLI natively supports processing lockfiles for several ecosystems, namely:
-* npm
-  * `package-lock.json`
-  * `npm-shrinkwrap.json`
-  * `yarn.lock` (Version 1 + 2)
-* PyPI
-  * `requirements.txt`
-  * `Pipfile.lock`
-  * `poetry.lock` (Version 1 + 2)
-* RubyGems
-  * `Gemfile.lock`
-* NuGet
-  * `*.csproj`
-* Maven
-  * `effective-pom.xml`
-  * `gradle.lockfile`
-* Golang
-  * `go.sum`
-* Cargo
-  * `Cargo.lock`
-* SPDX (Version 2.2 + 2.3)
-  * `*.spdx.json`
-  * `*.spdx.yaml`
-  * `*.spdx.yml`
-  * `*.spdx`
+The Phylum CLI supports processing many different lockfiles:
+
+| Lockfile type | Filenames |
+| ------------- | --------- |
+| `npm`         | `package-lock.json` <br /> `npm-shrinkwrap.json` |
+| `yarn`        | `yarn.lock` (Version 1 + 2) |
+| `pip`         | `requirements*.txt` |
+| `pipenv`      | `Pipfile.lock` |
+| `poetry`      | `poetry.lock` (Version 1 + 2) |
+| `gem`         | `Gemfile.lock` |
+| `nuget`       | `*.csproj` |
+| `mvn`         | `effective-pom.xml` |
+| `gradle`      | `gradle.lockfile` |
+| `go`          | `go.sum` |
+| `cargo`       | `Cargo.lock` |
+| `spdx`        | `*.spdx.json` <br /> `*.spdx.yaml` <br /> `*.spdx.yml` <br /> `*.spdx` |
+
+The lockfile type will be automatically detected based on the filename. If needed, this can be overridden with the
+`--lockfile-type` (`-t`) option.
 
 Lockfiles can also automatically be generated for certain manifest files. See [lockfile-generation][] for details.
 

--- a/docs/knowledge_base/lockfile-generation.md
+++ b/docs/knowledge_base/lockfile-generation.md
@@ -8,18 +8,29 @@ The Phylum CLI uses lockfile generators when it is given a manifest file with no
 
 ### Lockfile generators
 
-| Lockfile type | Filenames        | Required tool |
-| ------------- | ---------        | ------------- |
-| `npm`         | `package.json`   | `npm`         |
-| `yarn`        | `package.json`   | `yarn`        |
-| `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `setup.cfg` <br/> `pyproject.toml` | `pip-compile` (from `pip-tools`) |
-| `pipenv`      | `Pipfile`        | `pipenv`      |
-| `poetry`      | `pyproject.toml` | `poetry`      |
-| `gem`         | `Gemfile`        | `bundle` (from Bundler) |
-| `maven`       | `pom.xml`        | `mvn` (from Maven) |
-| `gradle`      | `build.gradle`   | `gradle`      |
-| `go`          | `go.mod`         | `go`          |
-| `cargo`       | `Cargo.toml`     | `cargo`       |
+| Lockfile type | Filenames        | Required tool               |
+| ------------- | ---------        | -------------               |
+| `npm`         | `package.json`   | [`npm`][npm]                |
+| `yarn`        | `package.json`   | [`yarn`][yarn]              |
+| `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `setup.cfg` <br/> `pyproject.toml` | `pip-compile` (from [`pip-tools`][pip-tools]) |
+| `pipenv`      | `Pipfile`        | [`pipenv`][pipenv]          |
+| `poetry`      | `pyproject.toml` | [`poetry`][poetry]          |
+| `gem`         | `Gemfile`        | `bundle` (from [Bundler][]) |
+| `mvn`         | `pom.xml`        | `mvn` (from [Maven][])      |
+| `gradle`      | `build.gradle`   | [`gradle`][gradle]          |
+| `go`          | `go.mod`         | [`go`][go]                  |
+| `cargo`       | `Cargo.toml`     | [`cargo`][cargo]            |
+
+[npm]: https://nodejs.org/
+[yarn]: https://yarnpkg.com/
+[pip-tools]: https://github.com/jazzband/pip-tools/
+[pipenv]: https://github.com/pypa/pipenv
+[poetry]: https://python-poetry.org/
+[bundler]: https://bundler.io/
+[maven]: https://maven.apache.org/
+[gradle]: https://gradle.org/
+[go]: https://go.dev/
+[cargo]: https://www.rust-lang.org/
 
 For files that can be handled by multiple generators, a fallback is used:
 

--- a/docs/knowledge_base/lockfile-generation.md
+++ b/docs/knowledge_base/lockfile-generation.md
@@ -1,0 +1,58 @@
+---
+title: Lockfile Generation
+category: 6255e67693d5200013b1fa41
+hidden: false
+---
+
+The Phylum CLI uses lockfile generators when it is given a manifest file with no matching lockfile.
+
+### Lockfile generators
+
+| Lockfile type | Filenames        | Required tool |
+| ------------- | ---------        | ------------- |
+| `npm`         | `package.json`   | `npm`         |
+| `yarn`        | `package.json`   | `yarn`        |
+| `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `setup.cfg` <br/> `pyproject.toml` | `pip-compile` (from `pip-tools`) |
+| `pipenv`      | `Pipfile`        | `pipenv`      |
+| `poetry`      | `pyproject.toml` | `poetry`      |
+| `gem`         | `Gemfile`        | `bundle` (from Bundler) |
+| `maven`       | `pom.xml`        | `mvn` (from Maven) |
+| `gradle`      | `build.gradle`   | `gradle`      |
+| `go`          | `go.mod`         | `go`          |
+| `cargo`       | `Cargo.toml`     | `cargo`       |
+
+For files that can be handled by multiple generators, a fallback is used:
+
+* `package.json` will use `npm`
+* `pyproject.toml` will use `poetry`
+
+This can be overridden on the command line with the `--lockfile-type` (`-t`) option. For example:
+
+```
+phylum analyze -t yarn package.json
+```
+
+### Lockifests
+
+Special handling is given to manifests that, for historical reasons, can also be used as lockfiles. Specifically,
+Python's `requirements.txt` is a manifest file. But in some scenarios it may be fully specified and effectively becomes
+a lockfile (e.g., `pip freeze > requirements.txt`).
+
+Phylum handles these files by first attempting to analyze them as a lockfile. If anything in the file is not fully
+specified, this will fail, and Phylum will silence the error and proceed to lockfile generation.
+
+### Example scenario
+
+1. A user runs `phylum analyze package.json`
+2. The CLI checks for the existence of a matching lockfile
+   (i.e., `package-lock.json`, `npm-shrinkwrap.json`, or `yarn.lock`)
+3. If a matching lockfile is found, that file will be used instead
+4. If no matching lockfile is found, proceed to manifest file generation
+5. Since no `--lockfile-type` was specified, the fallback will be used (in this case, `npm`)
+6. The lockfile generator runs this command to generate a lockfile:
+   ```
+   npm install --package-lock-only --ignore-scripts
+   ```
+7. The output lockfile (`package-lock.json`) is [analyzed][analyzing-dependencies]
+
+[analyzing-dependencies]: https://docs.phylum.io/docs/analyzing-dependencies

--- a/docs/knowledge_base/lockfile-generation.md
+++ b/docs/knowledge_base/lockfile-generation.md
@@ -4,7 +4,7 @@ category: 6255e67693d5200013b1fa41
 hidden: false
 ---
 
-The Phylum CLI uses lockfile generators when it is given a manifest file with no matching lockfile.
+The Phylum CLI can generate a lockfile when it is given a manifest file.
 
 ### Lockfile generators
 
@@ -42,6 +42,21 @@ This can be overridden on the command line with the `--lockfile-type` (`-t`) opt
 ```
 phylum analyze -t yarn package.json
 ```
+
+### Lockfile detection
+
+The Phylum CLI prefers to work directly with lockfiles if they are available. So in a few cases, the CLI will
+automatically switch and use the corresponding lockfile.
+
+First, if a user runs `parse` or `analyze` on a manifest file without specifying a lockfile type, the Phylum CLI will
+opportunistically switch to the lockfile if it is available in the same directory. For example, `phylum analyze go.mod`
+will automatically switch to `go.sum` if available. To override this, simply specify a lockfile type (i.e., `phylum
+analyze -t go go.mod`)
+
+Second, during automatic lockfile detection, manifest files will only be used if there is no corresponding lockfile in
+the same directory or any parent directory. For example, a single `Cargo.lock` file at the root of the repository will
+be used instead of looking at any `Cargo.toml` files anywhere in the repository. To avoid this, run `phylum init` and
+specify all files that you want analyzed.
 
 ### Lockifests
 

--- a/lockfile_generator/src/bundler.rs
+++ b/lockfile_generator/src/bundler.rs
@@ -17,4 +17,8 @@ impl Generator for Bundler {
         command.args(["lock"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Bundler"
+    }
 }

--- a/lockfile_generator/src/cargo.rs
+++ b/lockfile_generator/src/cargo.rs
@@ -17,4 +17,8 @@ impl Generator for Cargo {
         command.args(["generate-lockfile"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Cargo"
+    }
 }

--- a/lockfile_generator/src/go.rs
+++ b/lockfile_generator/src/go.rs
@@ -17,4 +17,8 @@ impl Generator for Go {
         command.args(["get", "-d"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Go"
+    }
 }

--- a/lockfile_generator/src/gradle.rs
+++ b/lockfile_generator/src/gradle.rs
@@ -17,4 +17,8 @@ impl Generator for Gradle {
         command.args(["dependencies", "--write-locks"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Gradle"
+    }
 }

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -129,15 +129,23 @@ pub enum Error {
     NoLockfileGenerated,
 }
 
-impl StdError for Error {}
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::ProcessCreation(_, err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io(err) => write!(f, "I/O error: {err}"),
+            Self::Io(_) => write!(f, "I/O error"),
             Self::InvalidManifest(path) => write!(f, "invalid manifest path: {path:?}"),
-            Self::ProcessCreation(program, err) => {
-                write!(f, "failed to spawn command {program}: {err}")
+            Self::ProcessCreation(program, _) => {
+                write!(f, "failed to spawn command {program}")
             },
             Self::NonZeroExit(Some(code), stderr) => {
                 write!(f, "package manager exited with error code {code}:\n\n{stderr}")

--- a/lockfile_generator/src/maven.rs
+++ b/lockfile_generator/src/maven.rs
@@ -17,4 +17,8 @@ impl Generator for Maven {
         command.args(["help:effective-pom", &format!("-Doutput={}", self.lockfile_name())]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Maven"
+    }
 }

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -21,4 +21,8 @@ impl Generator for Npm {
         command.args(["install", "--package-lock-only", "--ignore-scripts"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "npm"
+    }
 }

--- a/lockfile_generator/src/pip_tools.rs
+++ b/lockfile_generator/src/pip_tools.rs
@@ -17,4 +17,8 @@ impl Generator for PipTools {
         command.arg("-o").arg(self.lockfile_name()).arg(manifest_path);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "pip-tools"
+    }
 }

--- a/lockfile_generator/src/pipenv.rs
+++ b/lockfile_generator/src/pipenv.rs
@@ -17,4 +17,8 @@ impl Generator for Pipenv {
         command.args(["lock"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Pipenv"
+    }
 }

--- a/lockfile_generator/src/poetry.rs
+++ b/lockfile_generator/src/poetry.rs
@@ -17,4 +17,8 @@ impl Generator for Poetry {
         command.args(["lock"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Poetry"
+    }
 }

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -17,4 +17,8 @@ impl Generator for Yarn {
         command.args(["install", "--mode=skip-build", "--mode=update-lockfile"]);
         command
     }
+
+    fn tool(&self) -> &'static str {
+        "Yarn"
+    }
 }


### PR DESCRIPTION
WIP to close #1095 

```
> ./target/debug/phylum parse requirements.txt     
Generating lockfile for manifest "requirements.txt" using Pip…
❗ Error: Lockfile generation failed! For details, see: https://docs.phylum.io/docs/lockfile-generation

Caused by:
    0: failed to spawn command "pip-compile": Is pip-tools installed?
    1: No such file or directory (os error 2)
```