### PR TITLE
Remove setup.cfg as a manifest

### DIFF
--- a/docs/knowledge_base/lockfile-generation.md
+++ b/docs/knowledge_base/lockfile-generation.md
@@ -12,7 +12,7 @@ The Phylum CLI can generate a lockfile when it is given a manifest file.
 | ------------- | ---------        | -------------               |
 | `npm`         | `package.json`   | [`npm`][npm]                |
 | `yarn`        | `package.json`   | [`yarn`][yarn]              |
-| `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `setup.cfg` <br/> `pyproject.toml` | `pip-compile` (from [`pip-tools`][pip-tools]) |
+| `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `pyproject.toml` | `pip-compile` (from [`pip-tools`][pip-tools]) |
 | `pipenv`      | `Pipfile`        | [`pipenv`][pipenv]          |
 | `poetry`      | `pyproject.toml` | [`poetry`][poetry]          |
 | `gem`         | `Gemfile`        | `bundle` (from [Bundler][]) |

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -47,7 +47,6 @@ impl Parse for PyRequirements {
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("requirements.in"))
             || path.file_name() == Some(OsStr::new("pyproject.toml"))
-            || path.file_name() == Some(OsStr::new("setup.cfg"))
             || path.file_name() == Some(OsStr::new("setup.py"))
             || is_requirements_file(path)
     }


### PR DESCRIPTION
This file will always be accompanied by a `setup.py` or `pyproject.toml`

`setuptools` [documents][1] how to use `setup.cfg` without `setup.py`, but doing that requires `pyproject.toml`. Indeed, `pip-compile` fails when it is run on a project that only has `setup.cfg`:

```
build.BuildException: Source <path> does not appear to be a Python project: no pyproject.toml or setup.py
```

[1]: https://setuptools.pypa.io/en/latest/setuptools.html#setup-cfg-only-projects

Related to #1102