### PR TITLE
Add missing test attribute

### DIFF
--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -535,6 +535,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn pkg_locator() {
         let pkgs = Spdx.parse(include_str!("../../tests/fixtures/locator.spdx.json")).unwrap();
 


### PR DESCRIPTION
Add missing `#[test]` attribute on one of the SPDX unit tests.

Related to https://github.com/phylum-dev/cli/issues/1011
