### PR TITLE
Fix analysis report output

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -40,6 +40,20 @@ pub fn get_job_status(api_uri: &str, job_id: &JobId) -> Result<Url, BaseUriError
     Ok(url)
 }
 
+/// POST /data/jobs/{job_id}/policy/evaluate/raw
+pub fn get_job_status_raw(api_uri: &str, job_id: &JobId) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "data",
+        "jobs",
+        &job_id.to_string(),
+        "policy",
+        "evaluate",
+        "raw",
+    ]);
+    Ok(url)
+}
+
 /// POST /data/packages/check
 pub fn check_packages(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/packages/check")?)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -441,6 +441,7 @@ mod tests {
     use super::*;
     use crate::config::ConnectionInfo;
     use crate::test::mockito::*;
+    use crate::types::{EvaluatedDependency, PolicyRejection, RejectionSource};
 
     #[tokio::test]
     async fn create_client() -> Result<()> {
@@ -695,7 +696,29 @@ mod tests {
 
     #[tokio::test]
     async fn get_job_status_raw() -> Result<()> {
-        let body = todo!();
+        let body = PolicyEvaluationResponseRaw {
+            is_failure: false,
+            incomplete_packages_count: 3,
+            help: "help".into(),
+            dependencies: vec![EvaluatedDependency {
+                purl: "purl".into(),
+                registry: "registry".into(),
+                version: "version".into(),
+                rejections: vec![PolicyRejection {
+                    title: "title".into(),
+                    source: RejectionSource {
+                        source_type: "source_type".into(),
+                        tag: "tag".into(),
+                        domain: "domain".into(),
+                        severity: "severity".into(),
+                        description: "description".into(),
+                        reason: "reason".into(),
+                    },
+                    suppressed: false,
+                }],
+            }],
+            job_link: "job_link".into(),
+        };
         let expected_body = body.clone();
 
         let mock_server = build_mock_server().await;
@@ -708,7 +731,7 @@ mod tests {
         let client = build_phylum_api(&mock_server).await?;
 
         let job = JobId::from_str("59482a54-423b-448d-8325-f171c9dc336b").unwrap();
-        let response = client.get_job_status(&job, []).await?;
+        let response = client.get_job_status_raw(&job, []).await?;
 
         assert_eq!(response, expected_body);
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -708,16 +708,16 @@ mod tests {
                     title: "title".into(),
                     source: RejectionSource {
                         source_type: "source_type".into(),
-                        tag: "tag".into(),
-                        domain: "domain".into(),
-                        severity: "severity".into(),
-                        description: "description".into(),
-                        reason: "reason".into(),
+                        tag: None,
+                        domain: Some("domain".into()),
+                        severity: Some("severity".into()),
+                        description: None,
+                        reason: None,
                     },
                     suppressed: false,
                 }],
             }],
-            job_link: "job_link".into(),
+            job_link: Some("job_link".into()),
         };
         let expected_body = body.clone();
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -429,11 +429,10 @@ impl PhylumApi {
 /// Tests
 #[cfg(test)]
 mod tests {
-
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
-    use phylum_types::types::package::PackageType;
+    use phylum_types::types::package::{PackageType, RiskDomain, RiskLevel};
     use wiremock::http::HeaderName;
     use wiremock::matchers::{method, path, path_regex, query_param};
     use wiremock::{Mock, ResponseTemplate};
@@ -703,14 +702,15 @@ mod tests {
             dependencies: vec![EvaluatedDependency {
                 purl: "purl".into(),
                 registry: "registry".into(),
+                name: "name".into(),
                 version: "version".into(),
                 rejections: vec![PolicyRejection {
                     title: "title".into(),
                     source: RejectionSource {
                         source_type: "source_type".into(),
                         tag: None,
-                        domain: Some("domain".into()),
-                        severity: Some("severity".into()),
+                        domain: Some(RiskDomain::Vulnerabilities),
+                        severity: Some(RiskLevel::Low),
                         description: None,
                         reason: None,
                     },

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -29,7 +29,7 @@ pub async fn print_job_status(
     ignored_packages: impl Into<Vec<PackageDescriptor>>,
     pretty: bool,
 ) -> CommandResult {
-    let response = api.get_job_status(job_id, ignored_packages).await;
+    let response = api.get_job_status_raw(job_id, ignored_packages).await;
 
     // Provide nicer messages for specific errors.
     let status = match response {

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -126,19 +126,19 @@ impl Format for PolicyEvaluationResponseRaw {
         // Write summary for each issue.
         for package in &self.dependencies {
             for rejection in package.rejections.iter().filter(|rejection| !rejection.suppressed) {
-                let severity = match rejection.source.domain.as_str() {
-                    "author" => "AUT",
-                    "engineering" => "ENG",
-                    "malicious_code" | "malicious" => "MAL",
-                    "vulnerability" => "VUL",
-                    "license" => "LIC",
-                    _ => "UNK",
+                let domain = match rejection.source.domain.as_deref() {
+                    Some("author") => "[AUT]",
+                    Some("engineering") => "[ENG]",
+                    Some("malicious_code") | Some("malicious") => "[MAL]",
+                    Some("vulnerability") => "[VUL]",
+                    Some("license") => "[LIC]",
+                    None | _ => "     ",
                 };
-                let message = format!("[{severity}] {}", rejection.title);
+                let message = format!("{domain} {}", rejection.title);
 
-                let colored = match rejection.source.severity.as_str() {
-                    "low" | "info" => style(message).green(),
-                    "medium" => style(message).yellow(),
+                let colored = match rejection.source.severity.as_deref() {
+                    Some("low") | Some("info") => style(message).green(),
+                    Some("medium") => style(message).yellow(),
                     _ => style(message).red(),
                 };
 

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -99,6 +99,8 @@ impl Format for PolicyEvaluationResponseRaw {
     fn pretty<W: Write>(&self, writer: &mut W) {
         let _ = writeln!(writer);
 
+        // TODO: Print success/failure.
+
         // Print number of unprocessed packages.
         if self.incomplete_packages_count > 0 {
             let pluralization = if self.incomplete_packages_count == 1 { "" } else { "s" };

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -124,7 +124,9 @@ impl Format for PolicyEvaluationResponseRaw {
         }
 
         // Write summary for each issue.
-        for package in &self.dependencies {
+        for package in self.dependencies.iter().filter(|package| !package.rejections.is_empty()) {
+            let _ = writeln!(writer, "[{}] {}@{}", package.registry, package.name, package.version);
+
             for rejection in package.rejections.iter().filter(|rejection| !rejection.suppressed) {
                 let domain = rejection.source.domain.map_or_else(
                     || "     ".into(),
@@ -138,7 +140,7 @@ impl Format for PolicyEvaluationResponseRaw {
                     _ => style(message).red(),
                 };
 
-                let _ = writeln!(writer, "{}", colored);
+                let _ = writeln!(writer, "  {}", colored);
             }
         }
         if !self.dependencies.is_empty() {

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -99,7 +99,15 @@ impl Format for PolicyEvaluationResponseRaw {
     fn pretty<W: Write>(&self, writer: &mut W) {
         let _ = writeln!(writer);
 
-        // TODO: Print success/failure.
+        // Print summary status.
+        let status = if self.is_failure {
+            style("FAILURE").red()
+        } else if self.incomplete_packages_count > 0 {
+            style("INCOMPLETE").yellow()
+        } else {
+            style("SUCCESS").green()
+        };
+        let _ = writeln!(writer, "Phylum Supply Chain Risk Analysis — {status}\n");
 
         // Print number of unprocessed packages.
         if self.incomplete_packages_count > 0 {

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -132,7 +132,7 @@ impl Format for PolicyEvaluationResponseRaw {
                     Some("malicious_code") | Some("malicious") => "[MAL]",
                     Some("vulnerability") => "[VUL]",
                     Some("license") => "[LIC]",
-                    None | _ => "     ",
+                    _ => "     ",
                 };
                 let message = format!("{domain} {}", rejection.title);
 
@@ -150,7 +150,9 @@ impl Format for PolicyEvaluationResponseRaw {
         }
 
         // Print web URI for the job results.
-        let _ = writeln!(writer, "You can find the interactive report here:\n  {}", self.job_link);
+        if let Some(job_link) = &self.job_link {
+            let _ = writeln!(writer, "You can find the interactive report here:\n  {}", job_link);
+        }
     }
 }
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -103,11 +103,11 @@ pub struct PolicyRejection {
 pub struct RejectionSource {
     #[serde(rename = "type")]
     pub source_type: String,
-    pub tag: String,
-    pub domain: String,
-    pub severity: String,
-    pub description: String,
-    pub reason: String,
+    pub tag: Option<String>,
+    pub domain: Option<String>,
+    pub severity: Option<String>,
+    pub description: Option<String>,
+    pub reason: Option<String>,
 }
 
 #[cfg(test)]

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -71,6 +71,45 @@ pub struct PolicyEvaluationResponse {
     pub report: String,
 }
 
+/// Response body for `/data/jobs/{job_id}/policy/evaluate/raw`.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct PolicyEvaluationResponseRaw {
+    pub is_failure: bool,
+    pub incomplete_packages_count: u32,
+    pub help: String,
+    pub dependencies: Vec<EvaluatedDependency>,
+    pub job_link: String,
+}
+
+/// Policy evaluation results for a dependency.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct EvaluatedDependency {
+    pub purl: String,
+    pub registry: String,
+    pub version: String,
+    pub rejections: Vec<PolicyRejection>,
+}
+
+/// Policy rejection cause.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct PolicyRejection {
+    pub title: String,
+    pub source: RejectionSource,
+    pub suppressed: bool,
+}
+
+/// Policy rejection source.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct RejectionSource {
+    #[serde(rename = "type")]
+    pub source_type: String,
+    pub tag: String,
+    pub domain: String,
+    pub severity: String,
+    pub description: String,
+    pub reason: String,
+}
+
 #[cfg(test)]
 mod tests {
     use phylum_types::types::package::RiskLevel;

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use phylum_types::types::package::PackageDescriptor;
+use phylum_types::types::package::{PackageDescriptor, RiskDomain, RiskLevel};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -104,8 +104,8 @@ pub struct RejectionSource {
     #[serde(rename = "type")]
     pub source_type: String,
     pub tag: Option<String>,
-    pub domain: Option<String>,
-    pub severity: Option<String>,
+    pub domain: Option<RiskDomain>,
+    pub severity: Option<RiskLevel>,
     pub description: Option<String>,
     pub reason: Option<String>,
 }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -78,7 +78,7 @@ pub struct PolicyEvaluationResponseRaw {
     pub incomplete_packages_count: u32,
     pub help: String,
     pub dependencies: Vec<EvaluatedDependency>,
-    pub job_link: String,
+    pub job_link: Option<String>,
 }
 
 /// Policy evaluation results for a dependency.

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -86,6 +86,7 @@ pub struct PolicyEvaluationResponseRaw {
 pub struct EvaluatedDependency {
     pub purl: String,
     pub registry: String,
+    pub name: String,
     pub version: String,
     pub rejections: Vec<PolicyRejection>,
 }


### PR DESCRIPTION
This patch uses the new raw policy endpoint to fix the output of the analysis command to be properly formatted for a terminal emulator rather than just printing the default markdown.

Closes #1116.
