### PR TITLE
Bump to v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [5.3.0] - 2023-06-15
+
 ### Added
 - Add support for parsing additional SPDX locator formats
 - Print package manager STDERR when lockfile generation fails
@@ -511,7 +513,8 @@ before, the existing project ID will be re-linked.
 ## 0.0.1
 - Initial release.
 
-[unreleased]: https://github.com/phylum-dev/cli/compare/v5.2.0...HEAD
+[unreleased]: https://github.com/phylum-dev/cli/compare/v5.3.0...HEAD
+[5.3.0]: https://github.com/phylum-dev/cli/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/phylum-dev/cli/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/phylum-dev/cli/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/phylum-dev/cli/compare/v5.0.0...v5.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "5.2.0"
+version = "5.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "5.2.0"
+version = "5.3.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 5.3.0 - 2023-06-15
+
 ### Fixed
 
 - Uncaught extension errors now cause the CLI to exit with a non-zero exit code


### PR DESCRIPTION
Release-Version: v5.3.0

Cutting v5.3.0-rc2 today. Preparing this PR for a v5.3.0 release on Tuesday (2023-06-20)