### PR TITLE
Fix line continuations and --hash in python parser

### DIFF
--- a/lockfile/src/parsers/mod.rs
+++ b/lockfile/src/parsers/mod.rs
@@ -28,7 +28,7 @@ fn take_till_blank_line(input: &str) -> Result<&str, &str> {
 ///
 /// This supports both `\n` and `\r\n`. It also skips line continuations
 /// (`\\\n`, `\\\r\n`) and stops on EOF.
-fn take_continued_line(mut input: &str) -> Result<&str, &str> {
+fn take_continued_line(mut input: &str) -> Result<&str, ()> {
     loop {
         // Get everything up to the next NL or EOF.
         let (new_input, line) = recognize(alt((take_till_line_end, rest)))(input)?;
@@ -40,7 +40,7 @@ fn take_continued_line(mut input: &str) -> Result<&str, &str> {
         }
     }
 
-    Ok((input, ""))
+    Ok((input, ()))
 }
 
 type Result<T, U> = IResult<T, U, VerboseError<T>>;

--- a/lockfile/src/parsers/mod.rs
+++ b/lockfile/src/parsers/mod.rs
@@ -1,10 +1,10 @@
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take, take_until};
-use nom::character::complete::{anychar, line_ending, multispace0, space0};
-use nom::combinator::{eof, opt, recognize};
+use nom::bytes::complete::{tag, take_until};
+use nom::character::complete::{line_ending, multispace0, not_line_ending, space0};
+use nom::combinator::{eof, opt, recognize, rest};
 use nom::error::{context, VerboseError};
 use nom::multi::{count, many1, many_till};
-use nom::sequence::{delimited, tuple};
+use nom::sequence::{delimited, terminated, tuple};
 use nom::{AsChar, IResult};
 
 pub mod gem;
@@ -16,17 +16,12 @@ pub mod yarn;
 
 /// Consume everything until the next `\n` or `\r\n`.
 fn take_till_line_end(input: &str) -> Result<&str, &str> {
-    recognize(tuple((alt((take_until("\n"), take_until("\r\n"))), take(1usize))))(input)
+    recognize(terminated(not_line_ending, line_ending))(input)
 }
 
 /// Consume everything until the next `\n\n` or `\r\n\r\n`.
 fn take_till_blank_line(input: &str) -> Result<&str, &str> {
     recognize(alt((take_until("\n\n"), take_until("\r\n\r\n"))))(input)
-}
-
-/// Consume everything until the input is empty.
-fn take_till_eof(input: &str) -> Result<&str, &str> {
-    recognize(many_till(anychar, eof))(input)
 }
 
 /// Consume the next line.
@@ -36,7 +31,7 @@ fn take_till_eof(input: &str) -> Result<&str, &str> {
 fn take_continued_line(mut input: &str) -> Result<&str, &str> {
     loop {
         // Get everything up to the next NL or EOF.
-        let (new_input, line) = recognize(alt((take_till_line_end, take_till_eof)))(input)?;
+        let (new_input, line) = recognize(alt((take_till_line_end, rest)))(input)?;
         input = new_input;
 
         // Stop consuming lines once there are no continuations.

--- a/lockfile/src/parsers/mod.rs
+++ b/lockfile/src/parsers/mod.rs
@@ -1,6 +1,6 @@
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take, take_until};
-use nom::character::complete::{line_ending, multispace0, space0};
+use nom::character::complete::{anychar, line_ending, multispace0, space0};
 use nom::combinator::{eof, opt, recognize};
 use nom::error::{context, VerboseError};
 use nom::multi::{count, many1, many_till};
@@ -14,12 +14,38 @@ pub mod pypi;
 pub mod spdx;
 pub mod yarn;
 
+/// Consume everything until the next `\n` or `\r\n`.
 fn take_till_line_end(input: &str) -> Result<&str, &str> {
     recognize(tuple((alt((take_until("\n"), take_until("\r\n"))), take(1usize))))(input)
 }
 
+/// Consume everything until the next `\n\n` or `\r\n\r\n`.
 fn take_till_blank_line(input: &str) -> Result<&str, &str> {
     recognize(alt((take_until("\n\n"), take_until("\r\n\r\n"))))(input)
+}
+
+/// Consume everything until the input is empty.
+fn take_till_eof(input: &str) -> Result<&str, &str> {
+    recognize(many_till(anychar, eof))(input)
+}
+
+/// Consume the next line.
+///
+/// This supports both `\n` and `\r\n`. It also skips line continuations
+/// (`\\\n`, `\\\r\n`) and stops on EOF.
+fn take_continued_line(mut input: &str) -> Result<&str, &str> {
+    loop {
+        // Get everything up to the next NL or EOF.
+        let (new_input, line) = recognize(alt((take_till_line_end, take_till_eof)))(input)?;
+        input = new_input;
+
+        // Stop consuming lines once there are no continuations.
+        if !line.ends_with("\\\n") && !line.ends_with("\\\r\n") {
+            break;
+        }
+    }
+
+    Ok((input, ""))
 }
 
 type Result<T, U> = IResult<T, U, VerboseError<T>>;

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -183,7 +183,7 @@ fn line_done(input: &str) -> Result<&str, &str> {
     eof(input)
 }
 
-/// Pares package hashes.
+/// Parse package hashes.
 ///
 /// Example:
 ///   --hash=sha256:

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -2,26 +2,34 @@ use std::path::PathBuf;
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_until};
-use nom::character::complete::{alphanumeric1, char, not_line_ending, space0, space1};
+use nom::character::complete::{alphanumeric1, char, space1};
 use nom::combinator::{eof, opt, recognize, rest, verify};
 use nom::error::{VerboseError, VerboseErrorKind};
 use nom::multi::{many0, many1, separated_list0};
-use nom::sequence::{delimited, pair, terminated};
+use nom::sequence::{delimited, pair, terminated, tuple};
 use nom::Err as NomErr;
 use phylum_types::types::package::PackageType;
 
-use crate::parsers::Result;
+use crate::parsers::{self, Result};
 use crate::{Package, PackageVersion};
 
-pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
+pub fn parse(mut input: &str) -> Result<&str, Vec<Package>> {
     let mut pkgs = Vec::new();
 
-    for line in input
-        .lines()
-        .map(|line| line.trim())
-        .filter(|line| !line.starts_with('#') && !line.is_empty())
-    {
-        let (_, line) = recognize(alt((take_until(" #"), not_line_ending)))(line)?;
+    while !input.is_empty() {
+        // Get the next line.
+        let (new_input, line) = line(input)?;
+        input = new_input;
+
+        // Ignore empty lines.
+        if line.is_empty() {
+            continue;
+        }
+
+        // Strip comments.
+        let (_, line) = recognize(alt((take_until(" #"), parsers::take_till_eof)))(line)?;
+
+        // Parse dependency.
         let (_, pkg) = package(line)?;
         pkgs.push(pkg);
     }
@@ -29,9 +37,27 @@ pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
     Ok((input, pkgs))
 }
 
+/// Parse one line in the lockfile.
+fn line(input: &str) -> Result<&str, &str> {
+    // Take everything until the next newline.
+    //
+    // This takes line continuation characters into account.
+    let (input, mut line) = recognize(parsers::take_continued_line)(input)?;
+
+    // Remove irrelevant whitespace.
+    line = line.trim();
+
+    // Remove entirely commented out lines.
+    if line.starts_with('#') {
+        line = "";
+    }
+
+    Ok((input, line))
+}
+
 fn package(input: &str) -> Result<&str, Package> {
     // Ignore everything after `;`.
-    let (_, input) = recognize(alt((take_until(";"), not_line_ending)))(input)?;
+    let (_, input) = recognize(alt((take_until(";"), parsers::take_till_eof)))(input)?;
 
     // Parse for `-e` dependencies.
     if let Ok(editable) = editable(input) {
@@ -152,7 +178,7 @@ fn identifier_list(input: &str) -> Result<&str, &str> {
 
 fn line_done(input: &str) -> Result<&str, &str> {
     // Allow for spaces and arguments not impacting resolution.
-    let (input, _) = recognize(many0(alt((space1, package_hash))))(input)?;
+    let (input, _) = recognize(many0(alt((nl_space1, package_hash))))(input)?;
 
     eof(input)
 }
@@ -183,5 +209,24 @@ fn ws<'a, F>(inner: F) -> impl FnMut(&'a str) -> Result<&str, &str>
 where
     F: Fn(&'a str) -> Result<&str, &str>,
 {
-    delimited(space0, inner, space0)
+    delimited(nl_space0, inner, nl_space0)
+}
+
+/// Newline-aware space0.
+///
+/// This automatically handles " \\\n" and treats it as normal space.
+fn nl_space0(input: &str) -> Result<&str, &str> {
+    recognize(many0(alt((space1, line_continuation))))(input)
+}
+
+/// Newline-aware space1.
+///
+/// This automatically handles " \\\n" and treats it as normal space.
+fn nl_space1(input: &str) -> Result<&str, &str> {
+    recognize(many1(alt((space1, line_continuation))))(input)
+}
+
+/// Recognize line continuations.
+fn line_continuation(input: &str) -> Result<&str, &str> {
+    recognize(tuple((tag("\\"), opt(tag("\r")), tag("\n"))))(input)
 }

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_until};
-use nom::character::complete::{alphanumeric1, char, not_line_ending, space0};
+use nom::character::complete::{alphanumeric1, char, not_line_ending, space0, space1};
 use nom::combinator::{eof, opt, recognize, rest, verify};
 use nom::error::{VerboseError, VerboseErrorKind};
 use nom::multi::{many0, many1, separated_list0};
@@ -151,8 +151,29 @@ fn identifier_list(input: &str) -> Result<&str, &str> {
 }
 
 fn line_done(input: &str) -> Result<&str, &str> {
-    let (input, _) = space0(input)?;
+    // Allow for spaces and arguments not impacting resolution.
+    let (input, _) = recognize(many0(alt((space1, package_hash))))(input)?;
+
     eof(input)
+}
+
+/// Pares package hashes.
+///
+/// Example:
+///   --hash=sha256:
+/// 8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
+fn package_hash(input: &str) -> Result<&str, &str> {
+    // Argument name.
+    let (input, _) = tag("--hash=")(input)?;
+
+    // Hash variant.
+    let (input, _) = alphanumeric1(input)?;
+
+    // Separator.
+    let (input, _) = tag(":")(input)?;
+
+    // Package hash.
+    alphanumeric1(input)
 }
 
 /// A combinator that takes a parser `inner` and produces a parser that also

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -33,7 +33,10 @@ fn is_requirements_file(path: &Path) -> bool {
 impl Parse for PyRequirements {
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>> {
-        let (_, entries) = pypi::parse(data)
+        // Ignore newlines with line continuation characters.
+        let input = data.replace(" \\\n", " ").replace(" \\\r\n", " ");
+
+        let (_, entries) = pypi::parse(&input)
             .finish()
             .map_err(|e| anyhow!(convert_error(data, e)))
             .context("Failed to parse requirements file")?;

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -33,7 +33,7 @@ fn is_requirements_file(path: &Path) -> bool {
 impl Parse for PyRequirements {
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>> {
-        let (_, entries) = pypi::parse(&data)
+        let (_, entries) = pypi::parse(data)
             .finish()
             .map_err(|e| anyhow!(convert_error(data, e)))
             .context("Failed to parse requirements file")?;

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -33,10 +33,7 @@ fn is_requirements_file(path: &Path) -> bool {
 impl Parse for PyRequirements {
     /// Parses `requirements.txt` files into a vec of packages
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>> {
-        // Ignore newlines with line continuation characters.
-        let input = data.replace(" \\\n", " ").replace(" \\\r\n", " ");
-
-        let (_, entries) = pypi::parse(&input)
+        let (_, entries) = pypi::parse(&data)
             .finish()
             .map_err(|e| anyhow!(convert_error(data, e)))
             .context("Failed to parse requirements file")?;

--- a/tests/fixtures/requirements-locked.txt
+++ b/tests/fixtures/requirements-locked.txt
@@ -7,7 +7,8 @@
 # pip-compile requirements/requirements.in
 alembic==1.10.3
     # via -r requirements/requirements.in
-amqp==5.0.9
+amqp==5.0.9 --hash=sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0 \
+    --hash=sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
     # via kombu
 
 attrs==20.2.0   # This is an inline comment
@@ -23,7 +24,8 @@ attr @ file:///tmp/attr
 
 numpy @ file:///tmp/testing/numpy-1.23.5-pp38-pypy38_pp73-win_amd64.whl
 
-git-for-pip-example @ git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0
+git-for-pip-example @ \
+    git+https://github.com/matiascodesal/git-for-pip-example.git@v1.0.0
 
 tomli @ https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
 


### PR DESCRIPTION
This fixes the handling of line continuations in the requirements.txt file.

It also resolves an issue where the `--hash` argument was not accepted by the lockfile parser and caused the parsing of the file to fail.

Closes #1117.
