### PR TITLE
Rename parsers::Result to parsers::IResult

### DIFF
--- a/lockfile/src/parsers/go_sum.rs
+++ b/lockfile/src/parsers/go_sum.rs
@@ -6,10 +6,10 @@ use nom::multi::many1;
 use nom::sequence::{preceded, tuple};
 use phylum_types::types::package::PackageType;
 
-use super::Result;
+use super::IResult;
 use crate::{Package, PackageVersion};
 
-pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
+pub fn parse(input: &str) -> IResult<&str, Vec<Package>> {
     let (input, mut pkg_options) = many1(package)(input)?;
     let mut pkgs = pkg_options.drain(..).collect::<Vec<_>>();
 
@@ -20,7 +20,7 @@ pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
     Ok((input, pkgs))
 }
 
-fn package(input: &str) -> Result<&str, Package> {
+fn package(input: &str) -> IResult<&str, Package> {
     let (input, name) = package_name(input)?;
     let (input, version) = package_version(input)?;
     let (input, _hash) = package_hash(input)?;
@@ -34,7 +34,7 @@ fn package(input: &str) -> Result<&str, Package> {
     Ok((input, package))
 }
 
-fn package_name(input: &str) -> Result<&str, &str> {
+fn package_name(input: &str) -> IResult<&str, &str> {
     // Take away any leading whitespace.
     let (input, _) = space0(input)?;
 
@@ -42,7 +42,7 @@ fn package_name(input: &str) -> Result<&str, &str> {
     recognize(take_until(" "))(input)
 }
 
-fn package_version(input: &str) -> Result<&str, &str> {
+fn package_version(input: &str) -> IResult<&str, &str> {
     // Take away any leading whitespace.
     let (input, _) = space0(input)?;
 
@@ -61,7 +61,7 @@ fn package_version(input: &str) -> Result<&str, &str> {
     Ok((input, version))
 }
 
-fn package_hash(input: &str) -> Result<&str, &str> {
+fn package_hash(input: &str) -> IResult<&str, &str> {
     // Take away any leading whitespace.
     let (input, _) = space0(input)?;
 

--- a/lockfile/src/parsers/gradle_dep.rs
+++ b/lockfile/src/parsers/gradle_dep.rs
@@ -1,15 +1,13 @@
-use std::result::Result as StdResult;
-
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till};
 use nom::combinator::eof;
 use nom::error::VerboseError;
 use phylum_types::types::package::PackageType;
 
-use crate::parsers::Result;
+use crate::parsers::IResult;
 use crate::{Package, PackageVersion};
 
-pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
+pub fn parse(input: &str) -> IResult<&str, Vec<Package>> {
     let mut pkgs = Vec::new();
     for line in input.lines().filter(filter_line) {
         pkgs.push(package(line)?);
@@ -23,11 +21,11 @@ fn filter_line(line: &&str) -> bool {
 }
 
 // Take all non-white characters until encountering whitespace or `until`.
-fn not_space_until(input: &str, until: char) -> Result<&str, &str> {
+fn not_space_until(input: &str, until: char) -> IResult<&str, &str> {
     take_till(|c: char| c == until || c.is_whitespace())(input)
 }
 
-fn package(input: &str) -> StdResult<Package, nom::Err<VerboseError<&str>>> {
+fn package(input: &str) -> Result<Package, nom::Err<VerboseError<&str>>> {
     let (input, group_id) = not_space_until(input, ':')?;
     let (input, _) = tag(":")(input)?;
 

--- a/lockfile/src/parsers/mod.rs
+++ b/lockfile/src/parsers/mod.rs
@@ -5,7 +5,7 @@ use nom::combinator::{eof, opt, recognize, rest};
 use nom::error::{context, VerboseError};
 use nom::multi::{count, many1, many_till};
 use nom::sequence::{delimited, terminated, tuple};
-use nom::{AsChar, IResult};
+use nom::AsChar;
 
 pub mod gem;
 pub mod go_sum;
@@ -15,12 +15,12 @@ pub mod spdx;
 pub mod yarn;
 
 /// Consume everything until the next `\n` or `\r\n`.
-fn take_till_line_end(input: &str) -> Result<&str, &str> {
+fn take_till_line_end(input: &str) -> IResult<&str, &str> {
     recognize(terminated(not_line_ending, line_ending))(input)
 }
 
 /// Consume everything until the next `\n\n` or `\r\n\r\n`.
-fn take_till_blank_line(input: &str) -> Result<&str, &str> {
+fn take_till_blank_line(input: &str) -> IResult<&str, &str> {
     recognize(alt((take_until("\n\n"), take_until("\r\n\r\n"))))(input)
 }
 
@@ -28,7 +28,7 @@ fn take_till_blank_line(input: &str) -> Result<&str, &str> {
 ///
 /// This supports both `\n` and `\r\n`. It also skips line continuations
 /// (`\\\n`, `\\\r\n`) and stops on EOF.
-fn take_continued_line(mut input: &str) -> Result<&str, ()> {
+fn take_continued_line(mut input: &str) -> IResult<&str, ()> {
     loop {
         // Get everything up to the next NL or EOF.
         let (new_input, line) = recognize(alt((take_till_line_end, rest)))(input)?;
@@ -43,4 +43,4 @@ fn take_continued_line(mut input: &str) -> Result<&str, ()> {
     Ok((input, ()))
 }
 
-type Result<T, U> = IResult<T, U, VerboseError<T>>;
+type IResult<T, U> = nom::IResult<T, U, VerboseError<T>>;

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -10,10 +10,10 @@ use nom::sequence::{delimited, pair, terminated};
 use nom::Err as NomErr;
 use phylum_types::types::package::PackageType;
 
-use crate::parsers::{self, Result};
+use crate::parsers::{self, IResult};
 use crate::{Package, PackageVersion};
 
-pub fn parse(mut input: &str) -> Result<&str, Vec<Package>> {
+pub fn parse(mut input: &str) -> IResult<&str, Vec<Package>> {
     let mut pkgs = Vec::new();
 
     while !input.is_empty() {
@@ -38,7 +38,7 @@ pub fn parse(mut input: &str) -> Result<&str, Vec<Package>> {
 }
 
 /// Parse one line in the lockfile.
-fn line(input: &str) -> Result<&str, &str> {
+fn line(input: &str) -> IResult<&str, &str> {
     // Take everything until the next newline.
     //
     // This takes line continuation characters into account.
@@ -55,7 +55,7 @@ fn line(input: &str) -> Result<&str, &str> {
     Ok((input, line))
 }
 
-fn package(input: &str) -> Result<&str, Package> {
+fn package(input: &str) -> IResult<&str, Package> {
     // Ignore everything after `;`.
     let (_, input) = alt((take_until(";"), rest))(input)?;
 
@@ -98,7 +98,7 @@ fn package(input: &str) -> Result<&str, Package> {
 /// We'll use `/tmp/editable` as name here, since there's no other identifier
 /// attached. The path is left empty since this is usually just a git
 /// repository, which does not have any path.
-fn editable(input: &str) -> Result<&str, Package> {
+fn editable(input: &str) -> IResult<&str, Package> {
     // Ensure `-e` is present and skip it.
     let (input, _) = ws(tag("-e"))(input)?;
 
@@ -142,16 +142,16 @@ fn editable(input: &str) -> Result<&str, Package> {
 /// Find URI dependencies.
 ///
 /// This includes path, git and internet dependencies.
-fn uri_version(input: &str) -> Result<&str, &str> {
+fn uri_version(input: &str) -> IResult<&str, &str> {
     let (uri, _) = ws(tag("@"))(input)?;
     Ok(("", uri))
 }
 
-fn package_name(input: &str) -> Result<&str, &str> {
+fn package_name(input: &str) -> IResult<&str, &str> {
     terminated(ws(identifier), opt(ws(package_extras)))(input)
 }
 
-fn package_version(input: &str) -> Result<&str, &str> {
+fn package_version(input: &str) -> IResult<&str, &str> {
     // Ensure no `*` is in the version.
     let (_, input) = verify(rest, |s: &str| !s.contains('*'))(input)?;
 
@@ -162,21 +162,21 @@ fn package_version(input: &str) -> Result<&str, &str> {
     recognize(many1(alt((alphanumeric1, tag(".")))))(input)
 }
 
-fn identifier(input: &str) -> Result<&str, &str> {
+fn identifier(input: &str) -> IResult<&str, &str> {
     recognize(pair(alphanumeric1, many0(alt((alphanumeric1, alt((tag("-"), tag("_"), tag("."))))))))(
         input,
     )
 }
 
-fn package_extras(input: &str) -> Result<&str, &str> {
+fn package_extras(input: &str) -> IResult<&str, &str> {
     delimited(char('['), identifier_list, char(']'))(input)
 }
 
-fn identifier_list(input: &str) -> Result<&str, &str> {
+fn identifier_list(input: &str) -> IResult<&str, &str> {
     recognize(separated_list0(char(','), ws(identifier)))(input)
 }
 
-fn line_done(input: &str) -> Result<&str, &str> {
+fn line_done(input: &str) -> IResult<&str, &str> {
     // Allow for spaces and arguments not impacting resolution.
     let (input, _) = recognize(many0(alt((nl_space1, package_hash))))(input)?;
 
@@ -188,7 +188,7 @@ fn line_done(input: &str) -> Result<&str, &str> {
 /// Example:
 ///   --hash=sha256:
 /// 8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
-fn package_hash(input: &str) -> Result<&str, &str> {
+fn package_hash(input: &str) -> IResult<&str, &str> {
     // Argument name.
     let (input, _) = tag("--hash=")(input)?;
 
@@ -205,9 +205,9 @@ fn package_hash(input: &str) -> Result<&str, &str> {
 /// A combinator that takes a parser `inner` and produces a parser that also
 /// consumes both leading and trailing whitespace, returning the output of
 /// `inner`.
-fn ws<'a, F>(inner: F) -> impl FnMut(&'a str) -> Result<&str, &str>
+fn ws<'a, F>(inner: F) -> impl FnMut(&'a str) -> IResult<&str, &str>
 where
-    F: Fn(&'a str) -> Result<&str, &str>,
+    F: Fn(&'a str) -> IResult<&str, &str>,
 {
     delimited(nl_space0, inner, nl_space0)
 }
@@ -215,18 +215,18 @@ where
 /// Newline-aware space0.
 ///
 /// This automatically handles " \\\n" and treats it as normal space.
-fn nl_space0(input: &str) -> Result<&str, &str> {
+fn nl_space0(input: &str) -> IResult<&str, &str> {
     recognize(many0(alt((space1, line_continuation))))(input)
 }
 
 /// Newline-aware space1.
 ///
 /// This automatically handles " \\\n" and treats it as normal space.
-fn nl_space1(input: &str) -> Result<&str, &str> {
+fn nl_space1(input: &str) -> IResult<&str, &str> {
     recognize(many1(alt((space1, line_continuation))))(input)
 }
 
 /// Recognize line continuations.
-fn line_continuation(input: &str) -> Result<&str, &str> {
+fn line_continuation(input: &str) -> IResult<&str, &str> {
     recognize(pair(tag("\\"), line_ending))(input)
 }

--- a/lockfile/src/parsers/yarn.rs
+++ b/lockfile/src/parsers/yarn.rs
@@ -1,9 +1,10 @@
+use nom::InputTakeAtPosition;
 use phylum_types::types::package::PackageType;
 
 use super::*;
 use crate::{Package, PackageVersion};
 
-pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
+pub fn parse(input: &str) -> IResult<&str, Vec<Package>> {
     let (input, _) = yarn_lock_header(input)?;
 
     // Ignore empty lockfiles.
@@ -14,11 +15,11 @@ pub fn parse(input: &str) -> Result<&str, Vec<Package>> {
     many1(entry)(input)
 }
 
-fn yarn_lock_header(input: &str) -> Result<&str, &str> {
+fn yarn_lock_header(input: &str) -> IResult<&str, &str> {
     recognize(opt(tuple((count(take_till_line_end, 2), multispace0))))(input)
 }
 
-fn entry(input: &str) -> Result<&str, Package> {
+fn entry(input: &str) -> IResult<&str, Package> {
     let (i, capture) = recognize(many_till(
         take_till_line_end,
         recognize(tuple((space0, alt((line_ending, eof))))),
@@ -28,7 +29,7 @@ fn entry(input: &str) -> Result<&str, Package> {
     Ok((i, my_entry))
 }
 
-fn parse_entry(input: &str) -> Result<&str, Package> {
+fn parse_entry(input: &str) -> IResult<&str, Package> {
     context("entry", tuple((entry_name, entry_version)))(input).map(|(next_input, res)| {
         let (name, version) = res;
         (next_input, Package {
@@ -39,24 +40,20 @@ fn parse_entry(input: &str) -> Result<&str, Package> {
     })
 }
 
-fn entry_name(input: &str) -> Result<&str, &str> {
+fn entry_name(input: &str) -> IResult<&str, &str> {
     let (i, _) = opt(tag(r#"""#))(input)?;
     let opt_at = opt(tag("@"));
     let name = tuple((opt_at, take_until("@")));
     context("name", recognize(name))(i)
 }
 
-fn entry_version(input: &str) -> Result<&str, &str> {
+fn entry_version(input: &str) -> IResult<&str, &str> {
     let (i, _) = take_until(r#"version"#)(input)?;
     let version_key = tuple((tag(r#"version"#), opt(tag(r#"""#)), tag(r#" ""#)));
     context("version", delimited(version_key, is_version, tag(r#"""#)))(i)
 }
 
-fn is_version<T, E: nom::error::ParseError<T>>(input: T) -> IResult<T, T, E>
-where
-    T: nom::InputTakeAtPosition,
-    <T as nom::InputTakeAtPosition>::Item: AsChar,
-{
+fn is_version(input: &str) -> IResult<&str, &str> {
     input.split_at_position1_complete(
         |item| {
             let c: char = item.as_char();


### PR DESCRIPTION
Calling this type `Result` leads to confusion because it has two generic parameters just like `std::result::Result`. But the parameters are for input and output, not ok and error.

Using `IResult` is less confusing.