### PR TITLE
Add label to extension analyze API

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -140,6 +140,7 @@ async fn analyze(
     packages: Vec<PackageDescriptor>,
     project: Option<String>,
     group: Option<String>,
+    label: Option<String>,
 ) -> Result<JobId> {
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
@@ -155,7 +156,7 @@ async fn analyze(
         },
     };
 
-    let job_id = api.submit_request(&packages, project, None, group.map(String::from)).await?;
+    let job_id = api.submit_request(&packages, project, label, group.map(String::from)).await?;
 
     Ok(job_id)
 }

--- a/extensions/ci/PhylumExt.toml
+++ b/extensions/ci/PhylumExt.toml
@@ -1,0 +1,5 @@
+name = "ci"
+description = "Phylum CI analysis"
+
+[permissions]
+read = ["/"]

--- a/extensions/ci/main.ts
+++ b/extensions/ci/main.ts
@@ -1,0 +1,37 @@
+import { PhylumApi } from 'phylum';
+
+// Ensure required arguments are present.
+if (Deno.args.length < 4 || Deno.args.length > 5) {
+  console.error("Usage: phylum ci <PROJECT> [--group <GROUP>] <LABEL> <BASE> <LOCKFILE>");
+  Deno.exit(1);
+}
+
+// Find optional groups argument.
+let group = undefined;
+let groupArgsIndex = Deno.args.indexOf("--group");
+if (groupArgsIndex != -1) {
+    const groupArgs = Deno.args.splice(groupArgsIndex, groupArgsIndex);
+    group = groupArgs[1];
+}
+
+// Parse remaining arguments.
+const project = Deno.args[0];
+const label = Deno.args[1];
+const base = Deno.args[2];
+const lockfile = Deno.args[3];
+
+// Parse new lockfile.
+const lockfileDeps = await PhylumApi.parseLockfile(lockfile);
+
+// Deserialize base dependencies.
+const baseDepsJson = await Deno.readTextFile(base);
+const baseDeps = JSON.parse(baseDepsJson);
+
+// Submit analysis job.
+const jobID = await PhylumApi.analyze(lockfileDeps.packages, project, group, label);
+
+// Get analysis job results.
+const jobStatus = await PhylumApi.getJobStatus(jobID, baseDeps);
+
+// Output results as JSON.
+console.log(JSON.stringify(jobStatus));

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -88,6 +88,7 @@ export class PhylumApi {
    * @param packages - List of packages to analyze
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
    * @param group - Group name
+   * @param label - Analysis label for this job
    *
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
@@ -95,6 +96,7 @@ export class PhylumApi {
     packages: Package[],
     project?: string,
     group?: string,
+    label?: string,
   ): Promise<string> {
     return DenoCore.opAsync(
       "analyze",


### PR DESCRIPTION
This adds the new `label` option as the last optional parameter of the `analyze` function, allowing `phylum-ci` to use the extension API for its analysis.
