### PR TITLE
Disable lockfile generation for yarn v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correctly handle line continuations and --hash in `requirements.txt` parser
 
+### Removed
+- Lockfile generation for yarn v1
+
 ## [5.3.0] - 2023-06-15
 
 ### Added

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -38,11 +38,18 @@ pub trait Generator {
         vec![self.lockfile_name()]
     }
 
+    /// Verify that all the prerequisites for lockfile generation are met.
+    fn check_prerequisites(&self, _manifest_path: &Path) -> Result<()> {
+        Ok(())
+    }
+
     /// Generate the lockfile for a project.
     ///
     /// This will ignore all existing lockfiles and create a new lockfile based
     /// on the current project configuration.
     fn generate_lockfile(&self, manifest_path: &Path) -> Result<String> {
+        self.check_prerequisites(manifest_path)?;
+
         let canonicalized = fs::canonicalize(manifest_path)?;
         let project_path = canonicalized
             .parent()


### PR DESCRIPTION
Since yarn v1 isn't able to generate a lockfile without installing the dependencies and executing their build code, it could be dangerous to automatically generate lockfiles for the user.

To fix this issue, the lockfile generator will now return an error when lockfile generation is attempted with the yarn generator and only version 1 is used by the project.

While the lockfile generation with yarn v1 still worked and it would provide protection against vulnerable code in the target executable, it is safer to leave the lockfile generation up to the user so they're in full control.

Closes #1086.
