### PR TITLE
Fix ecosystem extensions without subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correctly handle line continuations and --hash in `requirements.txt` parser
+- Ecosystem extensions failing with valid arguments
 
 ### Removed
 - Lockfile generation for yarn v1

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -50,11 +50,15 @@ async function findRoot(manifest: string): Promise<string | undefined> {
   return undefined;
 }
 
-if (Deno.args.length != 0 && Deno.args[0].startsWith("-")) {
+// Ensure no arguments are passed before a subcommand.
+const firstSubcommand = Deno.args.findIndex((arg) => !arg.startsWith("-"));
+if (firstSubcommand > 0) {
   console.error(
     `[${
       red("phylum")
-    }] This extension does not support arguments before the first subcommand.`,
+    }] This extension does not support arguments before the first subcommand. Please open an issue if "${
+      Deno.args[0]
+    }" is not an argument.`,
   );
   Deno.exit(127);
 }

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -5,26 +5,24 @@ import {
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
 
-// Ensure no arguments are passed before `install` subcommand.
+// Ensure no arguments are passed before `add`/`update`/`install` subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `pip --no-color install package`).
-const subcommand = Deno.args[0];
-if (
-  Deno.args.length != 0 &&
-  subcommand !== "install" &&
-  Deno.args.includes("install")
-) {
+const firstSubcommand = Deno.args.findIndex((arg) => !arg.startsWith("-"));
+if (firstSubcommand > 0) {
   console.error(
     `[${
       red("phylum")
-    }] This extension does not support arguments before the first subcommand. Please open an issue if "${subcommand}" is not an argument.`,
+    }] This extension does not support arguments before the first subcommand. Please open an issue if "${
+      Deno.args[0]
+    }" is not an argument.`,
   );
   Deno.exit(125);
 }
 
 // Ignore all commands that shouldn't be intercepted.
-if (Deno.args.length == 0 || subcommand != "install") {
+if (Deno.args.length == 0 || Deno.args[0] != "install") {
   const cmd = new Deno.Command("pip3", { args: Deno.args });
   const status = await cmd.spawn().status;
   Deno.exit(status.code);

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -5,33 +5,16 @@ import {
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
 
-// List with all of pip's subcommands.
-const knownSubcommands = [
-  "install",
-  "download",
-  "uninstall",
-  "freeze",
-  "inspect",
-  "list",
-  "show",
-  "check",
-  "config",
-  "search",
-  "cache",
-  "index",
-  "wheel",
-  "hash",
-  "completion",
-  "debug",
-  "help",
-];
-
-// Ensure the first argument is a known subcommand.
+// Ensure no arguments are passed before `install` subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `pip --no-color install package`).
 const subcommand = Deno.args[0];
-if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
+if (
+  Deno.args.length != 0 &&
+  subcommand !== "install" &&
+  Deno.args.includes("install")
+) {
   console.error(
     `[${
       red("phylum")

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -24,41 +24,17 @@ async function findRoot(manifest: string): Promise<string | undefined> {
   return undefined;
 }
 
-// List with all of poetry's subcommands.
-const knownSubcommands = [
-  "about",
-  "add",
-  "build",
-  "check",
-  "config",
-  "export",
-  "help",
-  "init",
-  "install",
-  "list",
-  "lock",
-  "new",
-  "publish",
-  "remove",
-  "run",
-  "search",
-  "shell",
-  "show",
-  "update",
-  "version",
-  "cache",
-  "debug",
-  "env",
-  "self",
-  "source",
-];
-
-// Ensure the first argument is a known subcommand.
+// Ensure no arguments are passed before `add`/`update`/`install` subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `poetry --no-color add package`).
 const subcommand = Deno.args[0];
-if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
+if (
+  Deno.args.length != 0 &&
+    (Deno.args.includes("add") && subcommand !== "add") ||
+  (Deno.args.includes("update") && subcommand !== "update") ||
+  (Deno.args.includes("install") && subcommand !== "install")
+) {
   console.error(
     `[${
       red("phylum")

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -24,21 +24,18 @@ async function findRoot(manifest: string): Promise<string | undefined> {
   return undefined;
 }
 
-// Ensure no arguments are passed before `add`/`update`/`install` subcommand.
+// Ensure no arguments are passed before a subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `poetry --no-color add package`).
-const subcommand = Deno.args[0];
-if (
-  Deno.args.length != 0 &&
-    (Deno.args.includes("add") && subcommand !== "add") ||
-  (Deno.args.includes("update") && subcommand !== "update") ||
-  (Deno.args.includes("install") && subcommand !== "install")
-) {
+const firstSubcommand = Deno.args.findIndex((arg) => !arg.startsWith("-"));
+if (firstSubcommand > 0) {
   console.error(
     `[${
       red("phylum")
-    }] This extension does not support arguments before the first subcommand. Please open an issue if "${subcommand}" is not an argument.`,
+    }] This extension does not support arguments before the first subcommand. Please open an issue if "${
+      Deno.args[0]
+    }" is not an argument.`,
   );
   Deno.exit(127);
 }

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -50,72 +50,18 @@ async function findRoot(manifest: string): Promise<string | undefined> {
   return undefined;
 }
 
-// List with all of yarn's subcommands.
-const knownSubcommands = [
-  // Yarn v1+ subcommands.
-  "access",
-  "add",
-  "audit",
-  "autoclean",
-  "bin",
-  "cache",
-  "check",
-  "config",
-  "create",
-  "exec",
-  "generate-lock-entry",
-  "generateLockEntry",
-  "global",
-  "help",
-  "import",
-  "info",
-  "init",
-  "install",
-  "licenses",
-  "link",
-  "list",
-  "login",
-  "logout",
-  "node",
-  "outdated",
-  "owner",
-  "pack",
-  "policies",
-  "publish",
-  "remove",
-  "run",
-  "tag",
-  "team",
-  "unlink",
-  "unplug",
-  "upgrade",
-  "upgrade-interactive",
-  "upgradeInteractive",
-  "version",
-  "versions",
-  "why",
-  "workspace",
-  "workspaces",
-  // Yarn v2 subcommands.
-  "dedupe",
-  "dlx",
-  "explain",
-  "npm",
-  "patch",
-  "patch-commit",
-  "rebuild",
-  "set",
-  "up",
-  "plugin",
-  "workspace",
-];
-
-// Ensure the first argument is a known subcommand.
+// Ensure no arguments are passed before `add`/`install`/`up`/`dedupe` subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `yarn --cwd /tmp/project add package`).
 const subcommand = Deno.args[0];
-if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
+if (
+  Deno.args.length != 0 &&
+    (Deno.args.includes("add") && subcommand !== "add") ||
+  (Deno.args.includes("install") && subcommand !== "install") ||
+  (Deno.args.includes("up") && subcommand !== "up") ||
+  (Deno.args.includes("dedupe") && subcommand !== "dedupe")
+) {
   console.error(
     `[${
       red("phylum")

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -50,22 +50,18 @@ async function findRoot(manifest: string): Promise<string | undefined> {
   return undefined;
 }
 
-// Ensure no arguments are passed before `add`/`install`/`up`/`dedupe` subcommand.
+// Ensure no arguments are passed before a subcommand.
 //
 // This prevents us from skipping the analysis when an argument is passed before
 // the first subcommand (i.e.: `yarn --cwd /tmp/project add package`).
-const subcommand = Deno.args[0];
-if (
-  Deno.args.length != 0 &&
-    (Deno.args.includes("add") && subcommand !== "add") ||
-  (Deno.args.includes("install") && subcommand !== "install") ||
-  (Deno.args.includes("up") && subcommand !== "up") ||
-  (Deno.args.includes("dedupe") && subcommand !== "dedupe")
-) {
+const firstSubcommand = Deno.args.findIndex((arg) => !arg.startsWith("-"));
+if (firstSubcommand > 0) {
   console.error(
     `[${
       red("phylum")
-    }] This extension does not support arguments before the first subcommand. Please open an issue if "${subcommand}" is not an argument.`,
+    }] This extension does not support arguments before the first subcommand. Please open an issue if "${
+      Deno.args[0]
+    }" is not an argument.`,
   );
   Deno.exit(125);
 }


### PR DESCRIPTION
This fixes an issue where ecosystem extension invocations wouldn't work unless they also had a subcommand specified. This specifically prevented the common `--help` flag from being used on its own.

Closes #1025.

---

I think this is a way simpler and more reliable way to prevent options before subcommands, however it still isn't a bulletproof design. In this scenario something like `yarn add install` would fail for example, but I don't think any of the package manager subcommands have packages with the same name that are popular enough to make this an issue.

The other alternative would be a more complicated argument parser that actually checks for at least `-` at the start of arguments, which might require some edgecase handling too, but I'd like to avoid that unless necessary. If we did add something like this, it would be nice to have some abstraction in place so we only have to write it once for all ecosystem extensions.
