### PR TITLE
Add support for NuGet lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Support for NuGet's `packages.lock.json` lockfiles
+
 ## [5.4.0] - 2023-07-06
 
 ### Added

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -31,7 +31,7 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -25,7 +25,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `auto`
 
 -f, --force
 &emsp; Overwrite existing configurations without confirmation

--- a/docs/command_line_tool/phylum_parse.md
+++ b/docs/command_line_tool/phylum_parse.md
@@ -19,7 +19,7 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -15,7 +15,8 @@ The Phylum CLI supports processing many different lockfiles:
 | `pipenv`      | `Pipfile.lock`                                                         |
 | `poetry`      | `poetry.lock` (Version 1 + 2)                                          |
 | `gem`         | `Gemfile.lock`                                                         |
-| `nuget`       | `*.csproj`                                                             |
+| `msbuild`     | `*.csproj`                                                             |
+| `nugetlock`   | `packages.lock.json`                                                   |
 | `mvn`         | `effective-pom.xml`                                                    |
 | `gradle`      | `gradle.lockfile`                                                      |
 | `go`          | `go.sum`                                                               |

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub use cargo::Cargo;
-pub use csharp::CSProj;
+pub use csharp::{CSProj, PackagesLock};
 pub use golang::GoSum;
 use ignore::WalkBuilder;
 pub use java::{GradleLock, Pom};
@@ -50,9 +50,9 @@ pub enum LockfileFormat {
     Gradle,
     // This is historically called "nuget" but it's actually for MSBuild project files.
     // Nuget has its own file formats that are not currently supported.
-    #[serde(rename = "nuget")]
-    #[serde(alias = "msbuild")]
+    #[serde(alias = "nuget")]
     Msbuild,
+    NugetLock,
     Go,
     Cargo,
     Spdx,
@@ -91,7 +91,8 @@ impl LockfileFormat {
             LockfileFormat::Poetry => "poetry",
             LockfileFormat::Maven => "mvn",
             LockfileFormat::Gradle => "gradle",
-            LockfileFormat::Msbuild => "nuget",
+            LockfileFormat::Msbuild => "msbuild",
+            LockfileFormat::NugetLock => "nugetlock",
             LockfileFormat::Go => "go",
             LockfileFormat::Cargo => "cargo",
             LockfileFormat::Spdx => "spdx",
@@ -111,6 +112,7 @@ impl LockfileFormat {
             LockfileFormat::Maven => &Pom,
             LockfileFormat::Gradle => &GradleLock,
             LockfileFormat::Msbuild => &CSProj,
+            LockfileFormat::NugetLock => &PackagesLock,
             LockfileFormat::Go => &GoSum,
             LockfileFormat::Cargo => &Cargo,
             LockfileFormat::Spdx => &Spdx,
@@ -145,10 +147,11 @@ impl Iterator for LockfileFormatIter {
             6 => LockfileFormat::Pipenv,
             7 => LockfileFormat::Maven,
             8 => LockfileFormat::Gradle,
-            9 => LockfileFormat::Msbuild,
-            10 => LockfileFormat::Go,
-            11 => LockfileFormat::Cargo,
-            12 => LockfileFormat::Spdx,
+            9 => LockfileFormat::NugetLock,
+            10 => LockfileFormat::Msbuild,
+            11 => LockfileFormat::Go,
+            12 => LockfileFormat::Cargo,
+            13 => LockfileFormat::Spdx,
             _ => return None,
         };
         self.0 += 1;
@@ -340,6 +343,7 @@ mod tests {
             ("npm-shrinkwrap.json", LockfileFormat::Npm),
             ("pnpm-lock.yaml", LockfileFormat::Pnpm),
             ("sample.csproj", LockfileFormat::Msbuild),
+            ("packages.lock.json", LockfileFormat::NugetLock),
             ("gradle.lockfile", LockfileFormat::Gradle),
             ("effective-pom.xml", LockfileFormat::Maven),
             ("requirements.txt", LockfileFormat::Pip),
@@ -372,6 +376,7 @@ mod tests {
             ("gradle", LockfileFormat::Gradle),
             ("nuget", LockfileFormat::Msbuild),
             ("msbuild", LockfileFormat::Msbuild),
+            ("nugetlock", LockfileFormat::NugetLock),
             ("go", LockfileFormat::Go),
             ("cargo", LockfileFormat::Cargo),
             ("spdx", LockfileFormat::Spdx),
@@ -398,7 +403,8 @@ mod tests {
             ("poetry", LockfileFormat::Poetry),
             ("mvn", LockfileFormat::Maven),
             ("gradle", LockfileFormat::Gradle),
-            ("nuget", LockfileFormat::Msbuild),
+            ("msbuild", LockfileFormat::Msbuild),
+            ("nugetlock", LockfileFormat::NugetLock),
             ("go", LockfileFormat::Go),
             ("cargo", LockfileFormat::Cargo),
             ("spdx", LockfileFormat::Spdx),
@@ -440,6 +446,7 @@ mod tests {
             (LockfileFormat::Maven, 2),
             (LockfileFormat::Gradle, 1),
             (LockfileFormat::Msbuild, 2),
+            (LockfileFormat::NugetLock, 1),
             (LockfileFormat::Go, 1),
             (LockfileFormat::Cargo, 3),
             (LockfileFormat::Spdx, 6),

--- a/tests/fixtures/packages.lock.json
+++ b/tests/fixtures/packages.lock.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "Microsoft.Windows.SDK.Contracts": {
+        "type": "Direct",
+        "requested": "[10.0.22621.755, )",
+        "resolved": "10.0.22621.755",
+        "contentHash": "J1mpz9jekt87ZcbsHxU+iMvJIVJSMkTpeAftudx5AYsucPSxaQxlq3ZM2X8lVyRSdlMphtlfHfoTDKcMReIzdA==",
+        "dependencies": {
+          "System.Runtime.InteropServices.WindowsRuntime": "4.3.0",
+          "System.Runtime.WindowsRuntime": "4.6.0",
+          "System.Runtime.WindowsRuntime.UI.Xaml": "4.6.0"
+        }
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2020.0.2",
+        "contentHash": "G0dNlTBAM00KZXv1wWVwgg26d9/METcM6qWBpNQwllzQmmbu+Zu+FS1L1X4fFgGdPu3e8k9mmTBu6SwtQ0614g=="
+      },
+      "example.helpers": {
+        "type": "Project",
+        "dependencies": {
+          "SSH.NET": "[2020.0.2, )"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Build",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "System.Buffers": {
+        "type": "Platform",
+        "requested": "[4.5.1, )",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "Microsoft.CodeAnalysis.FxCopAnalyzers": {
+        "type": "Tool",
+        "requested": "[3.3.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw=="
+      }
+    },
+    ".NETFramework,Version=v4.8/win": {
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.8/win-arm64": {},
+    ".NETFramework,Version=v4.8/win-x64": {},
+    ".NETFramework,Version=v4.8/win-x86": {}
+  }
+}


### PR DESCRIPTION
This patch adds the ability for CLI to parse NuGet's `packages.lock.json` lockfiles.

Currently this only supports the format itself and does no generation from `*.csproj` files to `packages.lock.json` using `nuget`.

Closes #1056.
