### PR TITLE
Add support for pnpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Support for `pnpm-lock.yaml` lockfiles
+
 ### Changed
 - New output format for `phylum analyze` and `phylum history <job-id>`
 - Ignore `setup.py` when a `pyproject.toml` is present

--- a/docs/command_line_tool/phylum_analyze.md
+++ b/docs/command_line_tool/phylum_analyze.md
@@ -31,7 +31,7 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/command_line_tool/phylum_init.md
+++ b/docs/command_line_tool/phylum_init.md
@@ -25,7 +25,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -f, --force
 &emsp; Overwrite existing configurations without confirmation

--- a/docs/command_line_tool/phylum_parse.md
+++ b/docs/command_line_tool/phylum_parse.md
@@ -19,7 +19,7 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 
 -t, --lockfile-type <type>
 &emsp; Lock file type used for all lock files (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nuget`, `go`, `cargo`, `spdx`, `auto`
 
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/knowledge_base/analyzing-dependencies.md
+++ b/docs/knowledge_base/analyzing-dependencies.md
@@ -6,19 +6,20 @@ hidden: false
 
 The Phylum CLI supports processing many different lockfiles:
 
-| Lockfile type | Filenames |
-| ------------- | --------- |
-| `npm`         | `package-lock.json` <br /> `npm-shrinkwrap.json` |
-| `yarn`        | `yarn.lock` (Version 1 + 2) |
-| `pip`         | `requirements*.txt` |
-| `pipenv`      | `Pipfile.lock` |
-| `poetry`      | `poetry.lock` (Version 1 + 2) |
-| `gem`         | `Gemfile.lock` |
-| `nuget`       | `*.csproj` |
-| `mvn`         | `effective-pom.xml` |
-| `gradle`      | `gradle.lockfile` |
-| `go`          | `go.sum` |
-| `cargo`       | `Cargo.lock` |
+| Lockfile type | Filenames                                                              |
+| ------------- | ---------------------------------------------------------------------- |
+| `npm`         | `package-lock.json` <br /> `npm-shrinkwrap.json`                       |
+| `yarn`        | `yarn.lock` (Version 1 + 2)                                            |
+| `pnpm`        | `pnpm-lock.yaml`                                                       |
+| `pip`         | `requirements*.txt`                                                    |
+| `pipenv`      | `Pipfile.lock`                                                         |
+| `poetry`      | `poetry.lock` (Version 1 + 2)                                          |
+| `gem`         | `Gemfile.lock`                                                         |
+| `nuget`       | `*.csproj`                                                             |
+| `mvn`         | `effective-pom.xml`                                                    |
+| `gradle`      | `gradle.lockfile`                                                      |
+| `go`          | `go.sum`                                                               |
+| `cargo`       | `Cargo.lock`                                                           |
 | `spdx`        | `*.spdx.json` <br /> `*.spdx.yaml` <br /> `*.spdx.yml` <br /> `*.spdx` |
 
 The lockfile type will be automatically detected based on the filename. If needed, this can be overridden with the

--- a/docs/knowledge_base/lockfile-generation.md
+++ b/docs/knowledge_base/lockfile-generation.md
@@ -12,6 +12,7 @@ The Phylum CLI can generate a lockfile when it is given a manifest file.
 | ------------- | ---------        | -------------               |
 | `npm`         | `package.json`   | [`npm`][npm]                |
 | `yarn`        | `package.json`   | [`yarn`][yarn]              |
+| `pnpm`        | `package.json`   | [`pnpm`][pnpm]              |
 | `pip`         | `requirements*.txt` <br/> `requirements.in` <br/> `setup.py` <br/> `pyproject.toml` | [`pip`][pip] version 23.0.0+ |
 | `pipenv`      | `Pipfile`        | [`pipenv`][pipenv]          |
 | `poetry`      | `pyproject.toml` | [`poetry`][poetry]          |
@@ -21,16 +22,17 @@ The Phylum CLI can generate a lockfile when it is given a manifest file.
 | `go`          | `go.mod`         | [`go`][go]                  |
 | `cargo`       | `Cargo.toml`     | [`cargo`][cargo]            |
 
-[npm]: https://nodejs.org/
-[yarn]: https://yarnpkg.com/
-[pip]: https://pip.pypa.io/
+[npm]: https://nodejs.org
+[yarn]: https://yarnpkg.com
+[pnpm]: https://pnpm.io
+[pip]: https://pip.pypa.io
 [pipenv]: https://github.com/pypa/pipenv
-[poetry]: https://python-poetry.org/
-[bundler]: https://bundler.io/
-[maven]: https://maven.apache.org/
-[gradle]: https://gradle.org/
-[go]: https://go.dev/
-[cargo]: https://www.rust-lang.org/
+[poetry]: https://python-poetry.org
+[bundler]: https://bundler.io
+[maven]: https://maven.apache.org
+[gradle]: https://gradle.org
+[go]: https://go.dev
+[cargo]: https://www.rust-lang.org
 
 For files that can be handled by multiple generators, a fallback is used:
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -8,7 +8,7 @@ pub use csharp::CSProj;
 pub use golang::GoSum;
 use ignore::WalkBuilder;
 pub use java::{GradleLock, Pom};
-pub use javascript::{PackageLock, YarnLock};
+pub use javascript::{PackageLock, Pnpm, YarnLock};
 #[cfg(feature = "generator")]
 use lockfile_generator::Generator;
 use phylum_types::types::package::PackageType;
@@ -39,6 +39,7 @@ const MAX_LOCKFILE_DEPTH: usize = 5;
 pub enum LockfileFormat {
     Yarn,
     Npm,
+    Pnpm,
     Gem,
     Pip,
     Pipenv,
@@ -83,6 +84,7 @@ impl LockfileFormat {
         match self {
             LockfileFormat::Yarn => "yarn",
             LockfileFormat::Npm => "npm",
+            LockfileFormat::Pnpm => "pnpm",
             LockfileFormat::Gem => "gem",
             LockfileFormat::Pip => "pip",
             LockfileFormat::Pipenv => "pipenv",
@@ -101,6 +103,7 @@ impl LockfileFormat {
         match self {
             LockfileFormat::Yarn => &YarnLock,
             LockfileFormat::Npm => &PackageLock,
+            LockfileFormat::Pnpm => &Pnpm,
             LockfileFormat::Gem => &GemLock,
             LockfileFormat::Pip => &PyRequirements,
             LockfileFormat::Pipenv => &PipFile,
@@ -135,16 +138,17 @@ impl Iterator for LockfileFormatIter {
         let item = match self.0 {
             0 => LockfileFormat::Npm,
             1 => LockfileFormat::Yarn,
-            2 => LockfileFormat::Gem,
-            3 => LockfileFormat::Pip,
-            4 => LockfileFormat::Poetry,
-            5 => LockfileFormat::Pipenv,
-            6 => LockfileFormat::Maven,
-            7 => LockfileFormat::Gradle,
-            8 => LockfileFormat::Msbuild,
-            9 => LockfileFormat::Go,
-            10 => LockfileFormat::Cargo,
-            11 => LockfileFormat::Spdx,
+            2 => LockfileFormat::Pnpm,
+            3 => LockfileFormat::Gem,
+            4 => LockfileFormat::Pip,
+            5 => LockfileFormat::Poetry,
+            6 => LockfileFormat::Pipenv,
+            7 => LockfileFormat::Maven,
+            8 => LockfileFormat::Gradle,
+            9 => LockfileFormat::Msbuild,
+            10 => LockfileFormat::Go,
+            11 => LockfileFormat::Cargo,
+            12 => LockfileFormat::Spdx,
             _ => return None,
         };
         self.0 += 1;
@@ -334,6 +338,7 @@ mod tests {
             ("yarn.lock", LockfileFormat::Yarn),
             ("package-lock.json", LockfileFormat::Npm),
             ("npm-shrinkwrap.json", LockfileFormat::Npm),
+            ("pnpm-lock.yaml", LockfileFormat::Pnpm),
             ("sample.csproj", LockfileFormat::Msbuild),
             ("gradle.lockfile", LockfileFormat::Gradle),
             ("effective-pom.xml", LockfileFormat::Maven),
@@ -357,6 +362,7 @@ mod tests {
         for (name, expected_format) in [
             ("yarn", LockfileFormat::Yarn),
             ("npm", LockfileFormat::Npm),
+            ("pnpm", LockfileFormat::Pnpm),
             ("gem", LockfileFormat::Gem),
             ("pip", LockfileFormat::Pip),
             ("pipenv", LockfileFormat::Pipenv),
@@ -385,6 +391,7 @@ mod tests {
         for (expected_name, format) in [
             ("yarn", LockfileFormat::Yarn),
             ("npm", LockfileFormat::Npm),
+            ("pnpm", LockfileFormat::Pnpm),
             ("gem", LockfileFormat::Gem),
             ("pip", LockfileFormat::Pip),
             ("pipenv", LockfileFormat::Pipenv),
@@ -426,6 +433,7 @@ mod tests {
         for (format, lockfile_count) in [
             (LockfileFormat::Yarn, 4),
             (LockfileFormat::Npm, 2),
+            (LockfileFormat::Pnpm, 1),
             (LockfileFormat::Gem, 1),
             (LockfileFormat::Pipenv, 1),
             (LockfileFormat::Poetry, 2),

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -16,6 +16,7 @@ pub mod maven;
 pub mod npm;
 pub mod pip;
 pub mod pipenv;
+pub mod pnpm;
 pub mod poetry;
 pub mod yarn;
 

--- a/lockfile_generator/src/pnpm.rs
+++ b/lockfile_generator/src/pnpm.rs
@@ -1,0 +1,24 @@
+//! JavaScript pnpm ecosystem.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::Generator;
+
+pub struct Pnpm;
+
+impl Generator for Pnpm {
+    fn lockfile_name(&self) -> &'static str {
+        "pnpm-lock.yaml"
+    }
+
+    fn command(&self, _manifest_path: &Path) -> Command {
+        let mut command = Command::new("pnpm");
+        command.args(["install", "--lockfile-only", "--ignore-scripts"]);
+        command
+    }
+
+    fn tool(&self) -> &'static str {
+        "pnpm"
+    }
+}

--- a/tests/fixtures/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-lock.yaml
@@ -472,3 +472,9 @@ packages:
     name: demo
     version: 0.2.0
     dev: false
+
+  git.sr.ht/~undeadleech/pnpm-test/cf066e8d69df5ba2cf3d4275b9e775800148d7ff:
+    resolution: {commit: cf066e8d69df5ba2cf3d4275b9e775800148d7ff, repo: ssh://git@git.sr.ht/~undeadleech/pnpm-test, type: git}
+    name: testing
+    version: 1.0.0
+    dev: false

--- a/tests/fixtures/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-lock.yaml
@@ -1,0 +1,460 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  core-js:
+    specifier: ^3.31.0
+    version: 3.31.0
+  express:
+    specifier: ^4.18.2
+    version: 4.18.2
+  xxx:
+    specifier: link:../xxx
+    version: link:../xxx
+
+packages:
+
+  /accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+    dev: false
+
+  /array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    dev: false
+
+  /body-parser@1.20.1:
+    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /bytes@1.2.3-rc4:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /call-bind@1.0.2:
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    dependencies:
+      function-bind: 1.1.1
+      get-intrinsic: 1.2.1
+    dev: false
+
+  /content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: false
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /core-js@3.31.0:
+    resolution: {integrity: sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==}
+    requiresBuild: true
+    dev: false
+
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: false
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /express@4.18.2:
+    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /finalhandler@1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /function-bind@1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: false
+
+  /get-intrinsic@1.2.1:
+    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+    dev: false
+
+  /has-proto@1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /has@1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: false
+
+  /http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: false
+
+  /iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /merge-descriptors@1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    dev: false
+
+  /methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /object-inspect@1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
+    dev: false
+
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /path-to-regexp@0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: false
+
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
+  /qs@6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@2.5.1:
+    resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: false
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
+  /send@0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /serve-static@1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
+
+  /side-channel@1.0.4:
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      object-inspect: 1.12.3
+    dev: false
+
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    dev: false
+
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /bootstrap@5.3.0(@popperjs/core@2.11.8):
+    resolution: {integrity: sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==}
+    peerDependencies:
+      '@popperjs/core': ^2.11.7
+    dependencies:
+      '@popperjs/core': 2.11.8
+    dev: false
+
+  /@babel/core@7.22.5:
+    resolution: {integrity: sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-module-transforms': 7.22.5
+      '@babel/helpers': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false

--- a/tests/fixtures/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-lock.yaml
@@ -458,3 +458,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  github.com/Microsoft/TypeScript/a437de66b6d6f36f205eafcd21a732a29f905486:
+    resolution: {tarball: https://codeload.github.com/Microsoft/TypeScript/tar.gz/a437de66b6d6f36f205eafcd21a732a29f905486}
+    name: typescript
+    version: 5.2.0
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  gitlab.com/Phylum/demo/ab3010efa019564710a03010abace10afeb0a2fe:
+    resolution: {tarball: https://gitlab.com/api/v4/projects/Phylum%2demo/repository/archive.tar.gz?ref=ab3010efa019564710a03010abace10afeb0a2fe}
+    name: demo
+    version: 0.2.0
+    dev: false


### PR DESCRIPTION
This adds support for the new `pnpm-lock.yaml` lockfile type and its
package manager `pnpm`. Supported are both parsing the lockfile itself
and generating a lockfile from the `package.json`.

Closes https://github.com/phylum-dev/cli/issues/1138.