### PR TITLE
Use current thread executor

### DIFF
--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -186,7 +186,7 @@ fn handle_version(app_name: &str, ver: &str) -> CommandResult {
     Ok(ExitCode::Ok)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     match handle_commands().await {
         Ok(code) => code.exit(),


### PR DESCRIPTION
This patch aims to resolve a race condition in deno. The deno CLI uses tokio's current thread executor and the `deno_runtime` crate even has [helper functions][1] for setting up the runtime.

We could also use the `deno_runtime` functions to create the executor only when an extension is run and not change our primary runtime, but this seems to fix the issue and is a very small patch.

[1]: https://github.com/denoland/deno/blob/e4870d84be19f4ea768933522eff437f64963730/runtime/tokio_util.rs#L106C1-L106C59