### PR TITLE
test: update test for phylum website change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+      # Workaround to provide additional free space for testing.
+      # Reference: https://github.com/actions/runner-images/issues/2840
+      - name: Free disk space
+        if: startsWith(runner.name, 'GitHub Actions') && startsWith(matrix.os, 'ubuntu')
+        run: sudo rm -rf /usr/share/dotnet
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install --no-self-update stable --profile minimal -c clippy

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -56,7 +56,7 @@ fn correct_net_permission_successful_install_and_run() {
     test_cli
         .run(["correct-net-perms"])
         .success()
-        .stdout(predicate::str::contains("<!doctype html>"));
+        .stdout(predicate::str::contains("<!DOCTYPE html>"));
 }
 
 #[test]


### PR DESCRIPTION
The `extensions::permissions::correct_net_permission_successful_install_and_run` test started failing after the main Phylum website was updated. It no longer contains the lowercase text `<!doctype html>` and now it is uppercase: `<!DOCTYPE html>`.

A workaround is also added to the `Test` workflow, to free up disk space. Without it, the linking step causes an error due to running out of disk space.

Fixes #1157
