### PR TITLE
Bump to v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [5.5.0] - 2023-07-18
+
 ### Added
 - Support for NuGet's `packages.lock.json` lockfiles
-
-## [5.4.0] - 2023-07-06
-
-### Added
 - Support for `pnpm-lock.yaml` lockfiles
 
 ### Changed
@@ -532,8 +530,8 @@ before, the existing project ID will be re-linked.
 ## 0.0.1
 - Initial release.
 
-[unreleased]: https://github.com/phylum-dev/cli/compare/v5.4.0...HEAD
-[5.4.0]: https://github.com/phylum-dev/cli/compare/v5.3.0...v5.4.0
+[unreleased]: https://github.com/phylum-dev/cli/compare/v5.5.0...HEAD
+[5.5.0]: https://github.com/phylum-dev/cli/compare/v5.3.0...v5.5.0
 [5.3.0]: https://github.com/phylum-dev/cli/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/phylum-dev/cli/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/phylum-dev/cli/compare/v5.0.1...v5.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "5.4.0"
+version = "5.5.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## 5.4.0 - 2023-07-06
+## 5.5.0 - 2023-07-18
 
 ### Added
 


### PR DESCRIPTION
CLI v5.4.0 was rejected before release due to a race condition in deno. The race condition was fixed in #1149 and now we can release CLI v5.5.0.

The `v5.4.0` tag will remain, but mention of the release has been removed from the Changelogs so that they reflect our actual releases.

Release-Version: v5.5.0