### PR TITLE
Ensure correct cargo is used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,12 +38,10 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install --no-self-update stable --profile minimal -c clippy
-          rustup default stable
+        run: rustup toolchain install --no-self-update stable --profile minimal -c clippy
 
       - name: Clippy
-        run: cargo clippy --locked --all-features --all-targets -- -D warnings
+        run: rustup run stable cargo clippy --locked --all-features --all-targets -- -D warnings
 
   test-matrix:
     strategy:
@@ -56,12 +54,10 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install --no-self-update stable --profile minimal
-          rustup default stable
+        run: rustup toolchain install --no-self-update stable --profile minimal
 
       - name: Test
-        run: cargo test --locked
+        run: rustup run stable cargo test --locked
 
   oldstable:
     strategy:
@@ -72,11 +68,14 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Oldstable
+      - name: Install Rust toolchain (oldstable)
         run: |
           oldstable=$(cat "./cli/Cargo.toml" | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
           rustup toolchain install --profile minimal "$oldstable"
-          cargo "+$oldstable" check
+          echo "oldstable=$oldstable" >> "$GITHUB_ENV"
+
+      - name: Check
+        run: rustup run "$oldstable" cargo check
 
   all-features:
     # Skip this job when the secret is unavailable
@@ -89,10 +88,13 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update stable --profile minimal
+
       - name: All Features
         env:
           PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN_STAGING }}
-        run: cargo test --all-features
+        run: rustup run stable cargo test --all-features
 
   deno-checks:
     if: github.event_name != 'schedule'


### PR DESCRIPTION
This patch fixes an issue that was occurring on our self-hosted runner. Since this runner also builds Homebrew bottles, it has `cargo` installed via Homebrew.

Unfortunately, this can lead to the wrong `cargo` being used, which means that we are not getting the version that we expect in our stable test and our oldstable tests fail outright because the +<toolchain> syntax does not work with `cargo` from Homebrew.

To ensure that we are using `cargo` from `rustup`, this patch explicitly calls `rustup run`.