### PR TITLE
Use std::io::IsTerminal instead of atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,6 @@ version = "5.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "atty",
  "base64 0.21.2",
  "birdcage",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "5.5.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
-rust-version = "1.68.0"
+rust-version = "1.70.0"
 autotests = false
 
 [[test]]
@@ -19,7 +19,6 @@ end-to-end-tests = []
 
 [dependencies]
 anyhow = "1.0.44"
-atty = "0.2.14"
 base64 = "0.21.1"
 bytes = "1.1.0"
 chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }

--- a/cli/src/spinner.rs
+++ b/cli/src/spinner.rs
@@ -1,3 +1,4 @@
+use std::io::{self, IsTerminal};
 use std::time;
 
 use futures::Future;
@@ -39,7 +40,7 @@ impl Spinner {
     }
 
     fn new_inner(message: Option<String>) -> Self {
-        if atty::is(atty::Stream::Stderr) {
+        if io::stderr().is_terminal() {
             let (tx, rx) = mpsc::channel(10);
             let handle = tokio::spawn(Self::spin(rx, message));
             Self { tx: Some(tx), handle: Some(handle) }


### PR DESCRIPTION
See the related [GitHub security advisory](https://github.com/advisories/GHSA-g98v-hv3f-hcfr). This patch removes our dependency on `atty`, because it is unmaintained.

Alternately, I could have used the [`is-terminal`](https://crates.io/crates/is-terminal) crate and avoided the MSRV bump. But rust 1.70.0 is already available in [Homebrew](https://formulae.brew.sh/formula/rust#default), which is the only package manager that we currently target. So there is no real need to support anything older.