### PR TITLE
Add failure reason for ecosystem extensions

### DIFF
--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -59,6 +59,11 @@ pub fn check_packages(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/packages/check")?)
 }
 
+/// POST /data/packages/check/raw
+pub fn check_packages_raw(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_api_path(api_uri)?.join("data/packages/check/raw")?)
+}
+
 /// POST /data/packages/submit
 pub fn post_submit_package(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/packages/submit")?)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -324,6 +324,14 @@ impl PhylumApi {
         self.post(endpoints::check_packages(&self.config.connection.uri)?, package_list).await
     }
 
+    /// Check a set of packages against the default policy.
+    pub async fn check_packages_raw(
+        &self,
+        package_list: &[PackageDescriptor],
+    ) -> Result<PolicyEvaluationResponseRaw> {
+        self.post(endpoints::check_packages_raw(&self.config.connection.uri)?, package_list).await
+    }
+
     /// Get the status of all jobs
     pub async fn get_status(&self) -> Result<AllJobsStatusResponse> {
         self.get(endpoints::get_all_jobs_status(&self.config.connection.uri, 30)?).await

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -37,7 +37,7 @@ use crate::commands::parse;
 use crate::commands::ExitCode;
 #[cfg(unix)]
 use crate::dirs;
-use crate::types::PolicyEvaluationResponse;
+use crate::types::{PolicyEvaluationResponse, PolicyEvaluationResponseRaw};
 
 /// Parsed lockfile content.
 #[derive(Serialize, Deserialize, Debug)]
@@ -173,6 +173,18 @@ async fn check_packages(
     Ok(api.check_packages(&packages).await?)
 }
 
+/// Check a set of packages against the default policy.
+#[op]
+async fn check_packages_raw(
+    op_state: Rc<RefCell<OpState>>,
+    packages: Vec<PackageDescriptor>,
+) -> Result<PolicyEvaluationResponseRaw> {
+    let state = ExtensionState::from(op_state);
+    let api = state.api().await?;
+
+    Ok(api.check_packages_raw(&packages).await?)
+}
+
 /// Retrieve user info.
 /// Equivalent to `phylum auth status`.
 #[op]
@@ -234,6 +246,23 @@ async fn get_job_status(
     let job_id = JobId::from_str(&job_id)?;
     let ignored_packages = ignored_packages.unwrap_or_default();
     let response = api.get_job_status(&job_id, ignored_packages).await?;
+
+    Ok(response)
+}
+
+/// Retrieve a job's status.
+#[op]
+async fn get_job_status_raw(
+    op_state: Rc<RefCell<OpState>>,
+    job_id: String,
+    ignored_packages: Option<Vec<PackageDescriptor>>,
+) -> Result<PolicyEvaluationResponseRaw> {
+    let state = ExtensionState::from(op_state);
+    let api = state.api().await?;
+
+    let job_id = JobId::from_str(&job_id)?;
+    let ignored_packages = ignored_packages.unwrap_or_default();
+    let response = api.get_job_status_raw(&job_id, ignored_packages).await?;
 
     Ok(response)
 }
@@ -486,10 +515,12 @@ pub(crate) fn api_decls() -> Vec<OpDecl> {
     vec![
         analyze::decl(),
         check_packages::decl(),
+        check_packages_raw::decl(),
         get_user_info::decl(),
         get_access_token::decl(),
         get_refresh_token::decl(),
         get_job_status::decl(),
+        get_job_status_raw::decl(),
         get_current_project::decl(),
         get_groups::decl(),
         get_projects::decl(),

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added `getJobStatusRaw` and `checkPackagesRaw` APIs for detailed analysis results
+
 ## 5.5.0 - 2023-07-18
 
 ### Added

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -252,7 +252,7 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     );
   } else if (result.incomplete_packages_count > 0) {
     console.warn(
-      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE\n`,
     );
   } else {
     console.log(

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -3,7 +3,7 @@ import {
   red,
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
-import { PhylumApi } from "phylum";
+import { PhylumApi, PolicyEvaluationResponseRaw } from "phylum";
 
 class FileBackup {
   readonly fileName: string;
@@ -245,7 +245,7 @@ async function restoreBackup() {
 }
 
 // Write the analysis result status to STDOUT/STDERRR.
-function logPackageAnalysisResults(result: Record<string, unknown>) {
+function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
   if (!result.is_failure && result.incomplete_packages_count == 0) {
     console.log(
       `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -223,9 +223,9 @@ async function checkDryRun(subcommand: string, args: string[]) {
   logPackageAnalysisResults(result);
 
   if (result.is_failure) {
-      Deno.exit(127);
+    Deno.exit(127);
   } else if (result.incomplete_packages_count !== 0) {
-      Deno.exit(126);
+    Deno.exit(126);
   }
 }
 
@@ -273,43 +273,47 @@ function logPackageAnalysisResults(result: Record<string, unknown>) {
 
     let output = "";
     for (const pkg of result.dependencies) {
-        // Skip packages without policy rejections.
-        if (pkg.rejections.length === 0) {
-            continue;
+      // Skip packages without policy rejections.
+      if (pkg.rejections.length === 0) {
+        continue;
+      }
+
+      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+      for (const rejection of pkg.rejections) {
+        // Skip suppressed issues.
+        if (rejection.suppressed) {
+          continue;
         }
 
-        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+        // Format rejection title.
+        const domain = `[${rejection.source.domain || "     "}]`;
+        const message = `${domain} ${rejection.title}`;
 
-        for (const rejection of pkg.rejections) {
-            // Skip suppressed issues.
-            if (rejection.suppressed) {
-                continue;
-            }
-
-            // Format rejection title.
-            const domain = `[${rejection.source.domain || "     "}]`;
-            const message = `${domain} ${rejection.title}`;
-
-            // Color rejection based on severity.
-            let colored;
-            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
-                colored = green(message);
-            } else if (rejection.source.severity === "medium") {
-                colored = yellow(message);
-            } else {
-                colored = red(message);
-            }
-
-            output += ` ${colored}\n`;
+        // Color rejection based on severity.
+        let colored;
+        if (
+          rejection.source.severity === "low" ||
+          rejection.source.severity === "info"
+        ) {
+          colored = green(message);
+        } else if (rejection.source.severity === "medium") {
+          colored = yellow(message);
+        } else {
+          colored = red(message);
         }
+
+        output += ` ${colored}\n`;
+      }
     }
     if (result.dependencies.length !== 0) {
-        output += "\n";
+      output += "\n";
     }
 
     // Print web URI for the job results.
     if (result.job_link) {
-        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+      output +=
+        `You can find the interactive report here:\n ${result.job_link}\n`;
     }
 
     console.error(output);

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -246,15 +246,22 @@ async function restoreBackup() {
 
 // Write the analysis result status to STDOUT/STDERRR.
 function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
-  if (!result.is_failure && result.incomplete_packages_count == 0) {
-    console.log(
-      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+  if (result.is_failure) {
+    console.error(
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
     );
-  } else if (!result.is_failure) {
+  } else if (result.incomplete_packages_count > 0) {
     console.warn(
       `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
     );
+  } else {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+    );
+  }
 
+  // Print warning regarding incomplete packages.
+  if (result.incomplete_packages_count > 0) {
     // Ensure correct pluralization for incomplete packages.
     let unprocessedText =
       `${result.incomplete_packages_count} unprocessed package`;
@@ -266,56 +273,52 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     console.warn(
       `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
     );
-  } else {
-    console.error(
-      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
-    );
+  }
 
-    let output = "";
-    for (const pkg of result.dependencies) {
-      // Skip packages without policy rejections.
-      if (pkg.rejections.length === 0) {
+  // Print policy violations.
+  let output = "";
+  for (const pkg of result.dependencies) {
+    // Skip packages without policy rejections.
+    if (pkg.rejections.length === 0) {
+      continue;
+    }
+
+    output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+    for (const rejection of pkg.rejections) {
+      // Skip suppressed issues.
+      if (rejection.suppressed) {
         continue;
       }
 
-      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+      // Format rejection title.
+      const domain = `[${rejection.source.domain || "     "}]`;
+      const message = `${domain} ${rejection.title}`;
 
-      for (const rejection of pkg.rejections) {
-        // Skip suppressed issues.
-        if (rejection.suppressed) {
-          continue;
-        }
-
-        // Format rejection title.
-        const domain = `[${rejection.source.domain || "     "}]`;
-        const message = `${domain} ${rejection.title}`;
-
-        // Color rejection based on severity.
-        let colored;
-        if (
-          rejection.source.severity === "low" ||
-          rejection.source.severity === "info"
-        ) {
-          colored = green(message);
-        } else if (rejection.source.severity === "medium") {
-          colored = yellow(message);
-        } else {
-          colored = red(message);
-        }
-
-        output += ` ${colored}\n`;
+      // Color rejection based on severity.
+      let colored;
+      if (
+        rejection.source.severity === "low" ||
+        rejection.source.severity === "info"
+      ) {
+        colored = green(message);
+      } else if (rejection.source.severity === "medium") {
+        colored = yellow(message);
+      } else {
+        colored = red(message);
       }
-    }
-    if (result.dependencies.length !== 0) {
-      output += "\n";
-    }
 
-    // Print web URI for the job results.
-    if (result.job_link) {
-      output +=
-        `You can find the interactive report here:\n ${result.job_link}\n`;
+      output += ` ${colored}\n`;
     }
+  }
+  if (output.length !== 0) {
+    console.error(output + "\n");
+  }
 
-    console.error(output);
+  // Print web URI for the job results.
+  if (result.job_link) {
+    console.log(
+      `You can find the interactive report here:\n ${result.job_link}\n`,
+    );
   }
 }

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -20,6 +20,37 @@ export type ProcessOutput = {
   code: number | null;
 };
 
+export type PolicyEvaluationResponseRaw = {
+  is_failure: boolean;
+  incomplete_packages_count: number;
+  help: string;
+  job_link: string | null;
+  dependencies: EvaluatedDependencies[];
+};
+
+export type EvaluatedDependencies = {
+  purl: string;
+  registry: string;
+  name: string;
+  version: string;
+  rejections: PolicyRejection[];
+};
+
+export type PolicyRejection = {
+  title: string;
+  suppressed: boolean;
+  source: RejectionSource;
+};
+
+export type RejectionSource = {
+  type: string;
+  tag: string | null;
+  domain: string | null;
+  severity: string | null;
+  description: string | null;
+  reason: string | null;
+};
+
 async function requestHeaders(headersInit?: HeadersInit): Promise<Headers> {
   const headers = new Headers(headersInit);
 
@@ -119,7 +150,7 @@ export class PhylumApi {
    */
   static checkPackagesRaw(
     packages: Package[],
-  ): Promise<Record<string, unknown>> {
+  ): Promise<PolicyEvaluationResponseRaw> {
     return DenoCore.opAsync("check_packages_raw", packages);
   }
 
@@ -230,7 +261,7 @@ export class PhylumApi {
   static getJobStatusRaw(
     jobId: string,
     ignoredPackages?: Package[],
-  ): Promise<Record<string, unknown>> {
+  ): Promise<PolicyEvaluationResponseRaw> {
     return DenoCore.opAsync("get_job_status", jobId, ignoredPackages);
   }
 

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -115,6 +115,19 @@ export class PhylumApi {
    *
    * @param packages - List of packages to check (see `analyze()` for details)
    *
+   * @returns Raw job analysis results (see `getJobStatusRaw()` for details)
+   */
+  static checkPackagesRaw(
+    packages: Package[],
+  ): Promise<Record<string, unknown>> {
+    return DenoCore.opAsync("check_packages_raw", packages);
+  }
+
+  /**
+   * Check a list of packages against the default policy.
+   *
+   * @param packages - List of packages to check (see `analyze()` for details)
+   *
    * @returns Job analysis results (see `getJobStatus()` for details)
    */
   static checkPackages(packages: Package[]): Promise<Record<string, unknown>> {
@@ -172,6 +185,49 @@ export class PhylumApi {
    * ```
    */
   static getJobStatus(
+    jobId: string,
+    ignoredPackages?: Package[],
+  ): Promise<Record<string, unknown>> {
+    return DenoCore.opAsync("get_job_status", jobId, ignoredPackages);
+  }
+
+  /**
+   * Get job results.
+   *
+   * @param jobId - ID of the analysis job, see `PhylumApi.analyze`.
+   * @param ignoredPackages - List of packages which will be ignored in the report.
+   *
+   * @returns Raw job analysis results
+   *
+   * Job analysis results example:
+   * ```
+   * {
+   *   is_failure: false,
+   *   incomplete_packages_count: 0,
+   *   help: "The analysis contains 346 package(s) Phylum has not yet processed,\npreventing a complete risk analysis. Phylum is processing these\npackages currently and should complete soon.\nPlease wait for up to 30 minutes, then re-run the analysis.\n\nThis repository analyzes the risk of new dependencies. An\nadministrator of this repository has set requirements via Phylum policy.\n\nIf you see this comment, one or more dependencies have failed Phylum's risk analysis.",
+   *   job_link?: "https://phylum.io/projects/62a91e89-65cb-4597-8d4b-6ef119b29c5c",
+   *   dependencies: [
+   *     purl: "pkg:cargo/birdcage@0.2.1",
+   *     registry: "cargo",
+   *     name: "birdcage",
+   *     version: "0.2.1",
+   *     rejections: [
+   *       title: "Commercial license risk detected in birdcage@0.2.1",
+   *       suppressed: false,
+   *       source: {
+   *         type: "Issue",
+   *         tag?: "HL0030",
+   *         domain?: "license",
+   *         severity?: "high",
+   *         description?: "### Overview\nThis package uses the **GPL-3.0-or-later** license, which is a **high** risk level to commercial use.",
+   *         reason?: "risk level cannot exceed medium"
+   *       }
+   *     ]
+   *   ]
+   * }
+   * ```
+   */
+  static getJobStatusRaw(
     jobId: string,
     ignoredPackages?: Package[],
   ): Promise<Record<string, unknown>> {

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -24,7 +24,7 @@ export type PolicyEvaluationResponseRaw = {
   is_failure: boolean;
   incomplete_packages_count: number;
   help: string;
-  job_link?: string;
+  job_link: string | null;
   dependencies: EvaluatedDependencies[];
 };
 
@@ -44,11 +44,11 @@ export type PolicyRejection = {
 
 export type RejectionSource = {
   type: string;
-  tag?: string;
-  domain?: string;
-  severity?: string;
-  description?: string;
-  reason?: string;
+  tag: string | null;
+  domain: string | null;
+  severity: string | null;
+  description: string | null;
+  reason: string | null;
 };
 
 async function requestHeaders(headersInit?: HeadersInit): Promise<Headers> {

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -24,7 +24,7 @@ export type PolicyEvaluationResponseRaw = {
   is_failure: boolean;
   incomplete_packages_count: number;
   help: string;
-  job_link: string | null;
+  job_link?: string;
   dependencies: EvaluatedDependencies[];
 };
 
@@ -44,11 +44,11 @@ export type PolicyRejection = {
 
 export type RejectionSource = {
   type: string;
-  tag: string | null;
-  domain: string | null;
-  severity: string | null;
-  description: string | null;
-  reason: string | null;
+  tag?: string;
+  domain?: string;
+  severity?: string;
+  description?: string;
+  reason?: string;
 };
 
 async function requestHeaders(headersInit?: HeadersInit): Promise<Headers> {
@@ -236,7 +236,7 @@ export class PhylumApi {
    *   is_failure: false,
    *   incomplete_packages_count: 0,
    *   help: "The analysis contains 346 package(s) Phylum has not yet processed,\npreventing a complete risk analysis. Phylum is processing these\npackages currently and should complete soon.\nPlease wait for up to 30 minutes, then re-run the analysis.\n\nThis repository analyzes the risk of new dependencies. An\nadministrator of this repository has set requirements via Phylum policy.\n\nIf you see this comment, one or more dependencies have failed Phylum's risk analysis.",
-   *   job_link?: "https://phylum.io/projects/62a91e89-65cb-4597-8d4b-6ef119b29c5c",
+   *   job_link: "https://phylum.io/projects/62a91e89-65cb-4597-8d4b-6ef119b29c5c",
    *   dependencies: [
    *     purl: "pkg:cargo/birdcage@0.2.1",
    *     registry: "cargo",
@@ -247,11 +247,11 @@ export class PhylumApi {
    *       suppressed: false,
    *       source: {
    *         type: "Issue",
-   *         tag?: "HL0030",
-   *         domain?: "license",
-   *         severity?: "high",
-   *         description?: "### Overview\nThis package uses the **GPL-3.0-or-later** license, which is a **high** risk level to commercial use.",
-   *         reason?: "risk level cannot exceed medium"
+   *         tag: "HL0030",
+   *         domain: "license",
+   *         severity: "high",
+   *         description: "### Overview\nThis package uses the **GPL-3.0-or-later** license, which is a **high** risk level to commercial use.",
+   *         reason: "risk level cannot exceed medium"
    *       }
    *     ]
    *   ]

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -119,9 +119,9 @@ async function checkDryRun() {
   logPackageAnalysisResults(result);
 
   if (result.is_failure) {
-      Deno.exit(127);
+    Deno.exit(127);
   } else if (result.incomplete_packages_count !== 0) {
-      Deno.exit(126);
+    Deno.exit(126);
   }
 }
 
@@ -233,43 +233,47 @@ function logPackageAnalysisResults(result: Record<string, unknown>) {
 
     let output = "";
     for (const pkg of result.dependencies) {
-        // Skip packages without policy rejections.
-        if (pkg.rejections.length === 0) {
-            continue;
+      // Skip packages without policy rejections.
+      if (pkg.rejections.length === 0) {
+        continue;
+      }
+
+      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+      for (const rejection of pkg.rejections) {
+        // Skip suppressed issues.
+        if (rejection.suppressed) {
+          continue;
         }
 
-        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+        // Format rejection title.
+        const domain = `[${rejection.source.domain || "     "}]`;
+        const message = `${domain} ${rejection.title}`;
 
-        for (const rejection of pkg.rejections) {
-            // Skip suppressed issues.
-            if (rejection.suppressed) {
-                continue;
-            }
-
-            // Format rejection title.
-            const domain = `[${rejection.source.domain || "     "}]`;
-            const message = `${domain} ${rejection.title}`;
-
-            // Color rejection based on severity.
-            let colored;
-            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
-                colored = green(message);
-            } else if (rejection.source.severity === "medium") {
-                colored = yellow(message);
-            } else {
-                colored = red(message);
-            }
-
-            output += ` ${colored}\n`;
+        // Color rejection based on severity.
+        let colored;
+        if (
+          rejection.source.severity === "low" ||
+          rejection.source.severity === "info"
+        ) {
+          colored = green(message);
+        } else if (rejection.source.severity === "medium") {
+          colored = yellow(message);
+        } else {
+          colored = red(message);
         }
+
+        output += ` ${colored}\n`;
+      }
     }
     if (result.dependencies.length !== 0) {
-        output += "\n";
+      output += "\n";
     }
 
     // Print web URI for the job results.
     if (result.job_link) {
-        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+      output +=
+        `You can find the interactive report here:\n ${result.job_link}\n`;
     }
 
     console.error(output);

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -115,27 +115,13 @@ async function checkDryRun() {
     return;
   }
 
-  const result = await PhylumApi.checkPackages(packages);
+  const result = await PhylumApi.checkPackagesRaw(packages);
+  logPackageAnalysisResults(result);
 
-  if (!result.is_failure && result.incomplete_count == 0) {
-    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
-  } else if (!result.is_failure) {
-    console.warn(
-      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
-    );
-    console.warn(
-      `[${
-        yellow(
-          "phylum",
-        )
-      }] Unknown packages were submitted for analysis, please check again later.\n`,
-    );
-    Deno.exit(126);
-  } else {
-    console.error(
-      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
-    );
-    Deno.exit(127);
+  if (result.is_failure) {
+      Deno.exit(127);
+  } else if (result.incomplete_packages_count !== 0) {
+      Deno.exit(126);
   }
 }
 
@@ -215,5 +201,77 @@ function checkPipVersion() {
       `[${red("phylum")}] Pip version 23.0.0 or higher is required.\n`,
     );
     Deno.exit(128);
+  }
+}
+
+// Write the analysis result status to STDOUT/STDERRR.
+function logPackageAnalysisResults(result: Record<string, unknown>) {
+  if (!result.is_failure && result.incomplete_packages_count == 0) {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+    );
+  } else if (!result.is_failure) {
+    console.warn(
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+    );
+
+    // Ensure correct pluralization for incomplete packages.
+    let unprocessedText =
+      `${result.incomplete_packages_count} unprocessed package`;
+    if (result.incomplete_packages_count > 1) {
+      unprocessedText += "s";
+    }
+
+    const yellowPhylum = yellow("phylum");
+    console.warn(
+      `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
+    );
+  } else {
+    console.error(
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
+    );
+
+    let output = "";
+    for (const pkg of result.dependencies) {
+        // Skip packages without policy rejections.
+        if (pkg.rejections.length === 0) {
+            continue;
+        }
+
+        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+        for (const rejection of pkg.rejections) {
+            // Skip suppressed issues.
+            if (rejection.suppressed) {
+                continue;
+            }
+
+            // Format rejection title.
+            const domain = `[${rejection.source.domain || "     "}]`;
+            const message = `${domain} ${rejection.title}`;
+
+            // Color rejection based on severity.
+            let colored;
+            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
+                colored = green(message);
+            } else if (rejection.source.severity === "medium") {
+                colored = yellow(message);
+            } else {
+                colored = red(message);
+            }
+
+            output += ` ${colored}\n`;
+        }
+    }
+    if (result.dependencies.length !== 0) {
+        output += "\n";
+    }
+
+    // Print web URI for the job results.
+    if (result.job_link) {
+        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+    }
+
+    console.error(output);
   }
 }

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -1,4 +1,4 @@
-import { PhylumApi } from "phylum";
+import { PhylumApi, PolicyEvaluationResponseRaw } from "phylum";
 import {
   green,
   red,
@@ -205,7 +205,7 @@ function checkPipVersion() {
 }
 
 // Write the analysis result status to STDOUT/STDERRR.
-function logPackageAnalysisResults(result: Record<string, unknown>) {
+function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
   if (!result.is_failure && result.incomplete_packages_count == 0) {
     console.log(
       `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -212,7 +212,7 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     );
   } else if (result.incomplete_packages_count > 0) {
     console.warn(
-      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE\n`,
     );
   } else {
     console.log(

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -1,4 +1,4 @@
-import { PhylumApi } from "phylum";
+import { PhylumApi, PolicyEvaluationResponseRaw } from "phylum";
 import {
   green,
   red,
@@ -204,7 +204,7 @@ async function poetryCheckDryRun(
 }
 
 // Write the analysis result status to STDOUT/STDERRR.
-function logPackageAnalysisResults(result: Record<string, unknown>) {
+function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
   if (!result.is_failure && result.incomplete_packages_count == 0) {
     console.log(
       `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -194,12 +194,12 @@ async function poetryCheckDryRun(
 
   // Run Phylum analysis on the packages.
   const checkResult = await PhylumApi.checkPackagesRaw(packages);
-  logPackageAnalysisResults(result);
+  logPackageAnalysisResults(checkResult);
 
-  if (result.is_failure) {
-      Deno.exit(122);
-  } else if (result.incomplete_packages_count !== 0) {
-      Deno.exit(123);
+  if (checkResult.is_failure) {
+    Deno.exit(122);
+  } else if (checkResult.incomplete_packages_count !== 0) {
+    Deno.exit(123);
   }
 }
 
@@ -232,43 +232,47 @@ function logPackageAnalysisResults(result: Record<string, unknown>) {
 
     let output = "";
     for (const pkg of result.dependencies) {
-        // Skip packages without policy rejections.
-        if (pkg.rejections.length === 0) {
-            continue;
+      // Skip packages without policy rejections.
+      if (pkg.rejections.length === 0) {
+        continue;
+      }
+
+      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+      for (const rejection of pkg.rejections) {
+        // Skip suppressed issues.
+        if (rejection.suppressed) {
+          continue;
         }
 
-        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+        // Format rejection title.
+        const domain = `[${rejection.source.domain || "     "}]`;
+        const message = `${domain} ${rejection.title}`;
 
-        for (const rejection of pkg.rejections) {
-            // Skip suppressed issues.
-            if (rejection.suppressed) {
-                continue;
-            }
-
-            // Format rejection title.
-            const domain = `[${rejection.source.domain || "     "}]`;
-            const message = `${domain} ${rejection.title}`;
-
-            // Color rejection based on severity.
-            let colored;
-            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
-                colored = green(message);
-            } else if (rejection.source.severity === "medium") {
-                colored = yellow(message);
-            } else {
-                colored = red(message);
-            }
-
-            output += ` ${colored}\n`;
+        // Color rejection based on severity.
+        let colored;
+        if (
+          rejection.source.severity === "low" ||
+          rejection.source.severity === "info"
+        ) {
+          colored = green(message);
+        } else if (rejection.source.severity === "medium") {
+          colored = yellow(message);
+        } else {
+          colored = red(message);
         }
+
+        output += ` ${colored}\n`;
+      }
     }
     if (result.dependencies.length !== 0) {
-        output += "\n";
+      output += "\n";
     }
 
     // Print web URI for the job results.
     if (result.job_link) {
-        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+      output +=
+        `You can find the interactive report here:\n ${result.job_link}\n`;
     }
 
     console.error(output);

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -193,26 +193,84 @@ async function poetryCheckDryRun(
   }
 
   // Run Phylum analysis on the packages.
-  const checkResult = await PhylumApi.checkPackages(packages);
+  const checkResult = await PhylumApi.checkPackagesRaw(packages);
+  logPackageAnalysisResults(result);
 
-  if (!checkResult.is_failure && checkResult.incomplete_count == 0) {
-    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
-  } else if (!checkResult.is_failure) {
-    console.warn(
-      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
+  if (result.is_failure) {
+      Deno.exit(122);
+  } else if (result.incomplete_packages_count !== 0) {
+      Deno.exit(123);
+  }
+}
+
+// Write the analysis result status to STDOUT/STDERRR.
+function logPackageAnalysisResults(result: Record<string, unknown>) {
+  if (!result.is_failure && result.incomplete_packages_count == 0) {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
     );
+  } else if (!result.is_failure) {
     console.warn(
-      `[${
-        yellow(
-          "phylum",
-        )
-      }] Unknown packages were submitted for analysis, please check again later.\n`,
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
     );
-    Deno.exit(123);
+
+    // Ensure correct pluralization for incomplete packages.
+    let unprocessedText =
+      `${result.incomplete_packages_count} unprocessed package`;
+    if (result.incomplete_packages_count > 1) {
+      unprocessedText += "s";
+    }
+
+    const yellowPhylum = yellow("phylum");
+    console.warn(
+      `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
+    );
   } else {
     console.error(
-      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
     );
-    Deno.exit(122);
+
+    let output = "";
+    for (const pkg of result.dependencies) {
+        // Skip packages without policy rejections.
+        if (pkg.rejections.length === 0) {
+            continue;
+        }
+
+        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+        for (const rejection of pkg.rejections) {
+            // Skip suppressed issues.
+            if (rejection.suppressed) {
+                continue;
+            }
+
+            // Format rejection title.
+            const domain = `[${rejection.source.domain || "     "}]`;
+            const message = `${domain} ${rejection.title}`;
+
+            // Color rejection based on severity.
+            let colored;
+            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
+                colored = green(message);
+            } else if (rejection.source.severity === "medium") {
+                colored = yellow(message);
+            } else {
+                colored = red(message);
+            }
+
+            output += ` ${colored}\n`;
+        }
+    }
+    if (result.dependencies.length !== 0) {
+        output += "\n";
+    }
+
+    // Print web URI for the job results.
+    if (result.job_link) {
+        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+    }
+
+    console.error(output);
   }
 }

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -205,15 +205,22 @@ async function poetryCheckDryRun(
 
 // Write the analysis result status to STDOUT/STDERRR.
 function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
-  if (!result.is_failure && result.incomplete_packages_count == 0) {
-    console.log(
-      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+  if (result.is_failure) {
+    console.error(
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
     );
-  } else if (!result.is_failure) {
+  } else if (result.incomplete_packages_count > 0) {
     console.warn(
       `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
     );
+  } else {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+    );
+  }
 
+  // Print warning regarding incomplete packages.
+  if (result.incomplete_packages_count > 0) {
     // Ensure correct pluralization for incomplete packages.
     let unprocessedText =
       `${result.incomplete_packages_count} unprocessed package`;
@@ -225,56 +232,52 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     console.warn(
       `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
     );
-  } else {
-    console.error(
-      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
-    );
+  }
 
-    let output = "";
-    for (const pkg of result.dependencies) {
-      // Skip packages without policy rejections.
-      if (pkg.rejections.length === 0) {
+  // Print policy violations.
+  let output = "";
+  for (const pkg of result.dependencies) {
+    // Skip packages without policy rejections.
+    if (pkg.rejections.length === 0) {
+      continue;
+    }
+
+    output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+    for (const rejection of pkg.rejections) {
+      // Skip suppressed issues.
+      if (rejection.suppressed) {
         continue;
       }
 
-      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+      // Format rejection title.
+      const domain = `[${rejection.source.domain || "     "}]`;
+      const message = `${domain} ${rejection.title}`;
 
-      for (const rejection of pkg.rejections) {
-        // Skip suppressed issues.
-        if (rejection.suppressed) {
-          continue;
-        }
-
-        // Format rejection title.
-        const domain = `[${rejection.source.domain || "     "}]`;
-        const message = `${domain} ${rejection.title}`;
-
-        // Color rejection based on severity.
-        let colored;
-        if (
-          rejection.source.severity === "low" ||
-          rejection.source.severity === "info"
-        ) {
-          colored = green(message);
-        } else if (rejection.source.severity === "medium") {
-          colored = yellow(message);
-        } else {
-          colored = red(message);
-        }
-
-        output += ` ${colored}\n`;
+      // Color rejection based on severity.
+      let colored;
+      if (
+        rejection.source.severity === "low" ||
+        rejection.source.severity === "info"
+      ) {
+        colored = green(message);
+      } else if (rejection.source.severity === "medium") {
+        colored = yellow(message);
+      } else {
+        colored = red(message);
       }
-    }
-    if (result.dependencies.length !== 0) {
-      output += "\n";
-    }
 
-    // Print web URI for the job results.
-    if (result.job_link) {
-      output +=
-        `You can find the interactive report here:\n ${result.job_link}\n`;
+      output += ` ${colored}\n`;
     }
+  }
+  if (output.length !== 0) {
+    console.error(output + "\n");
+  }
 
-    console.error(output);
+  // Print web URI for the job results.
+  if (result.job_link) {
+    console.log(
+      `You can find the interactive report here:\n ${result.job_link}\n`,
+    );
   }
 }

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -211,7 +211,7 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     );
   } else if (result.incomplete_packages_count > 0) {
     console.warn(
-      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE\n`,
     );
   } else {
     console.log(

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -3,7 +3,7 @@ import {
   red,
   yellow,
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
-import { PhylumApi } from "phylum";
+import { PhylumApi, PolicyEvaluationResponseRaw } from "phylum";
 
 class FileBackup {
   readonly fileName: string;
@@ -236,7 +236,7 @@ async function restoreBackup() {
 }
 
 // Write the analysis result status to STDOUT/STDERRR.
-function logPackageAnalysisResults(result: Record<string, unknown>) {
+function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
   if (!result.is_failure && result.incomplete_packages_count == 0) {
     console.log(
       `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -243,7 +243,7 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     );
   } else if (result.incomplete_packages_count > 0) {
     console.warn(
-      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE\n`,
     );
   } else {
     console.log(

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -237,15 +237,22 @@ async function restoreBackup() {
 
 // Write the analysis result status to STDOUT/STDERRR.
 function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
-  if (!result.is_failure && result.incomplete_packages_count == 0) {
-    console.log(
-      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+  if (result.is_failure) {
+    console.error(
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
     );
-  } else if (!result.is_failure) {
+  } else if (result.incomplete_packages_count > 0) {
     console.warn(
       `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
     );
+  } else {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+    );
+  }
 
+  // Print warning regarding incomplete packages.
+  if (result.incomplete_packages_count > 0) {
     // Ensure correct pluralization for incomplete packages.
     let unprocessedText =
       `${result.incomplete_packages_count} unprocessed package`;
@@ -257,56 +264,52 @@ function logPackageAnalysisResults(result: PolicyEvaluationResponseRaw) {
     console.warn(
       `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
     );
-  } else {
-    console.error(
-      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
-    );
+  }
 
-    let output = "";
-    for (const pkg of result.dependencies) {
-      // Skip packages without policy rejections.
-      if (pkg.rejections.length === 0) {
+  // Print policy violations.
+  let output = "";
+  for (const pkg of result.dependencies) {
+    // Skip packages without policy rejections.
+    if (pkg.rejections.length === 0) {
+      continue;
+    }
+
+    output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+    for (const rejection of pkg.rejections) {
+      // Skip suppressed issues.
+      if (rejection.suppressed) {
         continue;
       }
 
-      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+      // Format rejection title.
+      const domain = `[${rejection.source.domain || "     "}]`;
+      const message = `${domain} ${rejection.title}`;
 
-      for (const rejection of pkg.rejections) {
-        // Skip suppressed issues.
-        if (rejection.suppressed) {
-          continue;
-        }
-
-        // Format rejection title.
-        const domain = `[${rejection.source.domain || "     "}]`;
-        const message = `${domain} ${rejection.title}`;
-
-        // Color rejection based on severity.
-        let colored;
-        if (
-          rejection.source.severity === "low" ||
-          rejection.source.severity === "info"
-        ) {
-          colored = green(message);
-        } else if (rejection.source.severity === "medium") {
-          colored = yellow(message);
-        } else {
-          colored = red(message);
-        }
-
-        output += ` ${colored}\n`;
+      // Color rejection based on severity.
+      let colored;
+      if (
+        rejection.source.severity === "low" ||
+        rejection.source.severity === "info"
+      ) {
+        colored = green(message);
+      } else if (rejection.source.severity === "medium") {
+        colored = yellow(message);
+      } else {
+        colored = red(message);
       }
-    }
-    if (result.dependencies.length !== 0) {
-      output += "\n";
-    }
 
-    // Print web URI for the job results.
-    if (result.job_link) {
-      output +=
-        `You can find the interactive report here:\n ${result.job_link}\n`;
+      output += ` ${colored}\n`;
     }
+  }
+  if (output.length !== 0) {
+    console.error(output + "\n");
+  }
 
-    console.error(output);
+  // Print web URI for the job results.
+  if (result.job_link) {
+    console.log(
+      `You can find the interactive report here:\n ${result.job_link}\n`,
+    );
   }
 }

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -214,9 +214,9 @@ async function checkDryRun() {
   logPackageAnalysisResults(result);
 
   if (result.is_failure) {
-      Deno.exit(127);
+    Deno.exit(127);
   } else if (result.incomplete_packages_count !== 0) {
-      Deno.exit(126);
+    Deno.exit(126);
   }
 }
 
@@ -264,43 +264,47 @@ function logPackageAnalysisResults(result: Record<string, unknown>) {
 
     let output = "";
     for (const pkg of result.dependencies) {
-        // Skip packages without policy rejections.
-        if (pkg.rejections.length === 0) {
-            continue;
+      // Skip packages without policy rejections.
+      if (pkg.rejections.length === 0) {
+        continue;
+      }
+
+      output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+      for (const rejection of pkg.rejections) {
+        // Skip suppressed issues.
+        if (rejection.suppressed) {
+          continue;
         }
 
-        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+        // Format rejection title.
+        const domain = `[${rejection.source.domain || "     "}]`;
+        const message = `${domain} ${rejection.title}`;
 
-        for (const rejection of pkg.rejections) {
-            // Skip suppressed issues.
-            if (rejection.suppressed) {
-                continue;
-            }
-
-            // Format rejection title.
-            const domain = `[${rejection.source.domain || "     "}]`;
-            const message = `${domain} ${rejection.title}`;
-
-            // Color rejection based on severity.
-            let colored;
-            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
-                colored = green(message);
-            } else if (rejection.source.severity === "medium") {
-                colored = yellow(message);
-            } else {
-                colored = red(message);
-            }
-
-            output += ` ${colored}\n`;
+        // Color rejection based on severity.
+        let colored;
+        if (
+          rejection.source.severity === "low" ||
+          rejection.source.severity === "info"
+        ) {
+          colored = green(message);
+        } else if (rejection.source.severity === "medium") {
+          colored = yellow(message);
+        } else {
+          colored = red(message);
         }
+
+        output += ` ${colored}\n`;
+      }
     }
     if (result.dependencies.length !== 0) {
-        output += "\n";
+      output += "\n";
     }
 
     // Print web URI for the job results.
     if (result.job_link) {
-        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+      output +=
+        `You can find the interactive report here:\n ${result.job_link}\n`;
     }
 
     console.error(output);

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -210,27 +210,13 @@ async function checkDryRun() {
     return;
   }
 
-  const result = await PhylumApi.checkPackages(lockfile.packages);
+  const result = await PhylumApi.checkPackagesRaw(lockfile.packages);
+  logPackageAnalysisResults(result);
 
-  if (!result.is_failure && result.incomplete_count == 0) {
-    console.log(`[${green("phylum")}] Supply Chain Risk Analysis - SUCCESS\n`);
-  } else if (!result.is_failure) {
-    console.warn(
-      `[${yellow("phylum")}] Supply Chain Risk Analysis - INCOMPLETE`,
-    );
-    console.warn(
-      `[${
-        yellow(
-          "phylum",
-        )
-      }] Unknown packages were submitted for analysis, please check again later.\n`,
-    );
-    Deno.exit(126);
-  } else {
-    console.error(
-      `[${red("phylum")}] Supply Chain Risk Analysis - FAILURE\n`,
-    );
-    Deno.exit(127);
+  if (result.is_failure) {
+      Deno.exit(127);
+  } else if (result.incomplete_packages_count !== 0) {
+      Deno.exit(126);
   }
 }
 
@@ -247,4 +233,76 @@ async function abort(code: number) {
 async function restoreBackup() {
   await packageLockBackup.restoreOrDelete();
   await manifestBackup.restoreOrDelete();
+}
+
+// Write the analysis result status to STDOUT/STDERRR.
+function logPackageAnalysisResults(result: Record<string, unknown>) {
+  if (!result.is_failure && result.incomplete_packages_count == 0) {
+    console.log(
+      `[${green("phylum")}] Phylum Supply Chain Risk Analysis - SUCCESS\n`,
+    );
+  } else if (!result.is_failure) {
+    console.warn(
+      `[${yellow("phylum")}] Phylum Supply Chain Risk Analysis - INCOMPLETE`,
+    );
+
+    // Ensure correct pluralization for incomplete packages.
+    let unprocessedText =
+      `${result.incomplete_packages_count} unprocessed package`;
+    if (result.incomplete_packages_count > 1) {
+      unprocessedText += "s";
+    }
+
+    const yellowPhylum = yellow("phylum");
+    console.warn(
+      `[${yellowPhylum}] The analysis contains ${unprocessedText}, preventing a complete risk analysis. Phylum is currently processing these packages and should complete soon. Please wait for up to 30 minutes, then re-run the analysis.\n`,
+    );
+  } else {
+    console.error(
+      `[${red("phylum")}] Phylum Supply Chain Risk Analysis - FAILURE\n`,
+    );
+
+    let output = "";
+    for (const pkg of result.dependencies) {
+        // Skip packages without policy rejections.
+        if (pkg.rejections.length === 0) {
+            continue;
+        }
+
+        output += `[${pkg.registry}] ${pkg.name}@${pkg.version}\n`;
+
+        for (const rejection of pkg.rejections) {
+            // Skip suppressed issues.
+            if (rejection.suppressed) {
+                continue;
+            }
+
+            // Format rejection title.
+            const domain = `[${rejection.source.domain || "     "}]`;
+            const message = `${domain} ${rejection.title}`;
+
+            // Color rejection based on severity.
+            let colored;
+            if (rejection.source.severity === "low" || rejection.source.severity === "info") {
+                colored = green(message);
+            } else if (rejection.source.severity === "medium") {
+                colored = yellow(message);
+            } else {
+                colored = red(message);
+            }
+
+            output += ` ${colored}\n`;
+        }
+    }
+    if (result.dependencies.length !== 0) {
+        output += "\n";
+    }
+
+    // Print web URI for the job results.
+    if (result.job_link) {
+        output += `You can find the interactive report here:\n ${result.job_link}\n`;
+    }
+
+    console.error(output);
+  }
 }


### PR DESCRIPTION
This adds the new `getJobStatusRaw` and `checkPackagesRaw` extension APIs which allow retrieving a more detailed analysis report.

The ecosystem extensions are also switched over to `checkPackagesRaw`, allowing the output to match the CLI's analysis output, which provides additional details on failure.

Closes #1093.
