### PR TITLE
Use locksmith tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,7 @@ dependencies = [
  "toml 0.7.6",
  "unicode-width",
  "url",
+ "uuid",
  "vuln-reach",
  "vulnreach_types",
  "walkdir",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -67,6 +67,7 @@ deno_ast = { version = "0.27.2", features = ["transpiling"] }
 birdcage = { version = "0.2.0" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
+uuid = "1.4.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -160,6 +160,11 @@ pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/openid-configuration")?)
 }
 
+/// GET /.well-known/locksmith-configuration
+pub fn locksmith_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_api_path(api_uri)?.join(".well-known/locksmith-configuration")?)
+}
+
 /// POST /reachability/vulnerabilities
 pub fn vulnreach(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(parse_base_url(api_uri)?.join("reachability/vulnerabilities")?)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -175,9 +175,10 @@ impl PhylumApi {
             },
         };
 
-        let tokens = handle_refresh_tokens(&refresh_token, ignore_certs, &config.connection.uri)
-            .await
-            .context("Token refresh failed")?;
+        let access_token =
+            handle_refresh_tokens(&refresh_token, ignore_certs, &config.connection.uri)
+                .await
+                .context("Token refresh failed")?;
 
         let mut headers = HeaderMap::new();
         // the cli runs a command or a few short commands then exits, so we do
@@ -185,7 +186,7 @@ impl PhylumApi {
         // here and be done.
         headers.insert(
             "Authorization",
-            HeaderValue::from_str(&format!("Bearer {}", tokens.access_token)).unwrap(),
+            HeaderValue::from_str(&format!("Bearer {}", access_token)).unwrap(),
         );
         headers.insert("Accept", HeaderValue::from_str("application/json").unwrap());
 
@@ -197,7 +198,7 @@ impl PhylumApi {
             .build()?;
 
         // Try to parse token's roles.
-        let roles = jwt::user_roles(tokens.access_token.as_str()).unwrap_or_default();
+        let roles = jwt::user_roles(access_token.as_str()).unwrap_or_default();
 
         Ok(Self { config, client, roles })
     }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -168,7 +168,7 @@ impl PhylumApi {
             Some(refresh_token) => refresh_token.clone(),
             None => {
                 let refresh_token =
-                    handle_auth_flow(AuthAction::Login, ignore_certs, &config.connection.uri)
+                    handle_auth_flow(AuthAction::Login, None, ignore_certs, &config.connection.uri)
                         .await
                         .context("User login failed")?;
                 config.auth_info.set_offline_access(refresh_token.clone());
@@ -209,12 +209,13 @@ impl PhylumApi {
     /// credentials. It is the duty of the calling code to save any changes
     pub async fn login(
         mut auth_info: AuthInfo,
+        token_name: Option<String>,
         ignore_certs: bool,
         api_uri: &str,
         reauth: bool,
     ) -> Result<AuthInfo> {
         let action = if reauth { AuthAction::Reauth } else { AuthAction::Login };
-        let refresh_token = handle_auth_flow(action, ignore_certs, api_uri).await?;
+        let refresh_token = handle_auth_flow(action, token_name, ignore_certs, api_uri).await?;
         auth_info.set_offline_access(refresh_token);
         Ok(auth_info)
     }
@@ -224,10 +225,12 @@ impl PhylumApi {
     /// credentials. It is the duty of the calling code to save any changes
     pub async fn register(
         mut auth_info: AuthInfo,
+        token_name: Option<String>,
         ignore_certs: bool,
         api_uri: &str,
     ) -> Result<AuthInfo> {
-        let refresh_token = handle_auth_flow(AuthAction::Register, ignore_certs, api_uri).await?;
+        let refresh_token =
+            handle_auth_flow(AuthAction::Register, token_name, ignore_certs, api_uri).await?;
         auth_info.set_offline_access(refresh_token);
         Ok(auth_info)
     }

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -27,7 +27,8 @@ use crate::api::endpoints::BaseUriError;
 use crate::app::USER_AGENT;
 use crate::auth::jwt::RealmRole;
 use crate::auth::{
-    fetch_oidc_server_settings, handle_auth_flow, handle_refresh_tokens, jwt, AuthAction, UserInfo,
+    fetch_locksmith_server_settings, handle_auth_flow, handle_refresh_tokens, jwt, AuthAction,
+    UserInfo,
 };
 use crate::config::{AuthInfo, Config};
 use crate::types::{
@@ -241,10 +242,12 @@ impl PhylumApi {
 
     /// Get information about the authenticated user
     pub async fn user_info(&self) -> Result<UserInfo> {
-        let oidc_settings =
-            fetch_oidc_server_settings(self.config.ignore_certs(), &self.config.connection.uri)
-                .await?;
-        self.get(oidc_settings.userinfo_endpoint).await
+        let locksmith_settings = fetch_locksmith_server_settings(
+            self.config.ignore_certs(),
+            &self.config.connection.uri,
+        )
+        .await?;
+        self.get(locksmith_settings.userinfo_endpoint).await
     }
 
     /// Create a new project

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -188,15 +188,32 @@ pub fn add_subcommands(command: Command) -> Command {
                 .about("Manage authentication, registration, and API keys")
                 .arg_required_else_help(true)
                 .subcommand_required(true)
-                .subcommand(Command::new("register").about("Register a new account"))
                 .subcommand(
-                    Command::new("login").about("Login to an existing account").arg(
-                        Arg::new("reauth")
-                            .action(ArgAction::SetTrue)
-                            .short('r')
-                            .long("reauth")
-                            .help("Force a login prompt"),
+                    Command::new("register").about("Register a new account").arg(
+                        Arg::new("token-name")
+                            .action(ArgAction::Set)
+                            .short('n')
+                            .long("token-name")
+                            .help("API token name"),
                     ),
+                )
+                .subcommand(
+                    Command::new("login")
+                        .about("Login to an existing account")
+                        .arg(
+                            Arg::new("reauth")
+                                .action(ArgAction::SetTrue)
+                                .short('r')
+                                .long("reauth")
+                                .help("Force a login prompt"),
+                        )
+                        .arg(
+                            Arg::new("token-name")
+                                .action(ArgAction::Set)
+                                .short('n')
+                                .long("token-name")
+                                .help("API token name"),
+                        ),
                 )
                 .subcommand(
                     Command::new("status").about("Return the current authentication status"),

--- a/cli/src/auth/mod.rs
+++ b/cli/src/auth/mod.rs
@@ -6,3 +6,7 @@ mod ip_addr_ext;
 pub mod jwt;
 mod oidc;
 mod server;
+
+pub fn is_locksmith_token(token: impl AsRef<str>) -> bool {
+    token.as_ref().starts_with("ph0_")
+}

--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use base64::engine::general_purpose;
 use base64::Engine as _;
 use maplit::hashmap;
-use phylum_types::types::auth::{AuthorizationCode, RefreshToken, TokenResponse};
+use phylum_types::types::auth::{AccessToken, AuthorizationCode, RefreshToken, TokenResponse};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use reqwest::Url;
@@ -281,9 +281,11 @@ pub async fn handle_refresh_tokens(
     refresh_token: &RefreshToken,
     ignore_certs: bool,
     api_uri: &str,
-) -> Result<TokenResponse> {
+) -> Result<AccessToken> {
     let oidc_settings = fetch_oidc_server_settings(ignore_certs, api_uri).await?;
-    refresh_tokens(&oidc_settings, refresh_token, ignore_certs).await
+    refresh_tokens(&oidc_settings, refresh_token, ignore_certs)
+        .await
+        .map(|token| token.access_token)
 }
 
 /// Represents the userdata stored for an authentication token.

--- a/cli/src/auth/server.rs
+++ b/cli/src/auth/server.rs
@@ -219,6 +219,7 @@ async fn spawn_server_and_get_auth_code(
 /// Handle the user login/registration flow.
 pub async fn handle_auth_flow(
     auth_action: AuthAction,
+    token_name: Option<String>,
     ignore_certs: bool,
     api_uri: &str,
 ) -> Result<RefreshToken> {
@@ -228,9 +229,16 @@ pub async fn handle_auth_flow(
     let (auth_code, callback_url) =
         spawn_server_and_get_auth_code(&locksmith_settings, auth_action, &challenge_code, state)
             .await?;
-    acquire_tokens(&locksmith_settings, &callback_url, &auth_code, &code_verifier, ignore_certs)
-        .await
-        .map(|tokens| tokens.token)
+    acquire_tokens(
+        &locksmith_settings,
+        &callback_url,
+        &auth_code,
+        &code_verifier,
+        token_name,
+        ignore_certs,
+    )
+    .await
+    .map(|tokens| tokens.token)
 }
 
 #[cfg(test)]
@@ -270,7 +278,7 @@ mod test {
         let (_verifier, _challenge) =
             CodeVerifier::generate(64).expect("Failed to build PKCE verifier and challenge");
 
-        let result = handle_auth_flow(AuthAction::Login, false, &api_uri).await?;
+        let result = handle_auth_flow(AuthAction::Login, None, false, &api_uri).await?;
 
         log::debug!("{:?}", result);
 
@@ -286,7 +294,7 @@ mod test {
         let (_verifier, _challenge) =
             CodeVerifier::generate(64).expect("Failed to build PKCE verifier and challenge");
 
-        let result = handle_auth_flow(AuthAction::Register, false, &api_uri).await?;
+        let result = handle_auth_flow(AuthAction::Register, None, false, &api_uri).await?;
 
         log::debug!("{:?}", result);
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -77,9 +77,9 @@ pub async fn handle_auth_token(config: &Config, matches: &clap::ArgMatches) -> C
 
     if matches.get_flag("bearer") {
         let api_uri = &config.connection.uri;
-        let tokens =
+        let access_token =
             auth::handle_refresh_tokens(refresh_token, config.ignore_certs(), api_uri).await?;
-        println!("{}", tokens.access_token);
+        println!("{}", access_token);
         Ok(ExitCode::Ok)
     } else {
         println!("{refresh_token}");

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -75,7 +75,7 @@ pub async fn handle_auth_status(config: Config, timeout: Option<u64>) -> Command
         Ok(user) => {
             print_user_success!(
                 "Currently authenticated as '{}<{}>' via {}",
-                user.name.map_or(" ".into(), |mut n| {
+                user.name.map_or_else(Default::default, |mut n| {
                     n.push(' ');
                     n
                 }),

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 use clap::ArgMatches;
+use log::debug;
 use phylum_types::types::auth::RefreshToken;
 use tokio::io::{self, AsyncBufReadExt, BufReader};
 
@@ -48,11 +49,17 @@ pub async fn handle_auth_status(config: Config, timeout: Option<u64>) -> Command
 
     let user_info = api.user_info().await;
 
+    debug!("User info reponse: {:?}", user_info);
+
     match user_info {
         Ok(user) => {
             print_user_success!(
-                "Currently authenticated as '{}' with long lived refresh token",
-                user.email
+                "Currently authenticated as '{}<{}>'",
+                user.name.map_or(" ".into(), |mut n| {
+                    n.push(' ');
+                    n
+                }),
+                user.email,
             );
             Ok(ExitCode::Ok)
         },

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -211,8 +211,7 @@ async fn get_access_token(
 
     let access_token =
         crate::auth::handle_refresh_tokens(&refresh_token, ignore_certs, &config.connection.uri)
-            .await?
-            .access_token;
+            .await?;
     Ok(access_token)
 }
 

--- a/docs/command_line_tool/phylum_auth_login.md
+++ b/docs/command_line_tool/phylum_auth_login.md
@@ -16,6 +16,9 @@ Usage: phylum auth login [OPTIONS]
 -r, --reauth
 &emsp; Force a login prompt
 
+-n, --token-name
+&emsp; API token name
+
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/command_line_tool/phylum_auth_register.md
+++ b/docs/command_line_tool/phylum_auth_register.md
@@ -13,6 +13,9 @@ Usage: phylum auth register [OPTIONS]
 
 ### Options
 
+-n, --token-name
+&emsp; API token name
+
 -v, --verbose...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 


### PR DESCRIPTION
This patch updates CLI to generate and use Locksmith tokens (aka "API keys")

For backwards compatibility, OIDC refresh tokens are still supported in the `settings.yaml` or via the `PHYLUM_API_KEY` environment variable. But they are no longer generated.