### PR TITLE
Use relative paths when project root is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Include lockfile paths when analyzing projects
+- Remove root path from lockfile paths
 
 ## [5.5.0] - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include lockfile paths when analyzing projects
 - Generate and use API Keys instead of OpenID Connect tokens
-- Use relative paths for project lockfile path submissions
 
 ### Fixed
 - Search for manifests' lockfiles in parent, rather than child directories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include lockfile paths when analyzing projects
 - Generate and use API Keys instead of OpenID Connect tokens
-- Remove root path from lockfile paths
+- Use relative paths for project lockfile path submissions
 
 ### Fixed
 - Search for manifests' lockfiles in parent, rather than child directories

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -384,8 +384,11 @@ async fn parse_lockfile(
         permissions.check_read(Path::new(&lockfile), "phylum")?;
     }
 
+    // Get .phylum_project path
+    let project_root = phylum_project::get_current_project().map(|p| p.root().to_owned());
+
     // Attempt to parse as requested lockfile type.
-    let parsed = parse::parse_lockfile(lockfile, lockfile_type.as_deref())?;
+    let parsed = parse::parse_lockfile(lockfile, &project_root, lockfile_type.as_deref())?;
 
     Ok(PackageLock { packages: parsed.packages, format: parsed.format })
 }

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -384,10 +384,11 @@ async fn parse_lockfile(
     }
 
     // Get .phylum_project path
-    let project_root = phylum_project::get_current_project().map(|p| p.root().to_owned());
+    let current_project = phylum_project::get_current_project();
+    let project_root = current_project.as_ref().map(|p| p.root());
 
     // Attempt to parse as requested lockfile type.
-    let parsed = parse::parse_lockfile(lockfile, &project_root, lockfile_type.as_deref())?;
+    let parsed = parse::parse_lockfile(lockfile, project_root, lockfile_type.as_deref())?;
 
     Ok(PackageLock { packages: parsed.packages, format: parsed.format })
 }

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -102,11 +102,18 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
 
         jobs_project = JobsProject::new(api, matches).await?;
 
+        // Get .phylum_project path
+        let project_root = phylum_project::get_current_project().map(|p| p.root().to_owned());
+
         for lockfile in jobs_project.lockfiles {
-            let res = parse::parse_lockfile(&lockfile.path, Some(&lockfile.lockfile_type))
-                .with_context(|| {
-                    format!("Unable to locate any valid package in lockfile {:?}", lockfile.path)
-                })?;
+            let res =
+                parse::parse_lockfile(&lockfile.path, &project_root, Some(&lockfile.lockfile_type))
+                    .with_context(|| {
+                        format!(
+                            "Unable to locate any valid package in lockfile {:?}",
+                            lockfile.path
+                        )
+                    })?;
 
             if pretty_print {
                 print_user_success!(

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -103,11 +103,12 @@ pub async fn handle_submission(api: &mut PhylumApi, matches: &clap::ArgMatches) 
         jobs_project = JobsProject::new(api, matches).await?;
 
         // Get .phylum_project path
-        let project_root = phylum_project::get_current_project().map(|p| p.root().to_owned());
+        let current_project = phylum_project::get_current_project();
+        let project_root = current_project.as_ref().map(|p| p.root());
 
         for lockfile in jobs_project.lockfiles {
             let res =
-                parse::parse_lockfile(&lockfile.path, &project_root, Some(&lockfile.lockfile_type))
+                parse::parse_lockfile(&lockfile.path, project_root, Some(&lockfile.lockfile_type))
                     .with_context(|| {
                         format!(
                             "Unable to locate any valid package in lockfile {:?}",

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -39,7 +39,17 @@ impl IntoIterator for ParsedLockfile {
     type Item = PackageDescriptorAndLockfile;
 
     fn into_iter(self) -> Self::IntoIter {
-        ParsedLockfileIterator { path: self.path, packages: self.packages.into_iter() }
+        // Get .phylum_project path
+        let root = phylum_project::get_current_project().map(|p| p.root().to_owned());
+        // Strip root path when set
+        let relative_path = match root {
+            Some(base) => match self.path.strip_prefix(&base) {
+                Ok(rel_path) => rel_path.to_path_buf(),
+                Err(_) => self.path.to_owned(),
+            },
+            None => self.path.to_owned(),
+        };
+        ParsedLockfileIterator { path: relative_path, packages: self.packages.into_iter() }
     }
 }
 

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -1,5 +1,6 @@
 //! `phylum parse` command for lockfile parsing
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::vec::IntoIter;
 use std::{env, fs, io};
@@ -55,14 +56,14 @@ pub fn lockfile_types(add_auto: bool) -> Vec<&'static str> {
 
 pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
     let project = phylum_project::get_current_project();
-    let project_root = project.as_ref().map(|p| p.root().to_owned());
+    let project_root = project.as_ref().map(|p| p.root());
     let lockfiles = config::lockfiles(matches, project.as_ref())?;
 
     let mut pkgs: Vec<PackageDescriptorAndLockfile> = Vec::new();
 
     for lockfile in lockfiles {
         let parsed_lockfile =
-            parse_lockfile(lockfile.path, &project_root, Some(&lockfile.lockfile_type))?;
+            parse_lockfile(lockfile.path, project_root, Some(&lockfile.lockfile_type))?;
         pkgs.extend(parsed_lockfile.into_iter());
     }
 
@@ -74,18 +75,17 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 /// Parse a package lockfile.
 pub fn parse_lockfile(
     path: impl Into<PathBuf>,
-    project_root: &Option<PathBuf>,
+    project_root: Option<&PathBuf>,
     lockfile_type: Option<&str>,
 ) -> Result<ParsedLockfile> {
     // Try and determine lockfile format.
     let path = path.into();
     let format = find_lockfile_format(&path, lockfile_type);
-    let project_root = project_root.to_owned();
 
     // Attempt to parse with all known parsers as fallback.
     let (format, lockfile) = match format {
         Some(format) => format,
-        None => return try_get_packages(path, &project_root),
+        None => return try_get_packages(path, project_root),
     };
 
     // Parse with the identified parser.
@@ -99,7 +99,7 @@ pub fn parse_lockfile(
         let packages = content.and_then(|content| parse_lockfile_content(&content, parser));
 
         // Attempt to strip root path for identified lockfile
-        let lockfile = strip_root_path(lockfile, &project_root);
+        let lockfile = strip_root_path(lockfile, project_root)?;
 
         match packages {
             Ok(packages) => return Ok(ParsedLockfile { path: lockfile, format, packages }),
@@ -204,9 +204,9 @@ fn find_manifest_format(path: &Path) -> Option<(LockfileFormat, Option<PathBuf>)
 }
 
 /// Attempt to get packages from an unknown lockfile type
-fn try_get_packages(path: PathBuf, project_root: &Option<PathBuf>) -> Result<ParsedLockfile> {
+fn try_get_packages(path: PathBuf, project_root: Option<&PathBuf>) -> Result<ParsedLockfile> {
     let data = fs::read_to_string(&path)?;
-    let lockfile = strip_root_path(path, project_root);
+    let lockfile = strip_root_path(path, project_root)?;
 
     for format in LockfileFormat::iter() {
         let parser = format.parser();
@@ -290,31 +290,25 @@ where
 /// function will return a path relative to this root. If no project root is
 /// provided, or if the path doesn't start with the project root, the function
 /// will return a path relative to the current directory.
-fn strip_root_path(path: PathBuf, project_root: &Option<PathBuf>) -> PathBuf {
-    let canonical_path = path.canonicalize().unwrap_or(path.clone());
-    let canonical_project_root =
-        project_root.as_ref().map(|p| p.canonicalize().unwrap_or(p.clone()));
+fn strip_root_path(path: PathBuf, project_root: Option<&PathBuf>) -> Result<PathBuf> {
+    let base: Cow<'_, Path> = match project_root {
+        Some(p) => p.into(),
+        None => env::current_dir()?.into(),
+    };
 
-    // If the canonical path starts with the provided project root, return the
-    // relative path.
-    if let Some(base) = &canonical_project_root {
-        return relative_from_to(base, &canonical_path);
-    }
-
-    // If there's no project root, return the path relative to the current
-    // directory.
-    let curr_dir = env::current_dir().unwrap_or_default();
-    relative_from_to(&curr_dir, &canonical_path)
+    relative_path(&base, &path)
 }
 
-/// Calculate a relative path from a starting directory (`from`) to a target
-/// path (`to`).
+/// Computes the relative path from the `from` path to the `to` path.
 ///
 /// This function iterates through the components of both paths in tandem. It
 /// skips the common prefix and then, for each remaining component in the
-/// starting directory, it adds a `..` to the result. Finally, it appends the
-/// unique components of the target path.
-fn relative_from_to(from: &Path, to: &Path) -> PathBuf {
+/// starting directory (`from`), it adds a `..` to the result. Finally, it
+/// appends the unique components of the target path (`to`).
+fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
+    let from = from.canonicalize()?;
+    let to = to.canonicalize()?;
+
     let mut from_components = from.components().peekable();
     let mut to_components = to.components().peekable();
 
@@ -328,7 +322,7 @@ fn relative_from_to(from: &Path, to: &Path) -> PathBuf {
         result.push("..");
     }
     result.extend(to_components);
-    result
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -366,7 +360,7 @@ mod tests {
         ];
 
         for (file, expected_format) in test_cases {
-            let parsed = try_get_packages(PathBuf::from(file), &None).unwrap();
+            let parsed = try_get_packages(PathBuf::from(file), None).unwrap();
             assert_eq!(parsed.format, expected_format, "{}", file);
         }
     }
@@ -419,23 +413,17 @@ mod tests {
         // Set up a temporary directory for testing.
         let tempdir = tempfile::tempdir().unwrap();
         let tempdir = tempdir.path().canonicalize().unwrap();
-        let curr_dir = env::current_dir().unwrap();
-
-        // Create a parent directory named "projects" within the temp directory.
-        let all_projects = tempdir.join("projects");
-        fs::create_dir_all(&all_projects).unwrap();
 
         // Create a sample project directory named "sample" inside the "projects"
         // directory. Also create a "Cargo.lock" file inside the "sample"
         // directory.
-        let sample_dir = all_projects.join("sample");
+        let sample_dir = tempdir.join("sample");
         let lockfile_path = sample_dir.join("Cargo.lock");
         fs::create_dir_all(&sample_dir).unwrap();
         File::create(&lockfile_path).unwrap();
 
         // Change the current directory to the "sample" project directory.
-        env::set_current_dir(&sample_dir).unwrap();
-        let path = strip_root_path(lockfile_path.clone(), &Some(sample_dir.clone()));
+        let path = relative_path(&sample_dir, &lockfile_path).unwrap();
         // The path to the lockfile should now be just the filename since it's in the
         // current directory.
         assert_eq!(path.as_os_str(), "Cargo.lock");
@@ -445,33 +433,24 @@ mod tests {
         fs::create_dir_all(&sub_dir).unwrap();
 
         // Change the current directory to the new "sub" directory.
-        env::set_current_dir(&sub_dir).unwrap();
-        let mut rel_lockfile_path = sub_dir.clone();
-        rel_lockfile_path.push("..");
-        rel_lockfile_path.push("Cargo.lock");
+        let rel_lockfile_path = sub_dir.join("../Cargo.lock");
 
         // Get the relative path from the sub directory to the lockfile in the sample
         // directory.
-        let path = strip_root_path(rel_lockfile_path.clone(), &Some(sample_dir.clone()));
+        let path = relative_path(&sample_dir, &rel_lockfile_path).unwrap();
         // The path to the lockfile should be the same as before since we are looking
         // relative to the sample directory.
         assert_eq!(path.as_os_str(), "Cargo.lock");
 
         // Create another "Cargo.lock" file one level above the "sample" directory.
-        let above_lockfile_path = all_projects.join("Cargo.lock");
+        let above_lockfile_path = tempdir.join("Cargo.lock");
         File::create(above_lockfile_path).unwrap();
-        let mut rel_lockfile_path = sub_dir;
-        rel_lockfile_path.push("..");
-        rel_lockfile_path.push("..");
-        rel_lockfile_path.push("Cargo.lock");
+        let rel_lockfile_path = sub_dir.join("../../Cargo.lock");
 
         // Although the current directory is still "sub", get the relative path to the
         // lockfile above the "sample" directory.
-        let path = strip_root_path(rel_lockfile_path.clone(), &Some(sample_dir.clone()));
+        let path = relative_path(&sample_dir, &rel_lockfile_path).unwrap();
         // The path to the lockfile should be relative to the "sample" directory.
         assert_eq!(path.as_os_str(), "../Cargo.lock");
-
-        // Restore the original working directory after the test.
-        env::set_current_dir(curr_dir).unwrap();
     }
 }

--- a/cli/tests/parse.rs
+++ b/cli/tests/parse.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use predicates::prelude::*;
+use tempfile::TempDir;
 
 use crate::common::TestCli;
 
@@ -29,18 +30,20 @@ fn parse_with_project_lockfile() {
 #[test]
 fn parse_with_project_lockfile_relative_paths() {
     // Setup CLI with temp dir.
-    let test_cli = TestCli::builder().cwd_temp().build();
-    let temp_path = test_cli.temp_path();
+    let tempdir = TempDir::new().unwrap();
+    let sensitive_dir = tempdir.path().join("sensitive_dir_name");
+    fs::create_dir_all(&sensitive_dir).unwrap();
+    let test_cli = TestCli::builder().cwd(sensitive_dir.clone()).build();
 
     // Write .phylum_project to temp dir.
     let config = "id: 00000000-0000-0000-0000-000000000000\nname: test\ncreated_at: \
                   2000-01-01T00:00:00.0Z\nlockfile_path: ./package-lock.json\nlockfile_type: npm";
-    fs::write(temp_path.join(".phylum_project"), config).unwrap();
+    fs::write(sensitive_dir.join(".phylum_project"), config).unwrap();
 
     // Copy lockfile to temp dir.
-    fs::copy("../tests/fixtures/package-lock.json", temp_path.join("./package-lock.json")).unwrap();
+    fs::copy("../tests/fixtures/package-lock.json", sensitive_dir.join("./package-lock.json"))
+        .unwrap();
 
-    let not_contain_var_folders =
-        predicate::function(|x: &str| !x.contains("\"lockfile\": \"/private/var/folders"));
-    test_cli.cmd().args(["parse"]).assert().success().stdout(not_contain_var_folders);
+    let not_sensitive_dir = predicate::str::contains("sensitive_dir_name").not();
+    test_cli.cmd().args(["parse"]).assert().success().stdout(not_sensitive_dir);
 }

--- a/cli/tests/parse.rs
+++ b/cli/tests/parse.rs
@@ -25,3 +25,22 @@ fn parse_with_project_lockfile() {
         .success()
         .stdout(predicate::str::contains("\"name\": \"typescript\""));
 }
+
+#[test]
+fn parse_with_project_lockfile_relative_paths() {
+    // Setup CLI with temp dir.
+    let test_cli = TestCli::builder().cwd_temp().build();
+    let temp_path = test_cli.temp_path();
+
+    // Write .phylum_project to temp dir.
+    let config = "id: 00000000-0000-0000-0000-000000000000\nname: test\ncreated_at: \
+                  2000-01-01T00:00:00.0Z\nlockfile_path: ./package-lock.json\nlockfile_type: npm";
+    fs::write(temp_path.join(".phylum_project"), config).unwrap();
+
+    // Copy lockfile to temp dir.
+    fs::copy("../tests/fixtures/package-lock.json", temp_path.join("./package-lock.json")).unwrap();
+
+    let not_contain_var_folders =
+        predicate::function(|x: &str| !x.contains("\"lockfile\": \"/private/var/folders"));
+    test_cli.cmd().args(["parse"]).assert().success().stdout(not_contain_var_folders);
+}


### PR DESCRIPTION
The lockfile paths were being submitted with an absolute path if the project root was set.

This can be caused by using relative lockfile paths in in the `.phylum_project`.


Closes https://github.com/phylum-dev/cli/issues/1169

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
