### PR TITLE
fix: update lockfile detection to search root directory first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include lockfile paths when analyzing projects
 
+### Fixed
+- Detect lockfile in current path before searching in subdirectories
+
 ## [5.5.0] - 2023-07-18
 
 ### Added

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -181,7 +181,26 @@ fn find_manifest_format(path: &Path) -> Option<(LockfileFormat, Option<PathBuf>)
 
     // Look for formats which already have a lockfile generated.
     let manifest_lockfile = formats.find_map(|format| {
+        // Check the root directory for a lockfile
+        let root_dir_entries = match fs::read_dir(manifest_dir) {
+            Ok(entries) => entries,
+            Err(_) => return None,
+        };
+
+        for entry_result in root_dir_entries {
+            match entry_result {
+                Ok(entry) => {
+                    if format.parser().is_path_lockfile(&entry.path()) {
+                        return Some((format, entry.path()));
+                    }
+                },
+                Err(_) => continue,
+            }
+        }
+
+        // If not found in root, then use WalkDir to search in the subdirectories
         let manifest_lockfile = WalkDir::new(manifest_dir)
+            .min_depth(1)
             .into_iter()
             .flatten()
             .find(|entry| format.parser().is_path_lockfile(entry.path()))?;
@@ -287,5 +306,12 @@ mod tests {
             let parsed = try_get_packages(PathBuf::from(file)).unwrap();
             assert_eq!(parsed.format, expected_format, "{}", file);
         }
+    }
+
+    #[test]
+    fn it_can_detect_correct_lockfile() {
+        let cli_cargo_toml = PathBuf::from("../Cargo.toml");
+        let (_, path) = find_manifest_format(&cli_cargo_toml).unwrap();
+        assert!(path.unwrap().ends_with("cli/Cargo.lock"));
     }
 }


### PR DESCRIPTION
The current search could potentially miss lock files in the current path.
This changes to search the current path first before sub directories.

Either way I imagine could still choose an incorrect lockfile related to another ecosystem if present.

Closes https://github.com/phylum-dev/cli/issues/1170

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
