### PR TITLE
Reverse search direction for manifests' lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include lockfile paths when analyzing projects
 
-### Fixed
-- Detect lockfile in current path before searching in subdirectories
-
 ## [5.5.0] - 2023-07-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include lockfile paths when analyzing projects
 
+### Fixed
+- Search for manifests' lockfiles in parent, rather than child directories
+
 ## [5.5.0] - 2023-07-18
 
 ### Added


### PR DESCRIPTION
Previously when a manifest was specified as the target for an analyze or
parse operation, the directory would be walked downwards depth-first to
find a lockfile for this manifest. This would both prefer lockfiles
farther away from the manifest and allow lockfiles from subdirectories.

This patch reverses the search direction for lockfiles, since they're
generally at or above their corresponding manifest. The new logic
prefers lockfiles closest to the manifest and searches the directory
tree upwards from there.

Closes https://github.com/phylum-dev/cli/issues/1170.