### PR TITLE
Add `auth list-tokens` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Generating lockfiles for `*.csproj` files
+- `phylum auth list-tokens` subcommand to list API tokens
 
 ### Changed
 - Include lockfile paths when analyzing projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `phylum auth list-tokens` subcommand to list API tokens
+
 ## [5.6.0] - 2023-08-08
 
 ### Added
 - Generating lockfiles for `*.csproj` files
-- `phylum auth list-tokens` subcommand to list API tokens
 
 ### Changed
 - Include lockfile paths when analyzing projects

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -4,7 +4,11 @@ use url::{ParseError, Url};
 
 use super::JobId;
 
+/// Phylum API base path.
 const API_PATH: &str = "api/v0/";
+
+/// Locksmith API base path.
+const LOCKSMITH_PATH: &str = "locksmith/v1/";
 
 // This wrapper provides important context to the user when their configuration
 // has a bad URL. Without it, the message can be something like "empty host".
@@ -165,6 +169,11 @@ pub fn locksmith_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/locksmith-configuration")?)
 }
 
+/// GET /tokens
+pub fn list_tokens(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_locksmith_path(api_uri)?.join("tokens")?)
+}
+
 /// POST /reachability/vulnerabilities
 pub fn vulnreach(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(parse_base_url(api_uri)?.join("reachability/vulnerabilities")?)
@@ -189,6 +198,10 @@ fn parse_base_url(api_uri: &str) -> Result<Url, BaseUriError> {
 
 fn get_api_path(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(parse_base_url(api_uri)?.join(API_PATH)?)
+}
+
+fn get_locksmith_path(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(parse_base_url(api_uri)?.join(LOCKSMITH_PATH)?)
 }
 
 #[cfg(test)]

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -166,7 +166,7 @@ pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
 
 /// GET /.well-known/locksmith-configuration
 pub fn locksmith_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join(".well-known/locksmith-configuration")?)
+    Ok(get_locksmith_path(api_uri)?.join(".well-known/locksmith-configuration")?)
 }
 
 /// GET /tokens

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -33,7 +33,7 @@ use crate::auth::{
 use crate::config::{AuthInfo, Config};
 use crate::types::{
     HistoryJob, PingResponse, PolicyEvaluationRequest, PolicyEvaluationResponse,
-    PolicyEvaluationResponseRaw,
+    PolicyEvaluationResponseRaw, UserToken,
 };
 
 pub mod endpoints;
@@ -94,8 +94,51 @@ struct ApiJsonError {
 }
 
 impl PhylumApi {
-    pub fn roles(&self) -> &HashSet<RealmRole> {
-        &self.roles
+    /// Create a phylum API client using the given Auth configuration, api url
+    /// and request timeout. If in the process of creating the client,
+    /// credentials must be obtained, the auth_info struct will be updated
+    /// with the new information. It is the duty of the calling code to save
+    /// any changes
+    pub async fn new(mut config: Config, request_timeout: Option<u64>) -> Result<Self> {
+        // Do we have a refresh token?
+        let ignore_certs = config.ignore_certs();
+        let refresh_token = match config.auth_info.offline_access() {
+            Some(refresh_token) => refresh_token.clone(),
+            None => {
+                let refresh_token =
+                    handle_auth_flow(AuthAction::Login, None, ignore_certs, &config.connection.uri)
+                        .await
+                        .context("User login failed")?;
+                config.auth_info.set_offline_access(refresh_token.clone());
+                refresh_token
+            },
+        };
+
+        let access_token = renew_access_token(&refresh_token, ignore_certs, &config.connection.uri)
+            .await
+            .context("Token refresh failed")?;
+
+        let mut headers = HeaderMap::new();
+        // the cli runs a command or a few short commands then exits, so we do
+        // not need to worry about refreshing the access token. We just set it
+        // here and be done.
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {}", access_token)).unwrap(),
+        );
+        headers.insert("Accept", HeaderValue::from_str("application/json").unwrap());
+
+        let client = Client::builder()
+            .user_agent(USER_AGENT.as_str())
+            .timeout(Duration::from_secs(request_timeout.unwrap_or(std::u64::MAX)))
+            .danger_accept_invalid_certs(ignore_certs)
+            .default_headers(headers)
+            .build()?;
+
+        // Try to parse token's roles.
+        let roles = jwt::user_roles(access_token.as_str()).unwrap_or_default();
+
+        Ok(Self { config, client, roles })
     }
 
     async fn get<T: DeserializeOwned, U: IntoUrl>(&self, path: U) -> Result<T> {
@@ -152,55 +195,6 @@ impl PhylumApi {
         }
 
         Ok(body)
-    }
-}
-
-impl PhylumApi {
-    /// Create a phylum API client using the given Auth configuration, api url
-    /// and request timeout. If in the process of creating the client,
-    /// credentials must be obtained, the auth_info struct will be updated
-    /// with the new information. It is the duty of the calling code to save
-    /// any changes
-    pub async fn new(mut config: Config, request_timeout: Option<u64>) -> Result<Self> {
-        // Do we have a refresh token?
-        let ignore_certs = config.ignore_certs();
-        let refresh_token = match config.auth_info.offline_access() {
-            Some(refresh_token) => refresh_token.clone(),
-            None => {
-                let refresh_token =
-                    handle_auth_flow(AuthAction::Login, None, ignore_certs, &config.connection.uri)
-                        .await
-                        .context("User login failed")?;
-                config.auth_info.set_offline_access(refresh_token.clone());
-                refresh_token
-            },
-        };
-
-        let access_token = renew_access_token(&refresh_token, ignore_certs, &config.connection.uri)
-            .await
-            .context("Token refresh failed")?;
-
-        let mut headers = HeaderMap::new();
-        // the cli runs a command or a few short commands then exits, so we do
-        // not need to worry about refreshing the access token. We just set it
-        // here and be done.
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_str(&format!("Bearer {}", access_token)).unwrap(),
-        );
-        headers.insert("Accept", HeaderValue::from_str("application/json").unwrap());
-
-        let client = Client::builder()
-            .user_agent(USER_AGENT.as_str())
-            .timeout(Duration::from_secs(request_timeout.unwrap_or(std::u64::MAX)))
-            .danger_accept_invalid_certs(ignore_certs)
-            .default_headers(headers)
-            .build()?;
-
-        // Try to parse token's roles.
-        let roles = jwt::user_roles(access_token.as_str()).unwrap_or_default();
-
-        Ok(Self { config, client, roles })
     }
 
     /// update auth info by forcing the login flow, using the given Auth
@@ -432,11 +426,21 @@ impl PhylumApi {
         Ok(())
     }
 
+    /// List a user's locksmith tokens.
+    pub async fn list_tokens(&self) -> Result<Vec<UserToken>> {
+        let url = endpoints::list_tokens(&self.config.connection.uri)?;
+        self.get(url).await
+    }
+
     /// Get reachable vulnerabilities.
     #[cfg(feature = "vulnreach")]
     pub async fn vulnerabilities(&self, job: Job) -> Result<Vec<Vulnerability>> {
         let url = endpoints::vulnreach(&self.config.connection.uri)?;
         self.post(url, job).await
+    }
+
+    pub fn roles(&self) -> &HashSet<RealmRole> {
+        &self.roles
     }
 
     pub fn config(&self) -> &Config {

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -234,6 +234,17 @@ pub fn add_subcommands(command: Command) -> Command {
                             .long("bearer")
                             .help("Output the short-lived bearer token for the Phylum API"),
                     ),
+                )
+                .subcommand(
+                    Command::new("list-tokens")
+                        .about("List all tokens associated with the logged-in user")
+                        .arg(
+                            Arg::new("json")
+                                .action(ArgAction::SetTrue)
+                                .short('j')
+                                .long("json")
+                                .help("Produce output in json format (default: false)"),
+                        ),
                 ),
         )
         .subcommand(Command::new("ping").about("Ping the remote system to verify it is available"))

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::io::{self, Write};
 use std::{cmp, str};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use console::style;
 use phylum_types::types::group::{
     GroupMember, ListGroupMembersResponse, ListUserGroupsResponse, UserGroup,
@@ -22,7 +22,7 @@ use vulnreach_types::Vulnerability;
 
 use crate::commands::status::PhylumStatus;
 use crate::print::{self, table_format};
-use crate::types::{HistoryJob, PolicyEvaluationResponse, PolicyEvaluationResponseRaw};
+use crate::types::{HistoryJob, PolicyEvaluationResponse, PolicyEvaluationResponseRaw, UserToken};
 
 /// Format type for CLI output.
 pub trait Format: Serialize {
@@ -177,7 +177,7 @@ impl Format for ListUserGroupsResponse {
         let table = format_table::<fn(&UserGroup) -> String, _>(&self.groups, &[
             ("Group Name", |group| print::truncate(&group.group_name, MAX_NAME_WIDTH).into_owned()),
             ("Owner", |group| print::truncate(&group.owner_email, MAX_OWNER_WIDTH).into_owned()),
-            ("Creation Time", |group| group.created_at.format("%FT%RZ").to_string()),
+            ("Creation Time", |group| format_datetime(group.created_at)),
         ]);
         let _ = writeln!(writer, "{table}");
     }
@@ -230,7 +230,7 @@ impl Format for Vec<JobDescriptor> {
             let date = job
                 .date
                 .parse::<DateTime<Utc>>()
-                .map(|date| date.format("%FT%RZ").to_string())
+                .map(format_datetime)
                 .unwrap_or_else(|_| "UNKNOWN".into());
 
             let _ = writeln!(writer, "Job ID: {}", style(job.job_id).cyan());
@@ -313,7 +313,22 @@ impl Format for Vec<HistoryJob> {
         let table = format_table::<fn(&HistoryJob) -> String, _>(self, &[
             ("Job ID", |job| job.id.clone()),
             ("Label", |job| job.label.clone().unwrap_or_default()),
-            ("Creation Time", |job| job.created.format("%FT%RZ").to_string()),
+            ("Creation Time", |job| format_datetime(job.created)),
+        ]);
+        let _ = writeln!(writer, "{table}");
+    }
+}
+
+impl Format for Vec<UserToken> {
+    fn pretty<W: Write>(&self, writer: &mut W) {
+        // Maximum length of the token name column.
+        const MAX_TOKEN_WIDTH: usize = 30;
+
+        let table = format_table::<fn(&UserToken) -> String, _>(self, &[
+            ("Name", |token| print::truncate(&token.name, MAX_TOKEN_WIDTH).into_owned()),
+            ("Creation Time", |token| format_datetime(token.creation_time)),
+            ("Access Time", |token| token.access_time.map_or(String::new(), format_datetime)),
+            ("Expiry", |token| token.expiry.map_or(String::new(), format_datetime)),
         ]);
         let _ = writeln!(writer, "{table}");
     }
@@ -455,4 +470,11 @@ fn risk_level_to_color(level: &RiskLevel) -> table_color::Color {
         RiskLevel::Low => table_color::BLUE,
         RiskLevel::Info => table_color::WHITE,
     }
+}
+
+/// Convert a UTC timestamp in the local timezone.
+fn format_datetime(timestamp: DateTime<Utc>) -> String {
+    let local: DateTime<Local> = timestamp.into();
+
+    local.format("%F %R").to_string()
 }

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -35,7 +35,7 @@ pub mod mockito {
     pub const DUMMY_AUTH_CODE: &str = "DUMMY_AUTH_CODE";
 
     pub const OIDC_URI: &str = "api/v0/.well-known/openid-configuration";
-    pub const LOCKSMITH_URI: &str = "api/v0/.well-known/locksmith-configuration";
+    pub const LOCKSMITH_URI: &str = "locksmith/v1/.well-known/locksmith-configuration";
     pub const AUTH_URI: &str = "auth";
     pub const USER_URI: &str = "user";
     pub const TOKEN_URI: &str = "token";

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -111,6 +111,15 @@ pub struct RejectionSource {
     pub reason: Option<String>,
 }
 
+/// Locksmith token details accessible after creation.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct UserToken {
+    pub name: String,
+    pub creation_time: DateTime<Utc>,
+    pub access_time: Option<DateTime<Utc>>,
+    pub expiry: Option<DateTime<Utc>>,
+}
+
 #[cfg(test)]
 mod tests {
     use phylum_types::types::package::RiskLevel;

--- a/docs/command_line_tool/phylum_auth.md
+++ b/docs/command_line_tool/phylum_auth.md
@@ -28,3 +28,4 @@ Usage: phylum auth [OPTIONS] <COMMAND>
 * [phylum auth status](./phylum_auth_status)
 * [phylum auth set-token](./phylum_auth_set-token)
 * [phylum auth token](./phylum_auth_token)
+* [phylum auth list-tokens](./phylum_auth_list-tokens)

--- a/docs/command_line_tool/phylum_auth_list-tokens.md
+++ b/docs/command_line_tool/phylum_auth_list-tokens.md
@@ -1,0 +1,25 @@
+---
+title: phylum auth list-tokens
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+List all tokens associated with the logged-in user
+
+```sh
+Usage: phylum auth list-tokens [OPTIONS]
+```
+
+### Options
+
+-j, --json
+&emsp; Produce output in json format (default: false)
+
+-v, --verbose...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+-q, --quiet...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+-h, --help
+&emsp; Print help


### PR DESCRIPTION
This patch adds a new `list-tokens` subcommand to the existing `auth` subcommand which lists all locksmith tokens associated with the logged in user.

See #1176.