### PR TITLE
Fix `Gemfile.lock` parsing with zero dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `phylum auth list-tokens` subcommand to list API tokens
 
+### Fixed
+- `Gemfile.lock` parsing with zero dependencies
+
 ## [5.6.0] - 2023-08-08
 
 ### Added

--- a/lockfile/src/parsers/gem.rs
+++ b/lockfile/src/parsers/gem.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{line_ending, not_line_ending, satisfy, space0};
-use nom::combinator::recognize;
+use nom::combinator::{opt, recognize};
 use nom::error::{VerboseError, VerboseErrorKind};
 use nom::multi::{many1, many_till};
 use nom::sequence::{delimited, tuple};
@@ -193,9 +193,10 @@ fn revision(input: &str) -> IResult<&str, &str> {
 }
 
 fn specs(input: &str) -> IResult<&str, &str> {
-    recognize(many_till(take_till_line_end, recognize(tuple((space0, tag("specs:"), line_ending)))))(
-        input,
-    )
+    recognize(many_till(
+        take_till_line_end,
+        recognize(tuple((space0, tag("specs:"), opt(line_ending)))),
+    ))(input)
 }
 
 fn package(input: &str) -> Result<Option<SpecsPackage>, NomErr<VerboseError<&str>>> {

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -90,4 +90,10 @@ mod tests {
             assert!(pkgs.contains(&expected_pkg), "missing package {expected_pkg:?}");
         }
     }
+
+    #[test]
+    fn empty_lockfile() {
+        let pkgs = GemLock.parse(include_str!("../../tests/fixtures/Gemfile.empty.lock")).unwrap();
+        assert!(pkgs.is_empty());
+    }
 }

--- a/tests/fixtures/Gemfile.empty.lock
+++ b/tests/fixtures/Gemfile.empty.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.4.13


### PR DESCRIPTION
This fixes an issue where the bundle lockfile parser would fail when encountering the lockfile generated by `bundle init; bundle lock`.

Closes #1183.