### PR TITLE
Fix reported lines in extension errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `phylum auth list-tokens` subcommand to list API tokens
 
+### Fixed
+- Incorrect line numbers when printing errors in TypeScript extensions
+
 ## [5.6.0] - 2023-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,6 +3612,7 @@ dependencies = [
  "cidr",
  "clap",
  "console",
+ "dashmap",
  "deno_ast",
  "deno_core",
  "deno_runtime",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,6 +68,7 @@ birdcage = { version = "0.2.0" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"
+dashmap = "5.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"


### PR DESCRIPTION
This fixes an issue with extensions where the reported line for an error did not match the supplied code, since the error was based on the transpiled JavaScript.

To make sure the error can be mapped from JavaScript back to the original TypeScript, a transpiler cache has been introduced which is used to retrieve the original source map when an error is encountered.

Fixes #961.
