### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{rs,toml}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+max_line_length = 80


### PR DESCRIPTION
Many of the items in this file are already enforced by other tools (i.e., `.gitattributes` for line endings, `rustfmt` for `.rs` files). But this file will assist in areas where strict automated tools do not exist or are not wanted (e.g., Markdown).