### PR TITLE
Ensure ecosystem extensions check removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Gemfile.lock` parsing with zero dependencies
 - Incorrect line numbers when printing errors in TypeScript extensions
 - Absolute paths submitted when analyzing manifest files
+- Ecosystem extensions not pre-checking `remove`/`uninstall` operations
 
 ## [5.6.0] - 2023-08-08
 

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -225,7 +225,9 @@ async function checkDryRun(subcommand: string, args: string[]) {
   try {
     await Deno.stat("./npm-shrinkwrap.json");
     lockfilePath = "./npm-shrinkwrap.json";
-  } catch (_e) {}
+  } catch (_e) {
+      //
+  }
 
   let lockfile;
   try {

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -203,7 +203,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
   } else {
     // Run just install if no new package is added.
     //
-    // This is necessary since `update` does not have the `package-lock-only`
+    // This is necessary since `remove` does not have the `package-lock-only`
     // and `ignore-scripts` options.
     const cmd = new Deno.Command("npm", {
       args: [

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -226,7 +226,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
     await Deno.stat("./npm-shrinkwrap.json");
     lockfilePath = "./npm-shrinkwrap.json";
   } catch (_e) {
-      //
+    //
   }
 
   let lockfile;

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -203,8 +203,8 @@ async function checkDryRun(subcommand: string, args: string[]) {
   } else {
     // Run just install if no new package is added.
     //
-    // This is necessary since `update` and `remove` do not have
-    // `package-lock-only` and/or `ignore-scripts` options.
+    // This is necessary since `update` does not have the `package-lock-only`
+    // and `ignore-scripts` options.
     const cmd = new Deno.Command("npm", {
       args: [
         "install",

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -74,6 +74,7 @@ if (
     "udpate".startsWith(Deno.args[0]) ||
     "upgrade".startsWith(Deno.args[0]) ||
     "unlink".startsWith(Deno.args[0]) ||
+    "uninstall".startsWith(Deno.args[0]) ||
     "remove".startsWith(Deno.args[0]) ||
     "rm".startsWith(Deno.args[0])
   )
@@ -181,7 +182,10 @@ async function checkDryRun(subcommand: string, args: string[]) {
   if (
     "install".startsWith(subcommand) ||
     "isntall".startsWith(subcommand) ||
-    "add".startsWith(subcommand)
+    "add".startsWith(subcommand) ||
+    "update".startsWith(subcommand) ||
+    "udpate".startsWith(subcommand) ||
+    "upgrade".startsWith(subcommand)
   ) {
     // Run the command without installation if a new package is installed.
     const cmd = new Deno.Command("npm", {
@@ -215,7 +219,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
   }
 
   // Ensure lockfile update was successful.
-  if (status && !status.success) {
+  if (!status.success) {
     console.error(`[${red("phylum")}] Lockfile update failed.\n`);
     await abort(status.code);
   }

--- a/extensions/poetry/main.ts
+++ b/extensions/poetry/main.ts
@@ -43,7 +43,7 @@ if (firstSubcommand > 0) {
 // Ignore all commands that shouldn't be intercepted.
 if (
   Deno.args.length == 0 ||
-  !["add", "update", "install"].includes(Deno.args[0])
+  !["add", "update", "install", "remove"].includes(Deno.args[0])
 ) {
   const cmd = new Deno.Command("poetry", { args: Deno.args });
   const status = await cmd.spawn().status;
@@ -64,7 +64,7 @@ if (!root) {
   Deno.exit(126);
 }
 
-// Analyze new dependencies with phylum before install/update.
+// Analyze new dependencies with phylum.
 await poetryCheckDryRun(Deno.args[0], Deno.args.slice(1));
 
 // Execute install without sandboxing after successful analysis.

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -69,7 +69,7 @@ if (firstSubcommand > 0) {
 // Ignore all commands that shouldn't be intercepted.
 if (
   Deno.args.length == 0 ||
-  !["add", "install", "up", "dedupe"].includes(Deno.args[0])
+  !["add", "install", "up", "dedupe", "remove"].includes(Deno.args[0])
 ) {
   const cmd = new Deno.Command("yarn", { args: Deno.args });
   const status = await cmd.spawn().status;
@@ -96,7 +96,7 @@ await packageLockBackup.backup();
 const manifestBackup = new FileBackup(root + "/package.json");
 await manifestBackup.backup();
 
-// Analyze new dependencies with phylum before install/update.
+// Analyze new dependencies with phylum.
 try {
   await checkDryRun();
 } catch (e) {


### PR DESCRIPTION
Almost all ecosystem package managers will install all missing packages when removing even unrelated packages. As a result it is required that we run an analysis even during package removal.

Closes #1189.
