### PR TITLE
Add selfmanage feature to xtask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Incorrect line numbers when printing errors in TypeScript extensions
 - Absolute paths submitted when analyzing manifest files
 - Ecosystem extensions not pre-checking `remove`/`uninstall` operations
+- Disabled update and uninstall commands in completion for Homebrew users
 
 ## [5.6.0] - 2023-08-08
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["selfmanage"]
+selfmanage = ["phylum-cli/selfmanage"]
+
 [dependencies]
 anyhow = "1.0.53"
 clap = { version = "4.0.9", features = ["wrap_help"] }
@@ -13,7 +17,7 @@ home = "0.5.3"
 log = "0.4.14"
 simplelog = "0.12.0"
 fs_extra = "1.2.0"
-phylum-cli = { path = "../cli" }
+phylum-cli = { path = "../cli", default-features = false }
 clap_markdown = { path = "../clap_markdown" }
 
 [dev-dependencies]


### PR DESCRIPTION
Fix #965 by adding a `selfmanage` feature to `xtask`. This allows generating completion files with or without the `selfmanage` commands.

### With selfmanage (default)
```
cargo run -p xtask -- gencomp
```

### Without selfmanage
```
cargo run -p xtask --no-default-features -- gencomp
```