### PR TITLE
Allow compile time override of default data dir

### DIFF
--- a/cli/src/dirs.rs
+++ b/cli/src/dirs.rs
@@ -5,12 +5,18 @@ use anyhow::{anyhow, Result};
 
 /// Resolve XDG data directory.
 pub fn data_dir() -> Result<PathBuf> {
-    xdg_dir("XDG_DATA_HOME", ".local/share")
+    if let Some(path) = env_path("XDG_DATA_HOME") {
+        return Ok(path);
+    }
+    Ok(home_dir()?.join(".local/share"))
 }
 
 /// Resolve XDG config directory.
 pub fn config_dir() -> Result<PathBuf> {
-    xdg_dir("XDG_CONFIG_HOME", ".config")
+    if let Some(path) = env_path("XDG_CONFIG_HOME") {
+        return Ok(path);
+    }
+    Ok(home_dir()?.join(".config"))
 }
 
 /// XDG binary directory.
@@ -23,12 +29,9 @@ pub fn home_dir() -> Result<PathBuf> {
     home::home_dir().ok_or_else(|| anyhow!("Couldn't find the user's home directory"))
 }
 
-/// Resolve an XDG directory.
-pub fn xdg_dir(env_var: &str, path_suffix: impl AsRef<Path>) -> Result<PathBuf> {
-    env::var_os(env_var)
-        .filter(|s| !s.is_empty())
-        .map(|var| Ok(PathBuf::from(var)))
-        .unwrap_or_else(|| Ok(home_dir()?.join(path_suffix)))
+/// Resolve a path from an environment variable.
+pub fn env_path(env_var: &str) -> Option<PathBuf> {
+    env::var_os(env_var).filter(|s| !s.is_empty()).map(PathBuf::from)
 }
 
 /// Expand leading tildes to the user's home path.

--- a/cli/src/dirs.rs
+++ b/cli/src/dirs.rs
@@ -8,7 +8,13 @@ pub fn data_dir() -> Result<PathBuf> {
     if let Some(path) = env_path("XDG_DATA_HOME") {
         return Ok(path);
     }
-    Ok(home_dir()?.join(".local/share"))
+
+    // Allow compile-time override of default data directory
+    if let Some(path) = option_env!("PHYLUM_OVERRIDE_DATA_DIR") {
+        Ok(PathBuf::from(path))
+    } else {
+        Ok(home_dir()?.join(".local/share"))
+    }
 }
 
 /// Resolve XDG config directory.


### PR DESCRIPTION
This patch is an attempt to fix #822

Allowing Homebrew installs to override the default data directory would allow us to use a custom path (likely `$HOMEBREW_PREFIX/var/lib/phylum/extensions`) for extensions when installed via homebrew.

### DRAFT

Feedback is welcome, but I am still testing this. A companion PR will be needed in phylum-dev/homebrew-cli to fully accomplish this.