### PR TITLE
Ensure lockfiles are files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Incorrect line numbers when printing errors in TypeScript extensions
 - Absolute paths submitted when analyzing manifest files
 - Ecosystem extensions not pre-checking `remove`/`uninstall` operations
+- Directories matching lockfile formats being detected as lockfiles
 
 ## [5.6.0] - 2023-08-08
 

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -91,11 +91,11 @@ impl Parse for Cargo {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("Cargo.lock"))
+        path.file_name() == Some(OsStr::new("Cargo.lock")) && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("Cargo.toml"))
+        path.file_name() == Some(OsStr::new("Cargo.toml")) && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -47,7 +47,7 @@ impl Parse for PackagesLock {
         };
 
         // Accept both `packages.lock.json` and `packages.<project_name>.lock.json`.
-        file_name.starts_with("packages.") && file_name.ends_with(".lock.json")
+        file_name.starts_with("packages.") && file_name.ends_with(".lock.json") && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -22,11 +22,11 @@ impl Parse for GoSum {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("go.sum"))
+        path.file_name() == Some(OsStr::new("go.sum")) && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("go.mod"))
+        path.file_name() == Some(OsStr::new("go.mod")) && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -31,11 +31,11 @@ impl Parse for GradleLock {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("gradle.lockfile"))
+        path.file_name() == Some(OsStr::new("gradle.lockfile")) && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("build.gradle"))
+        path.file_name() == Some(OsStr::new("build.gradle")) && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -126,12 +126,13 @@ impl Parse for PackageLock {
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
         let file_name = path.file_name();
-        file_name == Some(OsStr::new("package-lock.json"))
-            || file_name == Some(OsStr::new("npm-shrinkwrap.json"))
+        (file_name == Some(OsStr::new("package-lock.json"))
+            || file_name == Some(OsStr::new("npm-shrinkwrap.json")))
+            && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("package.json"))
+        path.file_name() == Some(OsStr::new("package.json")) && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -353,8 +353,14 @@ mod tests {
             (".spdx.yaml", LockfileFormat::Spdx),
         ];
 
+        let dir = tempfile::tempdir().unwrap();
+
         for (file, expected_type) in test_cases {
-            let pkg_type = get_path_format(Path::new(file));
+            // Create file, so we can read its metadata.
+            let path = dir.path().join(file);
+            File::create(&path).unwrap();
+
+            let pkg_type = get_path_format(&path);
             assert_eq!(pkg_type, Some(*expected_type), "{}", file);
         }
     }

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -41,14 +41,15 @@ impl Parse for PyRequirements {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        is_requirements_file(path)
+        is_requirements_file(path) && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("requirements.in"))
+        (path.file_name() == Some(OsStr::new("requirements.in"))
             || path.file_name() == Some(OsStr::new("pyproject.toml"))
             || path.file_name() == Some(OsStr::new("setup.py"))
-            || is_requirements_file(path)
+            || is_requirements_file(path))
+            && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/ruby.rs
+++ b/lockfile/src/ruby.rs
@@ -25,11 +25,11 @@ impl Parse for GemLock {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("Gemfile.lock"))
+        path.file_name() == Some(OsStr::new("Gemfile.lock")) && path.is_file()
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("Gemfile"))
+        path.file_name() == Some(OsStr::new("Gemfile")) && path.is_file()
     }
 
     #[cfg(feature = "generator")]

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -192,10 +192,11 @@ impl Parse for Spdx {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.ends_with(".spdx.json")
+        (path.ends_with(".spdx.json")
             || path.ends_with(".spdx.yaml")
             || path.ends_with(".spdx.yml")
-            || path.ends_with(".spdx")
+            || path.ends_with(".spdx"))
+            && path.is_file()
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {


### PR DESCRIPTION
This patch introduces a metadata check for lockfile and manifest paths to ensure that they're files instead of directories.

Closes #1177.

---

This is in part somewhat of a request for comments, since I'm not entirely sure which approach we want to take here. In the CLI we can certainly always read the metadata, but I'm not sure if the same applies to the GitHub app?

Is this check beneficial in general, or are we maybe just introducing another point of failure that doesn't really matter in practice?

One alternative I have thought of myself is to check that the metadata is **not** a directory. This would still work if the file doesn't exist at all, but it does technically still try to read the path's metadata.