### PR TITLE
Improve lockfile parsing errors

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -63,7 +63,10 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
 
     for lockfile in lockfiles {
         let parsed_lockfile =
-            parse_lockfile(lockfile.path, project_root, Some(&lockfile.lockfile_type))?;
+            parse_lockfile(&lockfile.path, project_root, Some(&lockfile.lockfile_type))
+                .with_context(|| {
+                    format!("could not parse lockfile: {}", lockfile.path.display())
+                })?;
         pkgs.extend(parsed_lockfile);
     }
 


### PR DESCRIPTION
As shown in #1177, some lockfile parsing errors result in poor error messages because the lockfile path is not always known.

This patch adds the lockfile path as context on the error to ensure that it will be present in the error message.

**Before**
```
> phylum parse
❗ Error: Is a directory (os error 21)
```

**After**
```
> phylum parse
❗ Error: could not parse lockfile: ./Cargo.lock

Caused by:
    Is a directory (os error 21)
```