### PR TITLE
Enable Web Storage API for extensions

### DIFF
--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -124,12 +124,12 @@ impl Extension {
             return Err(anyhow!("extension {} is not installed, skipping", self.name()));
         }
 
-        fs::remove_dir_all(&self.path)?;
-
         if let Some(state_path) = self.state_path() {
             // Ignore errors since this may not exist
             let _ = fs::remove_dir_all(state_path);
         }
+
+        fs::remove_dir_all(&self.path)?;
 
         println!("Extension {} uninstalled successfully", self.name());
 

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -126,7 +126,7 @@ impl Extension {
 
         fs::remove_dir_all(&self.path)?;
 
-        if let Ok(state_path) = self.state_path() {
+        if let Some(state_path) = self.state_path() {
             // Ignore errors since this may not exist
             let _ = fs::remove_dir_all(state_path);
         }
@@ -137,7 +137,7 @@ impl Extension {
     }
 
     /// Return true if this is an installed extension.
-    pub fn installed(&self) -> bool {
+    fn installed(&self) -> bool {
         let installed_path = extension_path(self.name())
             .ok()
             .and_then(|installed_path| installed_path.canonicalize().ok());
@@ -156,8 +156,12 @@ impl Extension {
     }
 
     /// A directory where installed extensions can store state.
-    pub fn state_path(&self) -> Result<PathBuf> {
-        extension_state_path(self.name())
+    pub fn state_path(&self) -> Option<PathBuf> {
+        if self.installed() {
+            extension_state_path(self.name()).ok()
+        } else {
+            None
+        }
     }
 
     /// Return the path to this extension's entry point.

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -157,11 +157,7 @@ impl Extension {
 
     /// A directory where installed extensions can store state.
     pub fn state_path(&self) -> Option<PathBuf> {
-        if self.installed() {
-            extension_state_path(self.name()).ok()
-        } else {
-            None
-        }
+        self.installed().then(|| extension_state_path(self.name()).ok()).flatten()
     }
 
     /// Return the path to this extension's entry point.

--- a/cli/src/commands/extensions/extension.rs
+++ b/cli/src/commands/extensions/extension.rs
@@ -126,13 +126,18 @@ impl Extension {
 
         fs::remove_dir_all(&self.path)?;
 
+        if let Ok(state_path) = self.state_path() {
+            // Ignore errors since this may not exist
+            let _ = fs::remove_dir_all(state_path);
+        }
+
         println!("Extension {} uninstalled successfully", self.name());
 
         Ok(())
     }
 
     /// Return true if this is an installed extension.
-    fn installed(&self) -> bool {
+    pub fn installed(&self) -> bool {
         let installed_path = extension_path(self.name())
             .ok()
             .and_then(|installed_path| installed_path.canonicalize().ok());
@@ -148,6 +153,11 @@ impl Extension {
     /// Return the path to this extension.
     pub fn path(&self) -> PathBuf {
         self.path.clone()
+    }
+
+    /// A directory where installed extensions can store state.
+    pub fn state_path(&self) -> Result<PathBuf> {
+        extension_state_path(self.name())
     }
 
     /// Return the path to this extension's entry point.
@@ -230,10 +240,14 @@ pub fn validate_name(name: &str) -> Result<(), anyhow::Error> {
 }
 
 // Construct and return the extension path: $XDG_DATA_HOME/phylum/extensions
-pub fn extensions_path() -> Result<PathBuf, anyhow::Error> {
+pub fn extensions_path() -> Result<PathBuf> {
     Ok(dirs::data_dir()?.join("phylum").join("extensions"))
 }
 
-fn extension_path(name: &str) -> Result<PathBuf, anyhow::Error> {
+fn extension_path(name: &str) -> Result<PathBuf> {
     Ok(extensions_path()?.join(name))
+}
+
+fn extension_state_path(name: &str) -> Result<PathBuf> {
+    Ok(dirs::state_dir()?.join("phylum/extensions").join(name))
 }

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,8 +1,8 @@
 //! Phylum CLI removal.
 
+use std::fs;
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::{fs, io};
 
 use anyhow::{anyhow, Result};
 use clap::ArgMatches;

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,8 +1,8 @@
 //! Phylum CLI removal.
 
-use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 use anyhow::{anyhow, Result};
 use clap::ArgMatches;
@@ -42,23 +42,38 @@ fn purge() -> Result<()> {
     Ok(())
 }
 
+/// Return Ok for file not found errors. Pass everything else through.
+fn ignore_not_found(err: io::Error) -> io::Result<()> {
+    if err.kind() == ErrorKind::NotFound {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
 /// Remove files created by `install.sh`.
 fn remove_installed_files() -> Result<()> {
     let data_dir = dirs::data_dir()?.join("phylum");
+    let state_dir = dirs::state_dir()?.join("phylum");
     let bin_path = dirs::bin_dir()?.join("phylum");
 
     let data_result = fs::remove_dir_all(data_dir);
+    let state_result = fs::remove_dir_all(state_dir).or_else(ignore_not_found);
     let bin_result = fs::remove_file(bin_path);
 
     if let Err(err) = &data_result {
         print_user_warning!("Could not remove data directory: {}", err);
     }
 
+    if let Err(err) = &state_result {
+        print_user_warning!("Could not remove state directory: {}", err);
+    }
+
     if let Err(err) = &bin_result {
         print_user_warning!("Could not remove phylum executable: {}", err);
     }
 
-    if data_result.is_ok() && bin_result.is_ok() {
+    if data_result.is_ok() && state_result.is_ok() && bin_result.is_ok() {
         print_user_success!("Successfully removed installer files");
     }
 

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -59,8 +59,7 @@ pub async fn run(
     let module_loader = Rc::new(ExtensionsModuleLoader::new(extension.path()));
     let source_map_getter: Box<dyn SourceMapGetter> = Box::new(module_loader.clone());
 
-    let origin_storage_dir =
-        if extension.installed() { Some(extension.state_path()?) } else { None };
+    let origin_storage_dir = extension.state_path();
 
     let options = WorkerOptions {
         origin_storage_dir,

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -59,7 +59,11 @@ pub async fn run(
     let module_loader = Rc::new(ExtensionsModuleLoader::new(extension.path()));
     let source_map_getter: Box<dyn SourceMapGetter> = Box::new(module_loader.clone());
 
+    let origin_storage_dir =
+        if extension.installed() { Some(extension.state_path()?) } else { None };
+
     let options = WorkerOptions {
+        origin_storage_dir,
         module_loader,
         bootstrap,
         source_map_getter: Some(source_map_getter),

--- a/cli/src/dirs.rs
+++ b/cli/src/dirs.rs
@@ -13,6 +13,11 @@ pub fn config_dir() -> Result<PathBuf> {
     xdg_dir("XDG_CONFIG_HOME", ".config")
 }
 
+/// Resolve XDG state directory.
+pub fn state_dir() -> Result<PathBuf> {
+    xdg_dir("XDG_STATE_HOME", ".local/state")
+}
+
 /// XDG binary directory.
 pub fn bin_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join(".local/bin"))

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -90,6 +90,14 @@ impl TestCli {
         self.tempdir.path()
     }
 
+    pub fn data_home(&self) -> PathBuf {
+        self.temp_path().join("data")
+    }
+
+    pub fn state_home(&self) -> PathBuf {
+        self.temp_path().join("state")
+    }
+
     pub fn install_extension(&self, path: &Path) -> Assert {
         self.run(["extension", "install", "-y", &path.to_string_lossy()])
     }
@@ -101,7 +109,8 @@ impl TestCli {
     pub fn cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("phylum").unwrap();
 
-        cmd.env("XDG_DATA_HOME", self.tempdir.path());
+        cmd.env("XDG_DATA_HOME", self.data_home());
+        cmd.env("XDG_STATE_HOME", self.state_home());
 
         if let Some(cwd) = self.cwd.as_ref() {
             cmd.current_dir(cwd);
@@ -147,7 +156,7 @@ pub struct TestExtension<'a> {
 
 impl<'a> TestExtension<'a> {
     fn new(test_cli: &'a TestCli, code: &str, permissions: &Permissions) -> Self {
-        let extension_path = test_cli.temp_path().to_owned().join("test-ext");
+        let extension_path = test_cli.temp_path().join("test-ext");
 
         // Create skeleton extension.
         test_cli.run(["extension", "new", &extension_path.to_string_lossy()]).success();

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -381,6 +381,27 @@ fn help_contains_description() {
         .stdout(predicate::str::contains("This extension does a thing"));
 }
 
+#[test]
+fn local_storage() {
+    let test_cli = TestCli::builder().build();
+
+    // Uninstalled extension should show -1 (because localStorage is disabled)
+    test_cli
+        .run(["extension", "run", &fixtures_path().join("run-count").to_string_lossy()])
+        .success()
+        .stdout(predicate::str::contains("Run Count: -1"));
+
+    // Installed extension should increment run count
+    test_cli.install_extension(&fixtures_path().join("run-count")).success();
+    test_cli.run(["run-count"]).success().stdout(predicate::str::contains("Run Count: 0"));
+    test_cli.run(["run-count"]).success().stdout(predicate::str::contains("Run Count: 1"));
+
+    // Uninstall should clear run count
+    test_cli.run(["extension", "uninstall", "run-count"]);
+    test_cli.install_extension(&fixtures_path().join("run-count")).success();
+    test_cli.run(["run-count"]).success().stdout(predicate::str::contains("Run Count: 0"));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Utilities
 ////////////////////////////////////////////////////////////////////////////////

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -397,7 +397,7 @@ fn local_storage() {
     test_cli.run(["run-count"]).success().stdout(predicate::str::contains("Run Count: 1"));
 
     // Uninstall should clear run count
-    test_cli.run(["extension", "uninstall", "run-count"]);
+    test_cli.run(["extension", "uninstall", "run-count"]).success();
     test_cli.install_extension(&fixtures_path().join("run-count")).success();
     test_cli.run(["run-count"]).success().stdout(predicate::str::contains("Run Count: 0"));
 }

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -39,7 +39,7 @@ fn extension_is_installed_correctly() {
     test_cli.install_extension(&fixtures_path().join("sample")).success();
 
     let _guard = ENV_MUTEX.lock().unwrap();
-    env::set_var("XDG_DATA_HOME", test_cli.temp_path());
+    env::set_var("XDG_DATA_HOME", test_cli.data_home());
 
     let installed_ext = Extension::load("sample").unwrap();
     assert_eq!(installed_ext.name(), "sample");
@@ -90,9 +90,7 @@ fn unsuccessful_installation_prints_failure_message() {
     // Try to install the extension from the installed path. Should fail with an
     // error.
     test_cli
-        .install_extension(
-            &test_cli.temp_path().to_owned().join("phylum").join("extensions").join("sample"),
-        )
+        .install_extension(&test_cli.data_home().join("phylum").join("extensions").join("sample"))
         .failure()
         .stderr(predicate::str::contains("skipping"));
 }
@@ -105,8 +103,7 @@ fn extension_is_uninstalled_correctly() {
 
     test_cli.install_extension(&fixtures_path().join("sample")).success();
 
-    let extension_path =
-        test_cli.temp_path().to_path_buf().join("phylum").join("extensions").join("sample");
+    let extension_path = test_cli.data_home().join("phylum").join("extensions").join("sample");
 
     assert!(walkdir::WalkDir::new(&extension_path).into_iter().count() > 1);
 

--- a/cli/tests/extensions/module_loader.rs
+++ b/cli/tests/extensions/module_loader.rs
@@ -51,8 +51,7 @@ fn module_with_traversal_fails_to_load() {
 #[test]
 fn symlinks_are_resolved() {
     let test_cli = TestCli::builder().build();
-    let ext_path =
-        test_cli.temp_path().to_owned().join("phylum").join("extensions").join("symlink");
+    let ext_path = test_cli.data_home().join("phylum").join("extensions").join("symlink");
 
     test_cli.install_extension(&fixtures_path().join("symlink")).success();
 
@@ -68,8 +67,7 @@ fn symlinks_are_resolved() {
 #[test]
 fn symlinks_with_traversal_fail() {
     let test_cli = TestCli::builder().build();
-    let ext_path =
-        test_cli.temp_path().to_owned().join("phylum").join("extensions").join("symlink");
+    let ext_path = test_cli.data_home().join("phylum").join("extensions").join("symlink");
 
     test_cli.install_extension(&fixtures_path().join("module-import").join("successful")).success();
     test_cli.install_extension(&fixtures_path().join("symlink")).success();

--- a/cli/tests/fixtures/extensions/run-count/PhylumExt.toml
+++ b/cli/tests/fixtures/extensions/run-count/PhylumExt.toml
@@ -1,0 +1,1 @@
+name = "run-count"

--- a/cli/tests/fixtures/extensions/run-count/main.ts
+++ b/cli/tests/fixtures/extensions/run-count/main.ts
@@ -1,0 +1,12 @@
+function runCount() {
+  try {
+    const c = parseInt(localStorage.getItem("runCount") ?? "0", 10);
+    localStorage.setItem("runCount", `${c+1}`);
+    return c;
+  } catch(_e) {
+    // Local Storage Disabled
+    return -1;
+  }
+}
+
+console.log(`Run Count: ${runCount()}`);

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Enable the Web Storage API (i.e., `localStorage`)
+
 ## 5.6.0 - 2023-08-08
 
 ### Added


### PR DESCRIPTION
This patch allows extensions to use `localStorage` to store state. Each extension has separate state and it is removed when the extension is uninstalled. Additionally, only installed extensions are allowed to persist state.

_Note:_ This also enables usage of `sessionStorage`, but the session lasts only as long as the process, so this does not provide any additional value.