### PR TITLE
Update SBOM identification

### DIFF
--- a/lockfile/src/cyclonedx.rs
+++ b/lockfile/src/cyclonedx.rs
@@ -185,8 +185,10 @@ impl Parse for CycloneDX {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        matches!(path.file_name().and_then(OsStr::to_str), Some(name) if name.ends_with("bom.json")
-            || name.ends_with("bom.xml"))
+        path.file_name()
+            .and_then(OsStr::to_str)
+            .map(|name| name.ends_with("bom.json") || name.ends_with("bom.xml"))
+            .unwrap_or(false)
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {

--- a/lockfile/src/cyclonedx.rs
+++ b/lockfile/src/cyclonedx.rs
@@ -185,8 +185,8 @@ impl Parse for CycloneDX {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("bom.json"))
-            || path.file_name() == Some(OsStr::new("bom.xml"))
+        matches!(path.file_name().and_then(OsStr::to_str), Some(name) if name.ends_with("bom.json")
+            || name.ends_with("bom.xml"))
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {
@@ -196,6 +196,8 @@ impl Parse for CycloneDX {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use crate::PackageVersion;
 
@@ -250,5 +252,21 @@ mod tests {
         let xml_pkgs = CycloneDX.parse(include_str!("../../tests/fixtures/bom.1.3.xml")).unwrap();
         assert_eq!(json_pkgs.len(), xml_pkgs.len());
         assert_eq!(json_pkgs, xml_pkgs);
+    }
+
+    #[test]
+    fn test_if_lockfile() {
+        let test_paths = vec![
+            "/foo/bar/test.bom.json",
+            "/foo/bar/test.bom.xml",
+            "/foo/bar/bom.json",
+            "/foo/bar/bom.xml",
+        ];
+
+        for path_str in test_paths {
+            let path_buf = PathBuf::from(path_str);
+            let is_lockfile = CycloneDX.is_path_lockfile(&path_buf);
+            assert!(is_lockfile, "Failed for path: {}", path_str);
+        }
     }
 }

--- a/lockfile/src/cyclonedx.rs
+++ b/lockfile/src/cyclonedx.rs
@@ -187,8 +187,7 @@ impl Parse for CycloneDX {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name()
             .and_then(OsStr::to_str)
-            .map(|name| name.ends_with("bom.json") || name.ends_with("bom.xml"))
-            .unwrap_or(false)
+            .map_or(false, |name| name.ends_with("bom.json") || name.ends_with("bom.xml"))
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -171,8 +171,15 @@ impl Parse for Spdx {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        matches!(path.file_name().and_then(OsStr::to_str), Some(name) if name.ends_with(".spdx.json")
-            || name.ends_with(".spdx.yaml") || name.ends_with(".spdx.yml") || name.ends_with(".spdx"))
+        path.file_name()
+            .and_then(OsStr::to_str)
+            .map(|name| {
+                name.ends_with(".spdx.json")
+                    || name.ends_with(".spdx.yaml")
+                    || name.ends_with(".spdx.yml")
+                    || name.ends_with(".spdx")
+            })
+            .unwrap_or(false)
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -170,10 +171,8 @@ impl Parse for Spdx {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.ends_with(".spdx.json")
-            || path.ends_with(".spdx.yaml")
-            || path.ends_with(".spdx.yml")
-            || path.ends_with(".spdx")
+        matches!(path.file_name().and_then(OsStr::to_str), Some(name) if name.ends_with(".spdx.json")
+            || name.ends_with(".spdx.yaml") || name.ends_with(".spdx.yml") || name.ends_with(".spdx"))
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {
@@ -183,6 +182,8 @@ impl Parse for Spdx {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use serde_json::json;
 
     use super::*;
@@ -591,5 +592,21 @@ mod tests {
         let actual = parse_results.err().unwrap().to_string();
 
         assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_if_lockfile() {
+        let test_paths = vec![
+            "/foo/bar/test.spdx.json",
+            "/foo/bar/test.spdx.yaml",
+            "/foo/bar/test.spdx.yml",
+            "/foo/bar/test.spdx",
+        ];
+
+        for path_str in test_paths {
+            let path_buf = PathBuf::from(path_str);
+            let is_lockfile = Spdx.is_path_lockfile(&path_buf);
+            assert!(is_lockfile, "Failed for path: {}", path_str);
+        }
     }
 }

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -171,15 +171,12 @@ impl Parse for Spdx {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name()
-            .and_then(OsStr::to_str)
-            .map(|name| {
-                name.ends_with(".spdx.json")
-                    || name.ends_with(".spdx.yaml")
-                    || name.ends_with(".spdx.yml")
-                    || name.ends_with(".spdx")
-            })
-            .unwrap_or(false)
+        path.file_name().and_then(OsStr::to_str).map_or(false, |name| {
+            name.ends_with(".spdx.json")
+                || name.ends_with(".spdx.yaml")
+                || name.ends_with(".spdx.yml")
+                || name.ends_with(".spdx")
+        })
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {


### PR DESCRIPTION
Correctly identifies SPDX SBOM files and also identifies CycloneDX SBOMs in the form of `<proj_name>.bom.json`
Closes https://github.com/phylum-dev/cli/issues/1212

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
- [ ] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
