### PR TITLE
Add relative path to each package in parseLockfile

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -43,7 +43,7 @@ use crate::types::{PolicyEvaluationResponse, PolicyEvaluationResponseRaw};
 /// Parsed lockfile content.
 #[derive(Serialize, Deserialize, Debug)]
 struct PackageLock {
-    packages: Vec<PackageDescriptor>,
+    packages: Vec<PackageDescriptorAndLockfile>,
     format: LockfileFormat,
 }
 

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -107,7 +107,7 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
         let project_root = current_project.as_ref().map(|p| p.root());
 
         for lockfile in jobs_project.lockfiles {
-            let res =
+            let mut parsed_lockfile =
                 parse::parse_lockfile(&lockfile.path, project_root, Some(&lockfile.lockfile_type))
                     .with_context(|| {
                         format!(
@@ -119,12 +119,12 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
             if pretty_print {
                 print_user_success!(
                     "Successfully parsed lockfile {:?} as type: {}",
-                    res.path,
-                    res.format.name()
+                    parsed_lockfile.path,
+                    parsed_lockfile.format.name()
                 );
             }
 
-            packages.extend(res);
+            packages.append(&mut parsed_lockfile.packages);
         }
 
         if let Some(base) = matches.get_one::<String>("base") {

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -139,10 +139,10 @@ pub async fn parse_lockfile() {
         .build()
         .run()
         .success()
-        .stdout(
-            "{\"packages\":[{\"name\":\"accepts\",\"version\":\"1.3.8\",\"type\":\"npm\"}],\"\
-             format\":\"yarn\"}\n",
-        );
+        .stdout(predicates::str::contains(
+            "{\"packages\":[{\"name\":\"accepts\",\"version\":\"1.3.8\",\"type\":\"npm\",\"\
+             lockfile\":\"",
+        ));
 }
 
 #[tokio::test]

--- a/docs/extensions/extension_example.md
+++ b/docs/extensions/extension_example.md
@@ -108,9 +108,9 @@ The lockfile object will look something like this:
 
 ```text
   packages: [
-    { name: "accepts", version: "1.3.8" },
-    { name: "array-flatten", version: "1.1.1" },
-    { name: "accepts", version: "1.0.0" }
+    { lockfile: "package-lock.json", name: "accepts", version: "1.3.8" },
+    { lockfile: "package-lock.json", name: "array-flatten", version: "1.1.1" },
+    { lockfile: "package-lock.json", name: "accepts", version: "1.0.0" }
   ],
   package_type: "npm"
 }

--- a/docs/extensions/extension_example.md
+++ b/docs/extensions/extension_example.md
@@ -108,9 +108,9 @@ The lockfile object will look something like this:
 
 ```text
   packages: [
-    { lockfile: "package-lock.json", name: "accepts", version: "1.3.8" },
-    { lockfile: "package-lock.json", name: "array-flatten", version: "1.1.1" },
-    { lockfile: "package-lock.json", name: "accepts", version: "1.0.0" }
+    { lockfile: "package-lock.json", type: "npm", name: "accepts", version: "1.3.8" },
+    { lockfile: "package-lock.json", type: "npm", name: "array-flatten", version: "1.1.1" },
+    { lockfile: "package-lock.json", type: "npm", name: "accepts", version: "1.0.0" }
   ],
   package_type: "npm"
 }

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `PhylumApi.parseLockfile` now adds a relative path to each package,
-    allowing for Phlum's UI to display the correct lockfile path for the job
+    allowing for Phylum's UI to display the correct lockfile path for the job
 
 ## 5.7.0 - 2023-08-24
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- `PhylumApi.parseLockfile` now adds a relative path to each package,
+    allowing for Phlum's UI to display the correct lockfile path for the job
+
 ## 5.7.0 - 2023-08-24
 
 ### Added

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -430,10 +430,10 @@ export class PhylumApi {
    * {
    *   format: "npm",
    *   packages: [
-   *     { name: "accepts", version: "1.3.8", type: "npm" },
-   *     { name: "ms", version: "2.0.0", type: "npm" },
-   *     { name: "negotiator", version: "0.6.3", type: "npm" },
-   *     { name: "ms", version: "2.1.3", type: "npm" }
+   *     { lockfile: "./package-lock.json", name: "accepts", version: "1.3.8", type: "npm" },
+   *     { lockfile: "./package-lock.json", name: "ms", version: "2.0.0", type: "npm" },
+   *     { lockfile: "./package-lock.json", name: "negotiator", version: "0.6.3", type: "npm" },
+   *     { lockfile: "./package-lock.json", name: "ms", version: "2.1.3", type: "npm" }
    *   ]
    * }
    * ```

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -430,10 +430,10 @@ export class PhylumApi {
    * {
    *   format: "npm",
    *   packages: [
-   *     { lockfile: "./package-lock.json", name: "accepts", version: "1.3.8", type: "npm" },
-   *     { lockfile: "./package-lock.json", name: "ms", version: "2.0.0", type: "npm" },
-   *     { lockfile: "./package-lock.json", name: "negotiator", version: "0.6.3", type: "npm" },
-   *     { lockfile: "./package-lock.json", name: "ms", version: "2.1.3", type: "npm" }
+   *     { lockfile: "package-lock.json", name: "accepts", version: "1.3.8", type: "npm" },
+   *     { lockfile: "package-lock.json", name: "ms", version: "2.0.0", type: "npm" },
+   *     { lockfile: "package-lock.json", name: "negotiator", version: "0.6.3", type: "npm" },
+   *     { lockfile: "package-lock.json", name: "ms", version: "2.1.3", type: "npm" }
    *   ]
    * }
    * ```


### PR DESCRIPTION
This patch changes the output of the `PhylumApi.parseLockfile` method to add the relative path to the origin lockfile to each individual package.

This allows for the UI to display the lockfile path without extensions themselves having to remap the array of packages themselves.

Closes #1219.
