### PR TITLE
Don't print package with no active rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Package header printed even when all issues were suppressed
+
 ## [5.7.0] - 2023-08-24
 
 ### Added

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -124,7 +124,11 @@ impl Format for PolicyEvaluationResponseRaw {
         }
 
         // Write summary for each issue.
-        for package in self.dependencies.iter().filter(|package| !package.rejections.is_empty()) {
+        for package in self
+            .dependencies
+            .iter()
+            .filter(|package| package.rejections.iter().any(|rejection| !rejection.suppressed))
+        {
             let _ = writeln!(writer, "[{}] {}@{}", package.registry, package.name, package.version);
 
             for rejection in package.rejections.iter().filter(|rejection| !rejection.suppressed) {


### PR DESCRIPTION
Packages with all rejections suppressed should not be displayed in the output report. This patch corrects the filter to account for that.