### PR TITLE
Bump Birdcage to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "birdcage"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3770335bb41dbfd57e869318d341a2eb946b6578d3232e70047a2ee26a5d7bc3"
+checksum = "d92dd4267938d2d01b141f1af28e31c78c764a2550f66fb4f28611fed20c97b3"
 dependencies = [
  "landlock",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.12.0"
 deno_runtime = { version = "0.122.0" }
 deno_core = { version = "0.199.0" }
 deno_ast = { version = "0.27.2", features = ["transpiling"] }
-birdcage = { version = "0.3.0" }
+birdcage = { version = "0.3.1" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -93,7 +93,8 @@ fn default_deny_net() {
 
     test_cli
         .run(["sandbox", "--allow-run", "/", "--allow-env", "--", "curl", "http://phylum.io"])
-        .failure();
+        .failure()
+        .stderr(predicate::str::contains("Could not resolve host: phylum.io"));
 }
 
 #[test]


### PR DESCRIPTION
This fixes a regression introduced in 041be47 which would prevent local sockets from working when the network sandbox was enabled.
