### PR TITLE
Add extension API for Linux sandbox control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,8 @@ dependencies = [
 [[package]]
 name = "birdcage"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92dd4267938d2d01b141f1af28e31c78c764a2550f66fb4f28611fed20c97b3"
 dependencies = [
+ "bitflags 2.4.0",
  "landlock",
  "libc",
  "seccompiler",
@@ -2792,8 +2791,7 @@ dependencies = [
 [[package]]
 name = "landlock"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520baa32708c4e957d2fc3a186bc5bd8d26637c33137f399ddfc202adb240068"
+source = "git+https://github.com/landlock-lsm/rust-landlock#83da4b590c87494456884e2956e739209eae3198"
 dependencies = [
  "enumflags2",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.12.0"
 deno_runtime = { version = "0.122.0" }
 deno_core = { version = "0.199.0" }
 deno_ast = { version = "0.27.2", features = ["transpiling"] }
-birdcage = { version = "0.3.1" }
+birdcage = { version = "0.3.1", path = "../../birdcage" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -539,6 +539,14 @@ pub fn add_subcommands(command: Command) -> Command {
                     .help("Do not add any default sandbox exceptions")
                     .long("strict")
                     .action(ArgAction::SetTrue),
+                Arg::new("best-effort")
+                    .help("Skip sandboxing if it is not supported")
+                    .long("best-effort")
+                    .action(ArgAction::SetTrue),
+                Arg::new("min-landlock-abi")
+                    .help("Minimum required landlock ABI")
+                    .long("min-landlock-abi")
+                    .value_name("ABI"),
                 Arg::new("cmd").help("Command to be executed").value_name("CMD").required(true),
                 Arg::new("args")
                     .help("Command arguments")


### PR DESCRIPTION
This patch adds two new fields to the `runSandboxed` extension API which allow controlling the minimum required Linux landlock ABI version and whether the command should still be executed when sandboxing is not possible.
