### PR TITLE
Fix JavaScript workspace lockfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
-- Cargo manifest generation for workspaces
+- Workspace lockfile generation for cargo, npm, yarn, and pnpm
 
 ## [5.7.1] - 2023-09-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,8 +3008,11 @@ name = "lockfile_generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "glob",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -5510,18 +5519,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",

--- a/lockfile_generator/Cargo.toml
+++ b/lockfile_generator/Cargo.toml
@@ -10,3 +10,8 @@ rust-version = "1.68.0"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 anyhow = "1.0.75"
+glob = "0.3.1"
+thiserror = "1.0.49"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -145,6 +145,7 @@ pub enum Error {
     InvalidManifest(PathBuf),
     PipReportVersionMismatch(&'static str, String),
     UnsupportedCommandVersion(&'static str, &'static str, String),
+    UnexpectedOutput(&'static str, String),
     Anyhow(anyhow::Error),
     NoLockfileGenerated,
 }
@@ -184,8 +185,9 @@ impl Display for Error {
             Self::UnsupportedCommandVersion(command, expected, received) => {
                 write!(f, "unsupported {command:?} version {received:?}, expected {expected:?}")
             },
-            Self::NoLockfileGenerated => write!(f, "no lockfile was generated"),
             Self::Anyhow(err) => write!(f, "{err}"),
+            Self::UnexpectedOutput(cmd, output) => write!(f, "unexpected output for {cmd:?}: {output}"),
+            Self::NoLockfileGenerated => write!(f, "no lockfile was generated"),
         }
     }
 }

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -186,7 +186,9 @@ impl Display for Error {
                 write!(f, "unsupported {command:?} version {received:?}, expected {expected:?}")
             },
             Self::Anyhow(err) => write!(f, "{err}"),
-            Self::UnexpectedOutput(cmd, output) => write!(f, "unexpected output for {cmd:?}: {output}"),
+            Self::UnexpectedOutput(cmd, output) => {
+                write!(f, "unexpected output for {cmd:?}: {output}")
+            },
             Self::NoLockfileGenerated => write!(f, "no lockfile was generated"),
         }
     }

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -145,8 +145,8 @@ pub enum Error {
     InvalidManifest(PathBuf),
     PipReportVersionMismatch(&'static str, String),
     UnsupportedCommandVersion(&'static str, &'static str, String),
-    UnexpectedOutput(&'static str, String),
     Anyhow(anyhow::Error),
+    UnexpectedOutput(&'static str, String),
     NoLockfileGenerated,
 }
 

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -1,7 +1,5 @@
-use std::error::Error as StdError;
 use std::ffi::OsString;
-use std::fmt::{self, Display, Formatter};
-use std::path::{Path, PathBuf};
+use std::path::{Path, PathBuf, StripPrefixError};
 use std::process::{Command, Stdio};
 use std::string::FromUtf8Error;
 use std::{fs, io};
@@ -135,85 +133,30 @@ impl FileRelocator {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Lockfile generation error.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    InvalidUtf8(FromUtf8Error),
-    Json(JsonError),
-    Io(io::Error),
-    ProcessCreation(String, String, io::Error),
-    NonZeroExit(Option<i32>, String),
+    #[error("{0}")]
+    Anyhow(#[from] anyhow::Error),
+    #[error("invalid manifest path: {0:?}")]
     InvalidManifest(PathBuf),
+    #[error("utf8 parsing error")]
+    InvalidUtf8(#[from] FromUtf8Error),
+    #[error("I/O error")]
+    Io(#[from] io::Error),
+    #[error("json parsing error")]
+    Json(#[from] JsonError),
+    #[error("package manager quit unexpectedly (code: {0:?}):\n\n{1}")]
+    NonZeroExit(Option<i32>, String),
+    #[error("unsupported pip report version {1:?}, expected {0:?}")]
     PipReportVersionMismatch(&'static str, String),
-    UnsupportedCommandVersion(&'static str, &'static str, String),
-    Anyhow(anyhow::Error),
+    #[error("failed to spawn command {0}: Is {1} installed?")]
+    ProcessCreation(String, String, io::Error),
+    #[error("could not strip path prefix")]
+    StripPrefix(#[from] StripPrefixError),
+    #[error("unexpected output for {0:?}: {1}")]
     UnexpectedOutput(&'static str, String),
+    #[error("unsupported {0:?} version {2:?}, expected {1:?}")]
+    UnsupportedCommandVersion(&'static str, &'static str, String),
+    #[error("no lockfile was generated")]
     NoLockfileGenerated,
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::InvalidUtf8(err) => Some(err),
-            Self::Json(err) => Some(err),
-            Self::Io(err) => Some(err),
-            Self::ProcessCreation(_, _, err) => Some(err),
-            Self::Anyhow(err) => err.source(),
-            _ => None,
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidUtf8(_) => write!(f, "utf8 parsing error"),
-            Self::Json(_) => write!(f, "json parsing error"),
-            Self::Io(_) => write!(f, "I/O error"),
-            Self::InvalidManifest(path) => write!(f, "invalid manifest path: {path:?}"),
-            Self::ProcessCreation(program, tool, _) => {
-                write!(f, "failed to spawn command {program}: Is {tool} installed?")
-            },
-            Self::NonZeroExit(Some(code), stderr) => {
-                write!(f, "package manager exited with error code {code}:\n\n{stderr}")
-            },
-            Self::NonZeroExit(None, stderr) => {
-                write!(f, "package manager quit unexpectedly:\n\n{stderr}")
-            },
-            Self::PipReportVersionMismatch(expected, received) => {
-                write!(f, "unsupported pip report version {received:?}, expected {expected:?}")
-            },
-            Self::UnsupportedCommandVersion(command, expected, received) => {
-                write!(f, "unsupported {command:?} version {received:?}, expected {expected:?}")
-            },
-            Self::Anyhow(err) => write!(f, "{err}"),
-            Self::UnexpectedOutput(cmd, output) => {
-                write!(f, "unexpected output for {cmd:?}: {output}")
-            },
-            Self::NoLockfileGenerated => write!(f, "no lockfile was generated"),
-        }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<FromUtf8Error> for Error {
-    fn from(err: FromUtf8Error) -> Self {
-        Self::InvalidUtf8(err)
-    }
-}
-
-impl From<JsonError> for Error {
-    fn from(err: JsonError) -> Self {
-        Self::Json(err)
-    }
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Anyhow(err)
-    }
 }

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -49,13 +49,7 @@ pub(crate) fn find_workspace_root(manifest_path: impl AsRef<Path>) -> Result<Pat
         .canonicalize()?;
 
     // Search parent directories for workspace manifests.
-    let mut path = original_root.as_path();
-    for _ in 0..WORKSPACE_ROOT_RECURSION_LIMIT {
-        path = match path.parent() {
-            Some(root_dir) => root_dir,
-            None => break,
-        };
-
+    for path in original_root.ancestors().skip(1).take(WORKSPACE_ROOT_RECURSION_LIMIT) {
         // Check if directory has an NPM manifest.
         let manifest_path = path.join("package.json");
         if !manifest_path.exists() {

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -1,40 +1,31 @@
 //! JavaScript npm ecosystem.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use glob::Pattern;
+use serde::Deserialize;
+
 use crate::{Error, Generator, Result};
+
+/// Maximum upwards travelsal when searching for a workspace root.
+const WORKSPACE_ROOT_RECURSION_LIMIT: usize = 16;
 
 pub struct Npm;
 
 impl Generator for Npm {
     fn lockfile_path(&self, manifest_path: &Path) -> Result<PathBuf> {
-        let project_path = manifest_path
-            .parent()
-            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-
-        let output = Command::new("npm").current_dir(project_path).args(["root"]).output()?;
-
-        // Ensure command was successful.
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::NonZeroExit(output.status.code(), stderr.into()));
-        }
-
-        // Parse root node_modules output.
-        let stdout = String::from_utf8(output.stdout).map_err(Error::InvalidUtf8)?;
-        let workspace_root = stdout
-            .strip_suffix("/node_modules\n")
-            .ok_or_else(|| Error::UnexpectedOutput("npm root", stdout.clone()))?;
-
-        Ok(PathBuf::from(workspace_root).join("package-lock.json"))
+        let workspace_root = find_workspace_root(manifest_path)?;
+        Ok(workspace_root.join("package-lock.json"))
     }
 
     fn conflicting_files(&self, manifest_path: &Path) -> Result<Vec<PathBuf>> {
+        let workspace_root = find_workspace_root(manifest_path)?;
         Ok(vec![
-            self.lockfile_path(manifest_path)?,
-            PathBuf::from("npm-shrinkwrap.json"),
-            PathBuf::from("yarn.lock"),
+            workspace_root.join("package-lock.json"),
+            workspace_root.join("npm-shrinkwrap.json"),
+            workspace_root.join("yarn.lock"),
         ])
     }
 
@@ -46,5 +37,109 @@ impl Generator for Npm {
 
     fn tool(&self) -> &'static str {
         "npm"
+    }
+}
+
+/// Find the workspace root of an npm project.
+pub(crate) fn find_workspace_root(manifest_path: impl AsRef<Path>) -> Result<PathBuf> {
+    let manifest_path = manifest_path.as_ref();
+    let original_root = manifest_path
+        .parent()
+        .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?
+        .canonicalize()?;
+
+    // Search parent directories for workspace manifests.
+    let mut path = original_root.as_path();
+    for _ in 0..WORKSPACE_ROOT_RECURSION_LIMIT {
+        path = match path.parent() {
+            Some(root_dir) => root_dir,
+            None => break,
+        };
+
+        // Check if directory has an NPM manifest.
+        let manifest_path = path.join("package.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+
+        // Parse manifest.
+        let content = fs::read_to_string(&manifest_path)?;
+        let manifest: PackageJson = serde_json::from_str(&content)?;
+
+        // Ignore non-workspace manifests.
+        let workspaces = match manifest.workspaces {
+            Some(workspaces) => workspaces,
+            None => continue,
+        };
+
+        // Get original manifest's location relative to this manifest.
+        let relative_path = original_root.strip_prefix(path)?;
+
+        // Check if original manifest location matches any workspace glob.
+        let is_root = workspaces.iter().any(|glob| {
+            let glob = glob.strip_prefix("./").unwrap_or(glob);
+            Pattern::new(glob).map_or(false, |pattern| pattern.matches_path(relative_path))
+        });
+
+        if is_root {
+            return Ok(path.into());
+        } else {
+            return Ok(original_root);
+        }
+    }
+
+    Ok(original_root)
+}
+
+/// Package JSON subset.
+#[derive(Deserialize, Debug)]
+struct PackageJson {
+    workspaces: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NON_WORKSPACE_MANIFEST: &str = r#"{ "name": "test" }"#;
+
+    #[test]
+    fn root_with_workspace() {
+        const WORKSPACE_MANIFEST: &str =
+            r#"{ "name": "parent", "workspaces": ["./packages/sub/*"] }"#;
+
+        // Write root workspace manifest.
+        let tempdir = tempfile::tempdir().unwrap();
+        let workspace_manifest = tempdir.path().join("package.json");
+        fs::write(&workspace_manifest, WORKSPACE_MANIFEST).unwrap();
+
+        // Create irrelevant non-manifest directory.
+        let nothing_dir = tempdir.path().join("packages");
+        fs::create_dir_all(&nothing_dir).unwrap();
+
+        // Write irrelevant intermediate manifest.
+        let sub_dir = nothing_dir.join("sub");
+        fs::create_dir_all(&sub_dir).unwrap();
+        let sub_manifest = sub_dir.join("package.json");
+        fs::write(&sub_manifest, NON_WORKSPACE_MANIFEST).unwrap();
+
+        // Write target project manifest.
+        let project_dir = sub_dir.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let project_manifest = project_dir.join("package.json");
+        fs::write(&project_manifest, NON_WORKSPACE_MANIFEST).unwrap();
+
+        let root = find_workspace_root(&project_manifest).unwrap();
+        assert_eq!(root, tempdir.path().to_path_buf());
+    }
+
+    #[test]
+    fn root_without_workspace() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let manifest_path = tempdir.path().join("package.json");
+        fs::write(&manifest_path, NON_WORKSPACE_MANIFEST).unwrap();
+
+        let root = find_workspace_root(&manifest_path).unwrap();
+        assert_eq!(root, tempdir.path().to_path_buf());
     }
 }

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -111,7 +111,7 @@ mod tests {
         // Write root workspace manifest.
         let tempdir = tempfile::tempdir().unwrap();
         let workspace_manifest = tempdir.path().join("package.json");
-        fs::write(&workspace_manifest, WORKSPACE_MANIFEST).unwrap();
+        fs::write(workspace_manifest, WORKSPACE_MANIFEST).unwrap();
 
         // Create irrelevant non-manifest directory.
         let nothing_dir = tempdir.path().join("packages");
@@ -121,7 +121,7 @@ mod tests {
         let sub_dir = nothing_dir.join("sub");
         fs::create_dir_all(&sub_dir).unwrap();
         let sub_manifest = sub_dir.join("package.json");
-        fs::write(&sub_manifest, NON_WORKSPACE_MANIFEST).unwrap();
+        fs::write(sub_manifest, NON_WORKSPACE_MANIFEST).unwrap();
 
         // Write target project manifest.
         let project_dir = sub_dir.join("project");

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -130,7 +130,7 @@ mod tests {
         fs::write(&project_manifest, NON_WORKSPACE_MANIFEST).unwrap();
 
         let root = find_workspace_root(&project_manifest).unwrap();
-        assert_eq!(root, tempdir.path().to_path_buf());
+        assert_eq!(root, tempdir.path().to_path_buf().canonicalize().unwrap());
     }
 
     #[test]
@@ -140,6 +140,6 @@ mod tests {
         fs::write(&manifest_path, NON_WORKSPACE_MANIFEST).unwrap();
 
         let root = find_workspace_root(&manifest_path).unwrap();
-        assert_eq!(root, tempdir.path().to_path_buf());
+        assert_eq!(root, tempdir.path().to_path_buf().canonicalize().unwrap());
     }
 }

--- a/lockfile_generator/src/npm.rs
+++ b/lockfile_generator/src/npm.rs
@@ -12,7 +12,22 @@ impl Generator for Npm {
         let project_path = manifest_path
             .parent()
             .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-        Ok(project_path.join("package-lock.json"))
+
+        let output = Command::new("npm").current_dir(project_path).args(["root"]).output()?;
+
+        // Ensure command was successful.
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::NonZeroExit(output.status.code(), stderr.into()));
+        }
+
+        // Parse root node_modules output.
+        let stdout = String::from_utf8(output.stdout).map_err(Error::InvalidUtf8)?;
+        let workspace_root = stdout
+            .strip_suffix("/node_modules\n")
+            .ok_or_else(|| Error::UnexpectedOutput("npm root", stdout.clone()))?;
+
+        Ok(PathBuf::from(workspace_root).join("package-lock.json"))
     }
 
     fn conflicting_files(&self, manifest_path: &Path) -> Result<Vec<PathBuf>> {

--- a/lockfile_generator/src/pnpm.rs
+++ b/lockfile_generator/src/pnpm.rs
@@ -22,13 +22,13 @@ impl Generator for Pnpm {
         // Get project root from env variable.
         let workspace_dir_env = env::var_os(WORKSPACE_DIR_ENV_VAR)
             .or_else(|| env::var_os(WORKSPACE_DIR_ENV_VAR.to_lowercase()))
-            .map(|workspace_dir| PathBuf::from(workspace_dir));
+            .map(PathBuf::from);
 
         // Fallback to recursive search for `WORKSPACE_MANIFEST_FILENAME`.
         let workspace_root = workspace_dir_env.or_else(|| find_workspace_root(project_path));
 
         // Fallback to non-workspace location.
-        let root = workspace_root.unwrap_or_else(|| PathBuf::new());
+        let root = workspace_root.unwrap_or_default();
 
         Ok(root.join("pnpm-lock.yaml"))
     }

--- a/lockfile_generator/src/pnpm.rs
+++ b/lockfile_generator/src/pnpm.rs
@@ -45,8 +45,8 @@ impl Generator for Pnpm {
 }
 
 /// Find PNPM workspace root.
-fn find_workspace_root(mut path: &Path) -> Option<PathBuf> {
-    loop {
+fn find_workspace_root(path: &Path) -> Option<PathBuf> {
+    for path in path.ancestors() {
         let dir = fs::read_dir(path).ok()?;
 
         for dir_entry in dir.into_iter().flatten().map(|entry| entry.path()) {
@@ -54,7 +54,7 @@ fn find_workspace_root(mut path: &Path) -> Option<PathBuf> {
                 return Some(path.into());
             }
         }
-
-        path = path.parent()?;
     }
+
+    None
 }

--- a/lockfile_generator/src/pnpm.rs
+++ b/lockfile_generator/src/pnpm.rs
@@ -2,17 +2,35 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{env, fs};
 
 use crate::{Error, Generator, Result};
+
+const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
+const WORKSPACE_DIR_ENV_VAR: &str = "NPM_CONFIG_WORKSPACE_DIR";
 
 pub struct Pnpm;
 
 impl Generator for Pnpm {
+    // Based on PNPM's implementation:
+    // https://github.com/pnpm/pnpm/blob/98377afd3452d92183e4b643a8b122887c0406c3/workspace/find-workspace-dir/src/index.ts
     fn lockfile_path(&self, manifest_path: &Path) -> Result<PathBuf> {
         let project_path = manifest_path
             .parent()
             .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-        Ok(project_path.join("pnpm-lock.yaml"))
+
+        // Get project root from env variable.
+        let workspace_dir_env = env::var_os(WORKSPACE_DIR_ENV_VAR)
+            .or_else(|| env::var_os(WORKSPACE_DIR_ENV_VAR.to_lowercase()))
+            .map(|workspace_dir| PathBuf::from(workspace_dir));
+
+        // Fallback to recursive search for `WORKSPACE_MANIFEST_FILENAME`.
+        let workspace_root = workspace_dir_env.or_else(|| find_workspace_root(project_path));
+
+        // Fallback to non-workspace location.
+        let root = workspace_root.unwrap_or_else(|| PathBuf::new());
+
+        Ok(root.join("pnpm-lock.yaml"))
     }
 
     fn command(&self, _manifest_path: &Path) -> Command {
@@ -23,5 +41,20 @@ impl Generator for Pnpm {
 
     fn tool(&self) -> &'static str {
         "pnpm"
+    }
+}
+
+/// Find PNPM workspace root.
+fn find_workspace_root(mut path: &Path) -> Option<PathBuf> {
+    loop {
+        let dir = fs::read_dir(path).ok()?;
+
+        for dir_entry in dir.into_iter().flatten().map(|entry| entry.path()) {
+            if dir_entry.file_name().map_or(false, |name| name == WORKSPACE_MANIFEST_FILENAME) {
+                return Some(path.into());
+            }
+        }
+
+        path = path.parent()?;
     }
 }

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde::Deserialize;
+
 use crate::{Error, Generator, Result};
 
 pub struct Yarn;
@@ -13,7 +15,38 @@ impl Generator for Yarn {
         let project_path = manifest_path
             .parent()
             .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-        Ok(project_path.join("yarn.lock"))
+
+        let output = Command::new("yarn")
+            .current_dir(project_path)
+            .args(["workspaces", "list", "--json"])
+            .output()?;
+
+        // Ensure command was successful.
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::NonZeroExit(output.status.code(), stderr.into()));
+        }
+
+        // Convert output to actual valid json.
+        let stdout = String::from_utf8(output.stdout).map_err(Error::InvalidUtf8)?;
+        let workspaces_json = format!("[{}]", stdout.trim_end().replace('\n', ","));
+
+        // Parse workspace list.
+        let mut workspaces: Vec<Workspace> = serde_json::from_str(&workspaces_json)?;
+
+        // Sort by longest location path, to prefer longer matches.
+        workspaces.sort_by(|a, b| b.location.len().cmp(&a.location.len()));
+
+        // Find workspace root by stripping the first matching location path.
+        let project_str = project_path
+            .to_str()
+            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
+        let workspace_root = workspaces
+            .into_iter()
+            .find_map(|project| project_str.strip_suffix(&project.location))
+            .unwrap_or(project_str);
+
+        Ok(PathBuf::from(workspace_root).join("yarn.lock"))
     }
 
     fn command(&self, _manifest_path: &Path) -> Command {
@@ -51,4 +84,10 @@ fn yarn_version(manifest_path: &Path) -> Result<String> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(Error::NonZeroExit(output.status.code(), stderr.into()))
     }
+}
+
+/// Yarn workspace project.
+#[derive(Deserialize)]
+struct Workspace {
+    location: String,
 }

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -4,49 +4,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serde::Deserialize;
-
-use crate::{Error, Generator, Result};
+use crate::{npm, Error, Generator, Result};
 
 pub struct Yarn;
 
 impl Generator for Yarn {
     fn lockfile_path(&self, manifest_path: &Path) -> Result<PathBuf> {
-        let project_path = manifest_path
-            .parent()
-            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-
-        let output = Command::new("yarn")
-            .current_dir(project_path)
-            .args(["workspaces", "list", "--json"])
-            .output()?;
-
-        // Ensure command was successful.
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::NonZeroExit(output.status.code(), stderr.into()));
-        }
-
-        // Convert output to actual valid json.
-        let stdout = String::from_utf8(output.stdout).map_err(Error::InvalidUtf8)?;
-        let workspaces_json = format!("[{}]", stdout.trim_end().replace('\n', ","));
-
-        // Parse workspace list.
-        let mut workspaces: Vec<Workspace> = serde_json::from_str(&workspaces_json)?;
-
-        // Sort by longest location path, to prefer longer matches.
-        workspaces.sort_by(|a, b| b.location.len().cmp(&a.location.len()));
-
-        // Find workspace root by stripping the first matching location path.
-        let project_str = project_path
-            .to_str()
-            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-        let workspace_root = workspaces
-            .into_iter()
-            .find_map(|project| project_str.strip_suffix(&project.location))
-            .unwrap_or(project_str);
-
-        Ok(PathBuf::from(workspace_root).join("yarn.lock"))
+        let workspace_root = npm::find_workspace_root(manifest_path)?;
+        Ok(workspace_root.join("yarn.lock"))
     }
 
     fn command(&self, _manifest_path: &Path) -> Command {
@@ -84,10 +49,4 @@ fn yarn_version(manifest_path: &Path) -> Result<String> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(Error::NonZeroExit(output.status.code(), stderr.into()))
     }
-}
-
-/// Yarn workspace project.
-#[derive(Deserialize)]
-struct Workspace {
-    location: String,
 }


### PR DESCRIPTION
This patch fixes the lockfile generation for workspaces with npm, yarn, and pnpm.

See #1236.
