### PR TITLE
Fix allow all networking permissions

### DIFF
--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -47,7 +47,7 @@ impl Permission {
     /// Add resource to allow list
     pub fn allow_resource(&mut self, resource: String) {
         match self {
-            Self::Boolean(true) => {},
+            Self::Boolean(true) => (),
             Self::Boolean(false) => {
                 *self = Self::List(vec![resource]);
             },

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Incorrect handling of `net = true` permission
+
 ## 5.7.1 - 2023-09-08
 
 ### Changed


### PR DESCRIPTION
This patch fixes a regression from e166fce that was causing `net = true` permissions to be handled like `net = false`. This meant than an extension using `net = true` would only be able to access the Phylum API domains from their extension code. Subprocesses and the network sandbox were unaffected by this regression.