### PR TITLE
Fix go lockfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Workspace lockfile generation for cargo, npm, yarn, and pnpm
+- Go lockfile generation
 
 ## [5.7.1] - 2023-09-08
 

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context};
 #[cfg(feature = "generator")]
+use lockfile_generator::go::Go as GoGenerator;
+#[cfg(feature = "generator")]
 use lockfile_generator::Generator;
 use nom::error::convert_error;
 use nom::Finish;
@@ -31,7 +33,7 @@ impl Parse for GoSum {
 
     #[cfg(feature = "generator")]
     fn generator(&self) -> Option<&'static dyn Generator> {
-        None // TODO
+        Some(&GoGenerator)
     }
 }
 


### PR DESCRIPTION
While lockfile generation was already implemented, it was never actually enabled in the `lockfile` crate. This patch enables the Go generator, which has been tested both with workspaces and normal go projects.
