### PR TITLE
Fix manifest filtering for different ecosystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Workspace lockfile generation for cargo, npm, yarn, and pnpm
 - Go lockfile generation
+- Ignored manifests with a different ecosystem's lockfile in a parent directory
 
 ## [5.7.1] - 2023-09-08
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -309,14 +309,14 @@ pub fn find_lockable_files_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileF
     for i in (0..manifests.len()).rev() {
         let mut remove = false;
 
-        let (manifest_path, manifest_format) = &manifests[i];
+        let (manifest_path, _) = &manifests[i];
 
         // Filter out manifests with a lockfile with matching format in a directory
         // above them.
         let mut lockfile_dirs =
             lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
         remove |= lockfile_dirs.any(|(lockfile_dir, lockfile_format)| {
-            lockfile_format.is_path_manifest(manifest_path)
+            lockfile_format.parser().is_path_manifest(manifest_path)
                 && manifest_path.starts_with(lockfile_dir)
         });
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -316,7 +316,8 @@ pub fn find_lockable_files_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileF
         let mut lockfile_dirs =
             lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
         remove |= lockfile_dirs.any(|(lockfile_dir, lockfile_format)| {
-            manifest_format == lockfile_format && manifest_path.starts_with(lockfile_dir)
+            lockfile_format.is_path_manifest(manifest_path)
+                && manifest_path.starts_with(lockfile_dir)
         });
 
         // Filter out `setup.py` files with `pyproject.toml` present.

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -309,11 +309,15 @@ pub fn find_lockable_files_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileF
     for i in (0..manifests.len()).rev() {
         let mut remove = false;
 
-        let (manifest_path, _) = &manifests[i];
+        let (manifest_path, manifest_format) = &manifests[i];
 
-        // Filter out manifests with a lockfile in a directory above them.
-        let mut lockfile_dirs = lockfiles.iter().filter_map(|(path, _)| path.parent());
-        remove |= lockfile_dirs.any(|lockfile_dir| manifest_path.starts_with(lockfile_dir));
+        // Filter out manifests with a lockfile with matching format in a directory
+        // above them.
+        let mut lockfile_dirs =
+            lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
+        remove |= lockfile_dirs.any(|(lockfile_dir, lockfile_format)| {
+            manifest_format == lockfile_format && manifest_path.starts_with(lockfile_dir)
+        });
 
         // Filter out `setup.py` files with `pyproject.toml` present.
         if manifest_path.ends_with("setup.py") {


### PR DESCRIPTION
This fixes an issue where manifests would get filtered out with a lockfile of a different ecosystem being present in a parent directory.

Closes #1245.
