### PR TITLE
Add repository URL to project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#4e8fa6a63fa29a44b2061d6919b467755d8c212a"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#8da8eacd6202a8a7587cb567750e762caa1bb6da"
 dependencies = [
  "chrono",
  "purl",

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -107,6 +107,13 @@ pub fn post_create_project(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/projects")?)
 }
 
+/// PUT /data/projects/<project_id>
+pub fn update_project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["data", "projects", project_id]);
+    Ok(url)
+}
+
 /// DELETE /data/projects/<project_id>
 pub fn delete_project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -253,11 +253,16 @@ impl PhylumApi {
     }
 
     /// Create a new project
-    pub async fn create_project(&self, name: &str, group: Option<&str>) -> Result<ProjectId> {
+    pub async fn create_project(
+        &self,
+        name: &str,
+        group: Option<String>,
+        repository_url: Option<String>,
+    ) -> Result<ProjectId> {
         let response: CreateProjectResponse = self
             .post(
                 endpoints::post_create_project(&self.config.connection.uri)?,
-                CreateProjectRequest { name: name.to_owned(), group_name: group.map(String::from) },
+                CreateProjectRequest { repository_url, name: name.to_owned(), group_name: group },
             )
             .await?;
         Ok(response.id)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -131,6 +131,30 @@ pub fn add_subcommands(command: Command) -> Command {
                     ]),
                 )
                 .subcommand(
+                    Command::new("update").about("Update a project").args(&[
+                        Arg::new("project-id")
+                            .short('i')
+                            .long("project-id")
+                            .value_name("PROJECT_ID")
+                            .help("ID of the project to be updated"),
+                        Arg::new("group")
+                            .short('g')
+                            .long("group")
+                            .value_name("GROUP_NAME")
+                            .help("Group that owns the project"),
+                        Arg::new("name")
+                            .short('n')
+                            .long("name")
+                            .value_name("NAME")
+                            .help("New project name"),
+                        Arg::new("repository-url")
+                            .short('r')
+                            .long("repository-url")
+                            .value_name("REPOSITORY_URL")
+                            .help("New repository URL"),
+                    ]),
+                )
+                .subcommand(
                     Command::new("list").about("List all existing projects").args(&[
                         Arg::new("json")
                             .action(ArgAction::SetTrue)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -110,6 +110,11 @@ pub fn add_subcommands(command: Command) -> Command {
                             .long("group")
                             .value_name("group_name")
                             .help("Group which will be the owner of the project"),
+                        Arg::new("repository-url")
+                            .short('r')
+                            .long("repository-url")
+                            .value_name("repository_url")
+                            .help("Repository URL of the project"),
                     ]),
                 )
                 .subcommand(
@@ -491,6 +496,11 @@ pub fn add_subcommands(command: Command) -> Command {
                     .long("force")
                     .help("Overwrite existing configurations without confirmation")
                     .action(ArgAction::SetTrue),
+                Arg::new("repository-url")
+                    .short('r')
+                    .long("repository-url")
+                    .value_name("REPOSITORY_URL")
+                    .help("Repository URL of the project"),
             ]),
         )
         .subcommand(

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -100,6 +100,15 @@ pub fn add_subcommands(command: Command) -> Command {
                 .arg_required_else_help(true)
                 .subcommand_required(true)
                 .subcommand(
+                    Command::new("status").about("Get current project information").args(&[
+                        Arg::new("json")
+                            .action(ArgAction::SetTrue)
+                            .short('j')
+                            .long("json")
+                            .help("Produce output in json format (default: false)"),
+                    ]),
+                )
+                .subcommand(
                     Command::new("create").about("Create a new project").args(&[
                         Arg::new("name")
                             .value_name("name")

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -142,7 +142,9 @@ async fn handle_commands() -> CommandResult {
         "version" => handle_version(&app_name, &ver),
         "parse" => parse::handle_parse(sub_matches),
         "ping" => handle_ping(Spinner::wrap(api).await?).await,
-        "project" => project::handle_project(&Spinner::wrap(api).await?, sub_matches).await,
+        "project" => {
+            project::handle_project(&Spinner::wrap(api).await?, app_helper, sub_matches).await
+        },
         "package" => packages::handle_get_package(&Spinner::wrap(api).await?, sub_matches).await,
         "history" => jobs::handle_history(&Spinner::wrap(api).await?, sub_matches).await,
         "group" => group::handle_group(&Spinner::wrap(api).await?, sub_matches).await,

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -312,13 +312,14 @@ async fn create_project(
     op_state: Rc<RefCell<OpState>>,
     name: String,
     group: Option<String>,
+    repository_url: Option<String>,
 ) -> Result<CreatedProject> {
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
     // Retrieve the id if the project already exists, otherwise return the id or the
     // error.
-    match api.create_project(&name, group.as_deref()).await {
+    match api.create_project(&name, group.clone(), repository_url).await {
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => api
             .get_project_id(&name, group.as_deref())
             .await

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -92,7 +92,7 @@ async fn prompt_project(
     // Prompt for group name.
     let group = match cli_group {
         Some(group) => Some(group.clone()),
-        None => prompt_group(groups).await?,
+        None => prompt_group(groups)?,
     };
 
     // Prompt for repository URL.
@@ -137,7 +137,7 @@ fn prompt_project_name() -> io::Result<String> {
 }
 
 /// Ask for the desired group.
-async fn prompt_group(groups: &[UserGroup]) -> anyhow::Result<Option<String>> {
+pub fn prompt_group(groups: &[UserGroup]) -> anyhow::Result<Option<String>> {
     // Skip group selection if user has none.
     if groups.is_empty() {
         return Ok(None);

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -1,17 +1,19 @@
 use std::path::Path;
 use std::result::Result as StdResult;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use clap::{ArgMatches, Command};
 use console::style;
+use dialoguer::{Confirm, FuzzySelect, Input};
 use phylum_project::{ProjectConfig, PROJ_CONF_FILE};
 use phylum_types::types::common::ProjectId;
 use reqwest::StatusCode;
 
 use crate::api::{PhylumApi, PhylumApiError, ResponseError};
-use crate::commands::{CommandResult, ExitCode};
+use crate::commands::{init, CommandResult, ExitCode};
 use crate::config::save_config;
 use crate::format::Format;
-use crate::{print_user_failure, print_user_success};
+use crate::{print, print_user_failure, print_user_success, print_user_warning};
 
 /// List the projects in this account.
 pub async fn get_project_list(
@@ -27,7 +29,11 @@ pub async fn get_project_list(
 }
 
 /// Handle the project subcommand.
-pub async fn handle_project(api: &PhylumApi, matches: &clap::ArgMatches) -> CommandResult {
+pub async fn handle_project(
+    api: &PhylumApi,
+    app: &mut Command,
+    matches: &ArgMatches,
+) -> CommandResult {
     if let Some(matches) = matches.subcommand_matches("create") {
         let name = matches.get_one::<String>("name").unwrap();
         let group = matches.get_one::<String>("group").cloned();
@@ -48,6 +54,8 @@ pub async fn handle_project(api: &PhylumApi, matches: &clap::ArgMatches) -> Comm
         });
 
         print_user_success!("Successfully created new project, {}", name);
+    } else if let Some(matches) = matches.subcommand_matches("update") {
+        update_project(app, api, matches).await?;
     } else if let Some(matches) = matches.subcommand_matches("delete") {
         let project_name = matches.get_one::<String>("name").unwrap();
         let group_name = matches.get_one::<String>("group");
@@ -91,7 +99,7 @@ pub async fn handle_project(api: &PhylumApi, matches: &clap::ArgMatches) -> Comm
     Ok(ExitCode::Ok)
 }
 
-/// Create and update the Phylum project.
+/// Create a Phylum project.
 pub async fn create_project(
     api: &PhylumApi,
     project: &str,
@@ -106,12 +114,140 @@ pub async fn create_project(
 /// Lookup project by name and group.
 pub async fn lookup_project(
     api: &PhylumApi,
-    project: &str,
+    name: &str,
     group: Option<&str>,
 ) -> StdResult<ProjectId, PhylumApiError> {
-    let uuid = api
-        .get_project_id(project, group)
-        .await
-        .context("A project with that name does not exist")?;
+    let uuid =
+        api.get_project_id(name, group).await.context("A project with that name does not exist")?;
     Ok(uuid)
+}
+
+/// Update a Phylum project.
+pub async fn update_project(
+    app: &mut Command,
+    api: &PhylumApi,
+    matches: &ArgMatches,
+) -> StdResult<(), PhylumApiError> {
+    let repository_url_cli = matches.get_one::<String>("repository-url");
+    let project_id_cli = matches.get_one::<String>("project-id");
+    let name_cli = matches.get_one::<String>("name");
+
+    // Determine interactivity by checking if project ID was supplied.
+    let interactive = project_id_cli.is_none();
+
+    // Sanity check non-interactive usage.
+    if !interactive && repository_url_cli.is_none() && name_cli.is_none() {
+        print_user_warning!("No changes requested, nothing to do.\n");
+        print::print_sc_help(app, &["project", "update"])?;
+        return Ok(());
+    }
+
+    // Prompt for project if necessary.
+    let group_name = matches.get_one::<String>("group").cloned();
+    let (project_id, group_name) = match project_id_cli {
+        Some(project_id) => (project_id.clone(), group_name),
+        None => prompt_project(api, group_name).await?,
+    };
+
+    // Get existing project information from the API.
+    let project = api.get_project(&project_id, group_name.as_deref()).await?;
+
+    // Check if repository URL should be changed.
+    let change_repository_url = if interactive {
+        let change_repository_url = Confirm::new()
+            .with_prompt("Change repository URL?")
+            .default(false)
+            .interact()
+            .map_err(|err| anyhow!(err))?;
+
+        println!();
+
+        change_repository_url
+    } else {
+        false
+    };
+
+    // Prompt for repository URL, defaulting to the existing one if empty.
+    let repository_url = match repository_url_cli {
+        None if change_repository_url => prompt_optional("New Repository URL", None)?,
+        None => project.repository_url.clone(),
+        Some(repository_url) => Some(repository_url.clone()),
+    };
+
+    // Prompt for name, defaulting to the existing one if empty.
+    let name = match name_cli {
+        None if interactive => {
+            prompt_optional("New Project Name", Some(project.name.clone()))?.unwrap()
+        },
+        name => name.cloned().unwrap_or(project.name.clone()),
+    };
+
+    api.update_project(&project_id, group_name.clone(), name.clone(), repository_url.clone())
+        .await?;
+
+    // Output success message.
+    let fmt_option = |opt| match opt {
+        Some(s) => format!("{s:?}"),
+        None => String::from("None"),
+    };
+    let mut success_msg = format!("Successfully updated project {project_id:?}");
+    if let Some(group_name) = &group_name {
+        success_msg += &format!(" (group {group_name:?})");
+    }
+    success_msg += ":\n";
+    success_msg += &format!("      Name: {:?} -> {name:?}\n", project.name);
+    success_msg += &format!(
+        "      Repository URL: {} -> {}",
+        fmt_option(project.repository_url),
+        fmt_option(repository_url)
+    );
+    print_user_success!("{}", success_msg);
+
+    Ok(())
+}
+
+/// Prompt for optional text input.
+fn prompt_optional(subject: &str, default: Option<String>) -> anyhow::Result<Option<String>> {
+    // Prompt for selection of one group.
+    let prompt = match &default {
+        Some(default) => format!("[ENTER] Confirm\n{subject} [default: {default}]"),
+        None => format!("[ENTER] Confirm\n{subject} [default: None]"),
+    };
+    let input: String = Input::new().with_prompt(prompt).allow_empty(true).interact()?;
+
+    println!();
+
+    if input.is_empty() {
+        Ok(default)
+    } else {
+        Ok(Some(input))
+    }
+}
+
+/// Prompt for project selection.
+async fn prompt_project(
+    api: &PhylumApi,
+    cli_group: Option<String>,
+) -> anyhow::Result<(String, Option<String>)> {
+    // Get the project group, prompting for it if necessary.
+    let group_name = match cli_group {
+        Some(cli_group) => Some(cli_group),
+        None => {
+            let groups = api.get_groups_list().await?.groups;
+            init::prompt_group(&groups)?
+        },
+    };
+
+    // Get all projects.
+    let projects = api.get_projects(group_name.as_deref()).await?;
+    let project_names: Vec<_> = projects.iter().map(|project| &project.name).collect();
+
+    // Prompt for project selection.
+    let prompt = "[ENTER] Confirm\nProject Name";
+    let index = FuzzySelect::new().with_prompt(prompt).items(&project_names).interact()?;
+    let project_id = projects[index].id.to_string();
+
+    println!();
+
+    Ok((project_id, group_name))
 }

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -31,10 +31,11 @@ pub async fn handle_project(api: &PhylumApi, matches: &clap::ArgMatches) -> Comm
     if let Some(matches) = matches.subcommand_matches("create") {
         let name = matches.get_one::<String>("name").unwrap();
         let group = matches.get_one::<String>("group").cloned();
+        let repository_url = matches.get_one::<String>("repository-url").cloned();
 
         log::info!("Initializing new project: `{}`", name);
 
-        let project_config = match create_project(api, name, group).await {
+        let project_config = match create_project(api, name, group, repository_url).await {
             Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
                 print_user_failure!("Project '{}' already exists", name);
                 return Ok(ExitCode::AlreadyExists);
@@ -95,8 +96,9 @@ pub async fn create_project(
     api: &PhylumApi,
     project: &str,
     group: Option<String>,
+    repository_url: Option<String>,
 ) -> StdResult<ProjectConfig, PhylumApiError> {
-    let project_id = api.create_project(project, group.as_deref()).await?;
+    let project_id = api.create_project(project, group.clone(), repository_url).await?;
 
     Ok(ProjectConfig::new(project_id.to_owned(), project.to_owned(), group))
 }

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -172,6 +172,19 @@ impl Format for Vec<ProjectSummaryResponse> {
     }
 }
 
+impl Format for ProjectSummaryResponse {
+    fn pretty<W: Write>(&self, writer: &mut W) {
+        let _ = writeln!(writer, "{}: {}", style("ID").blue(), self.id);
+        let _ = writeln!(writer, "{}: {}", style("Name").blue(), self.name);
+        if let Some(group_name) = &self.group_name {
+            let _ = writeln!(writer, "{}: {}", style("Group").blue(), group_name);
+        }
+        if let Some(repository_url) = &self.repository_url {
+            let _ = writeln!(writer, "{}: {}", style("Repository URL").blue(), repository_url);
+        }
+    }
+}
+
 impl Format for ListUserGroupsResponse {
     fn pretty<W: Write>(&self, writer: &mut W) {
         // Maximum length of group name column.

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -166,6 +166,7 @@ impl Format for Vec<ProjectSummaryResponse> {
         let table = format_table::<fn(&ProjectSummaryResponse) -> String, _>(self, &[
             ("Project Name", |project| print::truncate(&project.name, MAX_NAME_WIDTH).into_owned()),
             ("Project ID", |project| project.id.to_string()),
+            ("Repository URL", |project| project.repository_url.clone().unwrap_or_default()),
         ]);
         let _ = writeln!(writer, "{table}");
     }

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -233,7 +233,7 @@ pub async fn create_project() -> &'static str {
 
     // Attempt to create the project, ignoring conflicts.
     let api = PhylumApi::new(config, None).await.unwrap();
-    match api.create_project(PROJECT_NAME, None).await {
+    match api.create_project(PROJECT_NAME, None, None).await {
         Ok(_) | Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
         },
         err @ Err(_) => {

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -30,6 +30,9 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 `-f`, `--force`
 &emsp; Overwrite existing configurations without confirmation
 
+`-r`, `--repository-url` `<REPOSITORY_URL>`
+&emsp; Repository URL of the project
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project.md
+++ b/docs/commands/phylum_project.md
@@ -27,4 +27,5 @@ Usage: phylum project [OPTIONS] <COMMAND>
 * [phylum project delete](./phylum_project_delete)
 * [phylum project link](./phylum_project_link)
 * [phylum project list](./phylum_project_list)
+* [phylum project status](./phylum_project_status)
 * [phylum project update](./phylum_project_update)

--- a/docs/commands/phylum_project.md
+++ b/docs/commands/phylum_project.md
@@ -27,3 +27,4 @@ Usage: phylum project [OPTIONS] <COMMAND>
 * [phylum project delete](./phylum_project_delete)
 * [phylum project link](./phylum_project_link)
 * [phylum project list](./phylum_project_list)
+* [phylum project update](./phylum_project_update)

--- a/docs/commands/phylum_project_create.md
+++ b/docs/commands/phylum_project_create.md
@@ -21,6 +21,9 @@ Usage: phylum project create [OPTIONS] <name>
 `-g`, `--group` `<group_name>`
 &emsp; Group which will be the owner of the project
 
+`-r`, `--repository-url` `<repository_url>`
+&emsp; Repository URL of the project
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_status.md
+++ b/docs/commands/phylum_project_status.md
@@ -1,0 +1,25 @@
+---
+title: phylum project status
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Get current project information
+
+```sh
+Usage: phylum project status [OPTIONS]
+```
+
+### Options
+
+`-j`, `--json`
+&emsp; Produce output in json format (default: false)
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help

--- a/docs/commands/phylum_project_update.md
+++ b/docs/commands/phylum_project_update.md
@@ -1,0 +1,34 @@
+---
+title: phylum project update
+category: 6255e67693d5200013b1fa3e
+hidden: false
+---
+
+Update a project
+
+```sh
+Usage: phylum project update [OPTIONS]
+```
+
+### Options
+
+`-i`, `--project-id` `<PROJECT_ID>`
+&emsp; ID of the project to be updated
+
+`-g`, `--group` `<GROUP_NAME>`
+&emsp; Group that owns the project
+
+`-n`, `--name` `<NAME>`
+&emsp; New project name
+
+`-r`, `--repository-url` `<REPOSITORY_URL>`
+&emsp; New repository URL
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -342,8 +342,9 @@ export class PhylumApi {
   static createProject(
     name: string,
     group?: string,
+    repository_url?: string,
   ): Promise<{ id: string; status: "Created" | "Exists" }> {
-    return DenoCore.opAsync("create_project", name, group);
+    return DenoCore.opAsync("create_project", name, group, repository_url);
   }
 
   /**


### PR DESCRIPTION
This patch adds the new `repository_url` field to all subcommands
creating new projects. This includes `phylum init`, `phylum project
create`, and the `create_project` extension API.

See https://github.com/phylum-dev/roadmap/issues/361.