### PR TITLE
Unify clap `value_name` case

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -84,12 +84,12 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("project")
                     .short('p')
                     .long("project")
-                    .value_name("project_name")
+                    .value_name("PROJECT_NAME")
                     .help("Project to be queried"),
                 Arg::new("group")
                     .short('g')
                     .long("group")
-                    .value_name("group_name")
+                    .value_name("GROUP_NAME")
                     .help("Group to be queried"),
             ]),
         )
@@ -102,26 +102,26 @@ pub fn add_subcommands(command: Command) -> Command {
                 .subcommand(
                     Command::new("create").about("Create a new project").args(&[
                         Arg::new("name")
-                            .value_name("name")
+                            .value_name("NAME")
                             .help("Name of the project")
                             .required(true),
                         Arg::new("group")
                             .short('g')
                             .long("group")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Group which will be the owner of the project"),
                     ]),
                 )
                 .subcommand(
                     Command::new("delete").about("Delete a project").aliases(["rm"]).args(&[
                         Arg::new("name")
-                            .value_name("name")
+                            .value_name("NAME")
                             .help("Name of the project")
                             .required(true),
                         Arg::new("group")
                             .short('g')
                             .long("group")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Group that owns the project"),
                     ]),
                 )
@@ -135,20 +135,20 @@ pub fn add_subcommands(command: Command) -> Command {
                         Arg::new("group")
                             .short('g')
                             .long("group")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Group to list projects for"),
                     ]),
                 )
                 .subcommand(
                     Command::new("link").about("Link a repository to a project").args(&[
                         Arg::new("name")
-                            .value_name("name")
+                            .value_name("NAME")
                             .help("Name of the project")
                             .required(true),
                         Arg::new("group")
                             .short('g')
                             .long("group")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Group owning the project"),
                     ]),
                 ),
@@ -157,18 +157,18 @@ pub fn add_subcommands(command: Command) -> Command {
             Command::new("package").about("Retrieve the details of a specific package").args(&[
                 Arg::new("package-type")
                     .index(1)
-                    .value_name("type")
+                    .value_name("TYPE")
                     .help("Package ecosystem type")
                     .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo"])
                     .required(true),
                 Arg::new("name")
                     .index(2)
-                    .value_name("name")
+                    .value_name("NAME")
                     .help("The name of the package.")
                     .required(true),
                 Arg::new("version")
                     .index(3)
-                    .value_name("version")
+                    .value_name("VERSION")
                     .help("The version of the package.")
                     .required(true),
                 Arg::new("json")
@@ -179,7 +179,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("filter")
                     .short('f')
                     .long("filter")
-                    .value_name("filter")
+                    .value_name("FILTER")
                     .help(FILTER_ABOUT),
             ]),
         )
@@ -283,7 +283,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("lockfile-type")
                         .short('t')
                         .long("lockfile-type")
-                        .value_name("type")
+                        .value_name("TYPE")
                         .requires("lockfile")
                         .help("Lockfile type used for all lockfiles (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
@@ -297,7 +297,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("label")
                         .short('l')
                         .long("label")
-                        .value_name("label")
+                        .value_name("LABEL")
                         .help("Specify a label to use for analysis"),
                     Arg::new("json")
                         .action(ArgAction::SetTrue)
@@ -307,12 +307,12 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("project")
                         .short('p')
                         .long("project")
-                        .value_name("project_name")
+                        .value_name("PROJECT_NAME")
                         .help("Specify a project to use for analysis"),
                     Arg::new("group")
                         .short('g')
                         .long("group")
-                        .value_name("group_name")
+                        .value_name("GROUP_NAME")
                         .help("Specify a group to use for analysis")
                         .requires("project"),
                     Arg::new("lockfile")
@@ -323,7 +323,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("lockfile-type")
                         .short('t')
                         .long("lockfile-type")
-                        .value_name("type")
+                        .value_name("TYPE")
                         .requires("lockfile")
                         .help("Lockfile type used for all lockfiles (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
@@ -344,7 +344,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("file")
                         .short('f')
                         .long("file")
-                        .value_name("file")
+                        .value_name("FILE")
                         .help(
                             "File (or piped stdin) containing the list of packages (format \
                              `<name>:<version>`)",
@@ -353,7 +353,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("type")
                         .short('t')
                         .long("type")
-                        .value_name("type")
+                        .value_name("TYPE")
                         .help("Package ecosystem type")
                         .value_parser([
                             "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
@@ -363,12 +363,12 @@ pub fn add_subcommands(command: Command) -> Command {
                     Arg::new("project")
                         .short('p')
                         .long("project")
-                        .value_name("project_name")
+                        .value_name("PROJECT_NAME")
                         .help("Project to use for analysis"),
                     Arg::new("group")
                         .short('g')
                         .long("group")
-                        .value_name("group_name")
+                        .value_name("GROUP_NAME")
                         .help("Group to use for analysis")
                         .requires("project"),
                 ]),
@@ -391,7 +391,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 .subcommand(
                     Command::new("create").about("Create a new group").arg(
                         Arg::new("group_name")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Name for the new group")
                             .required(true),
                     ),
@@ -399,7 +399,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 .subcommand(
                     Command::new("delete").about("Delete a group").arg(
                         Arg::new("group_name")
-                            .value_name("group_name")
+                            .value_name("GROUP_NAME")
                             .help("Name for the group to be deleted")
                             .required(true),
                     ),
@@ -482,7 +482,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 Arg::new("lockfile-type")
                     .short('t')
                     .long("lockfile-type")
-                    .value_name("type")
+                    .value_name("TYPE")
                     .requires("lockfile")
                     .help("Lockfile type used for all lockfiles (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -17,19 +17,19 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 ### Options
 
-`-l`, `--label` `<label>`
+`-l`, `--label` `<LABEL>`
 &emsp; Specify a label to use for analysis
 
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`-p`, `--project` `<project_name>`
+`-p`, `--project` `<PROJECT_NAME>`
 &emsp; Specify a project to use for analysis
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Specify a group to use for analysis
 
-`-t`, `--lockfile-type` `<type>`
+`-t`, `--lockfile-type` `<TYPE>`
 &emsp; Lockfile type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 

--- a/docs/commands/phylum_group_create.md
+++ b/docs/commands/phylum_group_create.md
@@ -8,12 +8,12 @@ hidden: false
 Create a new group
 
 ```sh
-Usage: phylum group create [OPTIONS] <group_name>
+Usage: phylum group create [OPTIONS] <GROUP_NAME>
 ```
 
 ### Arguments
 
-`<group_name>`
+`<GROUP_NAME>`
 &emsp; Name for the new group
 
 ### Options

--- a/docs/commands/phylum_group_delete.md
+++ b/docs/commands/phylum_group_delete.md
@@ -8,12 +8,12 @@ hidden: false
 Delete a group
 
 ```sh
-Usage: phylum group delete [OPTIONS] <group_name>
+Usage: phylum group delete [OPTIONS] <GROUP_NAME>
 ```
 
 ### Arguments
 
-`<group_name>`
+`<GROUP_NAME>`
 &emsp; Name for the group to be deleted
 
 ### Options

--- a/docs/commands/phylum_history.md
+++ b/docs/commands/phylum_history.md
@@ -20,10 +20,10 @@ Usage: phylum history [OPTIONS] [JOB_ID]
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`-p`, `--project` `<project_name>`
+`-p`, `--project` `<PROJECT_NAME>`
 &emsp; Project to be queried
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Group to be queried
 
 `-v`, `--verbose`...

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -23,7 +23,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 `-l`, `--lockfile` `<LOCKFILE>`
 &emsp; Project-relative lockfile path
 
-`-t`, `--lockfile-type` `<type>`
+`-t`, `--lockfile-type` `<TYPE>`
 &emsp; Lockfile type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 

--- a/docs/commands/phylum_package.md
+++ b/docs/commands/phylum_package.md
@@ -7,19 +7,19 @@ hidden: false
 Retrieve the details of a specific package
 
 ```sh
-Usage: phylum package [OPTIONS] <type> <name> <version>
+Usage: phylum package [OPTIONS] <TYPE> <NAME> <VERSION>
 ```
 
 ### Arguments
 
-`<type>`
+`<TYPE>`
 &emsp; Package ecosystem type
 &emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
 
-`<name>`
+`<NAME>`
 &emsp; The name of the package.
 
-`<version>`
+`<VERSION>`
 &emsp; The version of the package.
 
 ### Options
@@ -27,7 +27,7 @@ Usage: phylum package [OPTIONS] <type> <name> <version>
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`-f`, `--filter` `<filter>`
+`-f`, `--filter` `<FILTER>`
 &emsp; Provide a filter used to limit the issues displayed
 
 &nbsp;&nbsp;&nbsp;&nbsp;EXAMPLES:

--- a/docs/commands/phylum_parse.md
+++ b/docs/commands/phylum_parse.md
@@ -17,7 +17,7 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 
 ### Options
 
-`-t`, `--lockfile-type` `<type>`
+`-t`, `--lockfile-type` `<TYPE>`
 &emsp; Lockfile type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 

--- a/docs/commands/phylum_project_create.md
+++ b/docs/commands/phylum_project_create.md
@@ -8,17 +8,17 @@ hidden: false
 Create a new project
 
 ```sh
-Usage: phylum project create [OPTIONS] <name>
+Usage: phylum project create [OPTIONS] <NAME>
 ```
 
 ### Arguments
 
-`<name>`
+`<NAME>`
 &emsp; Name of the project
 
 ### Options
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Group which will be the owner of the project
 
 `-v`, `--verbose`...

--- a/docs/commands/phylum_project_delete.md
+++ b/docs/commands/phylum_project_delete.md
@@ -8,17 +8,17 @@ hidden: false
 Delete a project
 
 ```sh
-Usage: phylum project delete [OPTIONS] <name>
+Usage: phylum project delete [OPTIONS] <NAME>
 ```
 
 ### Arguments
 
-`<name>`
+`<NAME>`
 &emsp; Name of the project
 
 ### Options
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Group that owns the project
 
 `-v`, `--verbose`...

--- a/docs/commands/phylum_project_link.md
+++ b/docs/commands/phylum_project_link.md
@@ -8,17 +8,17 @@ hidden: false
 Link a repository to a project
 
 ```sh
-Usage: phylum project link [OPTIONS] <name>
+Usage: phylum project link [OPTIONS] <NAME>
 ```
 
 ### Arguments
 
-`<name>`
+`<NAME>`
 &emsp; Name of the project
 
 ### Options
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Group owning the project
 
 `-v`, `--verbose`...

--- a/docs/commands/phylum_project_list.md
+++ b/docs/commands/phylum_project_list.md
@@ -16,7 +16,7 @@ Usage: phylum project list [OPTIONS]
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`-g`, `--group` `<group_name>`
+`-g`, `--group` `<GROUP_NAME>`
 &emsp; Group to list projects for
 
 `-v`, `--verbose`...


### PR DESCRIPTION
Previously the case for the value names of CLI arguments was mixed lower and upper case. Since the standard on unix systems is usually uppercase, all options have been changed to comply with this format.