### PR TITLE
Add find-lockable-files subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [5.7.3] - 2023-10-17
 
+### Changed
+- Automatic manifest resolution with subcommands `init`/`parse`/`analyze` will
+    no longer return manifests in subdirectories of other manifests
+
 ### Fixed
 - Pip requirements.txt parser failing with third-party registries
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -500,6 +500,11 @@ pub fn add_subcommands(command: Command) -> Command {
                 .long("json")
                 .help("Produce output in json format (default: false)")]),
         )
+        .subcommand(
+            Command::new("find-lockable-files")
+                .about("Find all lockfile and manifest paths")
+                .hide(true),
+        )
         .subcommand(extensions::command());
 
     #[cfg(unix)]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -13,7 +13,8 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, extensions, group, init, jobs, packages, parse, project, status, CommandResult, ExitCode,
+    auth, extensions, find_lockable_files, group, init, jobs, packages, parse, project, status,
+    CommandResult, ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;
@@ -158,6 +159,7 @@ async fn handle_commands() -> CommandResult {
         "extension" => extensions::handle_extensions(Box::pin(api), sub_matches, app_helper).await,
         #[cfg(unix)]
         "sandbox" => sandbox::handle_sandbox(sub_matches).await,
+        "find-lockable-files" => find_lockable_files::handle_command(),
         extension_subcmd => {
             extensions::handle_run_extension(Box::pin(api), extension_subcmd, sub_matches).await
         },

--- a/cli/src/commands/find_lockable_files.rs
+++ b/cli/src/commands/find_lockable_files.rs
@@ -1,0 +1,11 @@
+//! `phylum find-lockable-files` subcommand.
+
+use crate::commands::{CommandResult, ExitCode};
+
+/// Handle `phylum find-lockable-files` subcommand.
+pub fn handle_command() -> CommandResult {
+    let lockables = phylum_lockfile::LockableFiles::find_at(".");
+    let json = serde_json::to_string(&lockables)?;
+    println!("{}", json);
+    Ok(ExitCode::Ok)
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ use std::process;
 
 pub mod auth;
 pub mod extensions;
+pub mod find_lockable_files;
 pub mod group;
 pub mod init;
 pub mod jobs;

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -277,52 +277,86 @@ pub fn find_lockfiles_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileFormat
         .collect()
 }
 
+/// Collection of lockfiles and manifests.
+#[derive(Serialize)]
+pub struct LockableFiles {
+    pub lockfiles: Vec<(PathBuf, LockfileFormat)>,
+    pub manifests: Vec<(PathBuf, LockfileFormat)>,
+}
+
+impl LockableFiles {
+    /// Find lockfiles and manifests at or below the specified root directory.
+    ///
+    /// Walks the directory tree and returns all recognized files.
+    ///
+    /// Paths excluded by gitignore are automatically ignored.
+    pub fn find_at(root: impl AsRef<Path>) -> Self {
+        let mut lockables = Self { lockfiles: Vec::new(), manifests: Vec::new() };
+
+        let walker = WalkBuilder::new(root).max_depth(Some(MAX_LOCKFILE_DEPTH)).build();
+
+        // Find all lockfiles and manifests in the specified directory.
+        for entry in walker.into_iter().flatten() {
+            let path = entry.path();
+
+            for format in LockfileFormat::iter() {
+                let parser = format.parser();
+
+                if parser.is_path_lockfile(path) {
+                    lockables.lockfiles.push((path.to_path_buf(), format));
+                    break;
+                } else if parser.is_path_manifest(path) {
+                    // Select first matching format for manifests.
+                    lockables.manifests.push((path.to_path_buf(), format));
+                    break;
+                }
+            }
+        }
+
+        lockables
+    }
+}
+
 /// Find lockfiles and manifests at or below the specified root directory.
 ///
 /// Walks the directory tree and returns all recognized files.
 ///
+/// This will filter out manifests if there is a manifest or lockfile in a
+/// directory above them. To get all lockfiles and manifests, see
+/// [`LockableFiles::find_at`].
+///
 /// Paths excluded by gitignore are automatically ignored.
 pub fn find_lockable_files_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileFormat)> {
-    let mut manifests: Vec<(PathBuf, _)> = Vec::new();
-    let mut lockfiles = Vec::new();
+    let mut lockables = LockableFiles::find_at(root);
 
-    let walker = WalkBuilder::new(root).max_depth(Some(MAX_LOCKFILE_DEPTH)).build();
-
-    // Find all lockfiles and manifests in the specified directory.
-    for entry in walker.into_iter().flatten() {
-        let path = entry.path();
-
-        for format in LockfileFormat::iter() {
-            let parser = format.parser();
-
-            if parser.is_path_lockfile(path) {
-                lockfiles.push((path.to_path_buf(), format));
-                break;
-            } else if parser.is_path_manifest(path) {
-                // Select first matching format for manifests.
-                manifests.push((path.to_path_buf(), format));
-                break;
-            }
-        }
-    }
-
-    for i in (0..manifests.len()).rev() {
+    for i in (0..lockables.manifests.len()).rev() {
         let mut remove = false;
 
-        let (manifest_path, _) = &manifests[i];
+        let (manifest_path, _) = &lockables.manifests[i];
 
-        // Filter out manifests with a lockfile with matching format in a directory
-        // above them.
+        // Filter out manifest if there's a lockfile with a matching format in a
+        // directory above.
         let mut lockfile_dirs =
-            lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
+            lockables.lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
         remove |= lockfile_dirs.any(|(lockfile_dir, lockfile_format)| {
             lockfile_format.parser().is_path_manifest(manifest_path)
                 && manifest_path.starts_with(lockfile_dir)
         });
 
+        // Filter out manifest if there's a manifest with a matching format in a
+        // directory above.
+        let mut manifest_dirs = lockables.manifests.iter().filter_map(|(path, format)| {
+            let parent = path.parent()?;
+            (path != manifest_path).then_some((parent, format))
+        });
+        remove |= manifest_dirs.any(|(manifest_dir, manifest_format)| {
+            manifest_format.parser().is_path_manifest(manifest_path)
+                && manifest_path.starts_with(manifest_dir)
+        });
+
         // Filter out `setup.py` files with `pyproject.toml` present.
         if manifest_path.ends_with("setup.py") {
-            remove |= manifests.iter().any(|(path, _)| {
+            remove |= lockables.manifests.iter().any(|(path, _)| {
                 let dir = path.parent().unwrap();
                 manifest_path.starts_with(dir) && path.ends_with("pyproject.toml")
             });
@@ -330,13 +364,13 @@ pub fn find_lockable_files_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileF
 
         // Remove unwanted manifests.
         if remove {
-            manifests.swap_remove(i);
+            lockables.manifests.swap_remove(i);
         }
     }
 
     // Return all manifests and lockfiles.
-    lockfiles.append(&mut manifests);
-    lockfiles
+    lockables.lockfiles.append(&mut lockables.manifests);
+    lockables.lockfiles
 }
 
 /// Define a custom error for unknown ecosystems.


### PR DESCRIPTION
This patch adds a new subcommand which allows looking up all lockfiles
and manifests in the current directory without performing any filtering
on the result.

The manifest resolution is also changed to remove manifests when there
is a manifest of the same ecosystem in a directory above, indicating
that the project is likely a workspace.

Closes https://github.com/phylum-dev/cli/issues/1255.