### PR TITLE
Fix `find-permissions` for symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "birdcage"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a00b46409c8a47c3d58d2adae897a5975bc13b363babb6f2bb1df3063e1b398"
+checksum = "b4005c1802ead5b6f2879e0518f3daf6676670f0e8ad14099fbff41056ee2a5b"
 dependencies = [
  "bitflags 2.4.1",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.12.0"
 deno_runtime = { version = "0.122.0" }
 deno_core = { version = "0.199.0" }
 deno_ast = { version = "0.27.2", features = ["transpiling"] }
-birdcage = { version = "0.5.0" }
+birdcage = { version = "0.6.0" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `skipSandbox` parameter for `parseLockfile` to generate lockfiles without sandbox protection
 - `generateLockfiles` parameter for `parseLockfile` to inhibit lockfile generation
 
+### Fixed
+
+- Exceptions for symlinks in `runSandboxed` on Linux
+- Removing exceptions for child directories on macOS
+
 ## 5.8.0 - 2023-10-24
 
 ### Added

--- a/extensions/find-permissions/main.ts
+++ b/extensions/find-permissions/main.ts
@@ -139,6 +139,20 @@ async function checkPath(allowed: string[], path: string) {
       directories.push(path + entry.name);
     } else if (entry.isFile) {
       files.push(path + entry.name);
+    } else if (entry.isSymlink) {
+      let symlink_entry;
+      try {
+        symlink_entry = await Deno.stat(path + entry.name);
+      } catch (_e) {
+        // Ignore dead symlinks.
+        continue;
+      }
+
+      if (symlink_entry.isDirectory) {
+        directories.push(path + entry.name);
+      } else if (symlink_entry.isFile) {
+        files.push(path + entry.name);
+      }
     }
   }
 


### PR DESCRIPTION
This fixes an issue where dependencies on symlinked directories or files would report overly coarse results.
