### PR TITLE
Add support for build.gradle.kts manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Path dependencies for pnpm lockfiles
+- Gradle lockfile generation with `build.gradle.kts` manifests
 
 ## [5.7.3] - 2023-10-17
 

--- a/docs/lockfile_generation.md
+++ b/docs/lockfile_generation.md
@@ -18,7 +18,7 @@ The Phylum CLI can generate a lockfile when it is given a manifest file.
 | `poetry`      | `pyproject.toml` | [`poetry`][poetry]          |
 | `gem`         | `Gemfile`        | `bundle` (from [Bundler][]) |
 | `mvn`         | `pom.xml`        | `mvn` (from [Maven][])      |
-| `gradle`      | `build.gradle`   | [`gradle`][gradle]          |
+| `gradle`      | `build.gradle` <br/> `build.gradle.kts`   | [`gradle`][gradle]          |
 | `go`          | `go.mod`         | [`go`][go]                  |
 | `cargo`       | `Cargo.toml`     | [`cargo`][cargo]            |
 | `nugetlock`   | `*.csproj`       | [`dotnet`][dotnet]          |

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -36,6 +36,7 @@ impl Parse for GradleLock {
 
     fn is_path_manifest(&self, path: &Path) -> bool {
         path.file_name() == Some(OsStr::new("build.gradle"))
+            || path.file_name() == Some(OsStr::new("build.gradle.kts"))
     }
 
     #[cfg(feature = "generator")]


### PR DESCRIPTION
This fixes an issue where build.gradle files written in Kotlin wouldn't be detected as manifests.