### PR TITLE
Fix pnpm lockfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Path dependencies for pnpm lockfiles
 - Gradle lockfile generation with `build.gradle.kts` manifests
+- Lockfile generation for non-workspace pnpm projects
 
 ## [5.7.3] - 2023-10-17
 

--- a/lockfile_generator/src/pnpm.rs
+++ b/lockfile_generator/src/pnpm.rs
@@ -28,7 +28,7 @@ impl Generator for Pnpm {
         let workspace_root = workspace_dir_env.or_else(|| find_workspace_root(project_path));
 
         // Fallback to non-workspace location.
-        let root = workspace_root.unwrap_or_default();
+        let root = workspace_root.unwrap_or_else(|| project_path.into());
 
         Ok(root.join("pnpm-lock.yaml"))
     }


### PR DESCRIPTION
This fixes an issue where the pnpm lockfile generator would fall back to `./pnpm-lock.yaml` if no workspace was present, instead of the correct `<MANIFEST_PATH>/../pnpm-lock.yaml`.
