### PR TITLE
Move CHANGELOG entries to correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Gradle lockfile generation with `build.gradle.kts` manifests
+- Lockfile generation for non-workspace pnpm projects
 - Fixed issue parsing BOM files containing unsupported ecosystems
 
 ## [5.8.0] - 2023-10-24
@@ -23,8 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Path dependencies for pnpm lockfiles
-- Gradle lockfile generation with `build.gradle.kts` manifests
-- Lockfile generation for non-workspace pnpm projects
 
 ## [5.7.3] - 2023-10-17
 


### PR DESCRIPTION
The entries from #1269 and #1270 were accidentally put in the wrong section. The patch fixes that.

It looks like #1269 was based on an old `main`, so the entry ended up in the wrong spot when merged. And since #1270 was done on the same day, it was natural to put that changelog entry right next to the other one.