### PR TITLE
Add sandbox for lockfile generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,8 +416,6 @@ dependencies = [
 [[package]]
 name = "birdcage"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a00b46409c8a47c3d58d2adae897a5975bc13b363babb6f2bb1df3063e1b398"
 dependencies = [
  "bitflags 2.4.1",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,8 @@ dependencies = [
 [[package]]
 name = "birdcage"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a00b46409c8a47c3d58d2adae897a5975bc13b363babb6f2bb1df3063e1b398"
 dependencies = [
  "bitflags 2.4.1",
  "libc",

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -325,6 +325,10 @@ pub fn add_subcommands(command: Command) -> Command {
                         .requires("lockfile")
                         .help("Lockfile type used for all lockfiles (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
+                    Arg::new("skip-sandbox")
+                        .action(ArgAction::SetTrue)
+                        .long("skip-sandbox")
+                        .help("Run lockfile generation without sandbox protection"),
                 ],
             ),
         )
@@ -372,6 +376,10 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_hint(ValueHint::FilePath)
                         .help("Previous list of dependencies for analyzing the delta")
                         .hide(true),
+                    Arg::new("skip-sandbox")
+                        .action(ArgAction::SetTrue)
+                        .long("skip-sandbox")
+                        .help("Run lockfile generation without sandbox protection"),
                 ]),
         )
         .subcommand(

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -376,6 +376,7 @@ async fn parse_lockfile(
     op_state: Rc<RefCell<OpState>>,
     lockfile: String,
     lockfile_type: Option<String>,
+    skip_sandbox: Option<bool>,
 ) -> Result<PackageLock> {
     // Ensure extension has file read-access.
     {
@@ -389,7 +390,8 @@ async fn parse_lockfile(
     let project_root = current_project.as_ref().map(|p| p.root());
 
     // Attempt to parse as requested lockfile type.
-    let parsed = parse::parse_lockfile(lockfile, project_root, lockfile_type.as_deref())?;
+    let sandbox = !skip_sandbox.unwrap_or_default();
+    let parsed = parse::parse_lockfile(lockfile, project_root, lockfile_type.as_deref(), sandbox)?;
 
     Ok(PackageLock { packages: parsed.packages, format: parsed.format })
 }

--- a/cli/src/commands/extensions/permissions.rs
+++ b/cli/src/commands/extensions/permissions.rs
@@ -393,7 +393,7 @@ mod tests {
             unsandboxed_run: Permission::List(vec![]),
         };
 
-        let permissions_options = PermissionsOptions::try_from(&permissions).unwrap();
+        let permissions_options = PermissionsOptions::from(&permissions);
 
         assert!(permissions.is_allow_none());
         assert!(permissions_options.allow_read.is_none());
@@ -419,7 +419,7 @@ mod tests {
             unsandboxed_run: Permission::Boolean(true),
         };
 
-        let permissions_options = PermissionsOptions::try_from(&permissions).unwrap();
+        let permissions_options = PermissionsOptions::from(&permissions);
 
         assert!(permissions_options.allow_read.unwrap().is_empty());
         assert!(permissions_options.allow_write.unwrap().is_empty());

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -96,6 +96,7 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
     let label;
 
     if let Some(matches) = matches.subcommand_matches("analyze") {
+        let sandbox_generation = !matches.get_flag("skip-sandbox");
         label = matches.get_one::<String>("label");
         pretty_print = !matches.get_flag("json");
         synch = true;
@@ -107,14 +108,15 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
         let project_root = current_project.as_ref().map(|p| p.root());
 
         for lockfile in jobs_project.lockfiles {
-            let mut parsed_lockfile =
-                parse::parse_lockfile(&lockfile.path, project_root, Some(&lockfile.lockfile_type))
-                    .with_context(|| {
-                        format!(
-                            "Unable to locate any valid package in lockfile {:?}",
-                            lockfile.path
-                        )
-                    })?;
+            let mut parsed_lockfile = parse::parse_lockfile(
+                &lockfile.path,
+                project_root,
+                Some(&lockfile.lockfile_type),
+                sandbox_generation,
+            )
+            .with_context(|| {
+                format!("Unable to locate any valid package in lockfile {:?}", lockfile.path)
+            })?;
 
             if pretty_print {
                 print_user_success!(

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -183,32 +183,25 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
     permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead("/bin".into()))?;
 
     // Add paths required by specific ecosystems.
-    //
-    // This will automatically resolve `~` to the user's home directory.
-    #[allow(clippy::type_complexity)]
-    let path_exceptions: &[(_, fn(PathBuf) -> Exception)] = &[
-        // Cargo.
-        ("~/.rustup", Exception::ExecuteAndRead),
-        ("~/.cargo", Exception::Read),
-        ("/etc/passwd", Exception::Read),
-        // Bundle.
-        ("/dev/urandom", Exception::Read),
-        // Maven
-        ("/opt/maven", Exception::ExecuteAndRead),
-        ("/etc/java-openjdk", Exception::Read),
-        // Gradle.
-        ("/usr/share/java/gradle/lib", Exception::Read),
-        // Pnpm.
-        ("/tmp", Exception::Read),
-        // Yarn.
-        ("~/.yarn", Exception::Read),
-    ];
     let home = dirs::home_dir()?;
-    let home = home.to_string_lossy();
-    for (path, exfn) in path_exceptions {
-        let path = path.replace('~', &home);
-        permissions::add_exception(&mut birdcage, exfn(path.into()))?;
-    }
+    // Cargo.
+    permissions::add_exception(&mut birdcage, Exception::Read(home.join(".rustup")))?;
+    permissions::add_exception(&mut birdcage, Exception::Read(home.join(".cargo")))?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/etc/passwd".into()))?;
+    // Bundle.
+    permissions::add_exception(&mut birdcage, Exception::Read("/dev/urandom".into()))?;
+    // Maven.
+    permissions::add_exception(&mut birdcage, Exception::Read("/opt/maven".into()))?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/etc/java-openjdk".into()))?;
+    // Gradle.
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::Read("/usr/share/java/gradle/lib".into()),
+    )?;
+    // Pnpm.
+    permissions::add_exception(&mut birdcage, Exception::Read("/tmp".into()))?;
+    // Yarn.
+    permissions::add_exception(&mut birdcage, Exception::Read(home.join("./yarn")))?;
 
     Ok(birdcage)
 }

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -193,10 +193,25 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
     // Maven.
     permissions::add_exception(&mut birdcage, Exception::Read("/opt/maven".into()))?;
     permissions::add_exception(&mut birdcage, Exception::Read("/etc/java-openjdk".into()))?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/maven".into()))?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/openjdk".into()))?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::Read("/opt/homebrew/Cellar/maven".into()),
+    )?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::Read("/opt/homebrew/Cellar/openjdk".into()),
+    )?;
     // Gradle.
     permissions::add_exception(
         &mut birdcage,
         Exception::Read("/usr/share/java/gradle/lib".into()),
+    )?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/gradle".into()))?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::Read("/opt/homebrew/Cellar/gradle".into()),
     )?;
     // Pnpm.
     permissions::add_exception(&mut birdcage, Exception::Read("/tmp".into()))?;

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -191,6 +191,8 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
     // Bundle.
     permissions::add_exception(&mut birdcage, Exception::Read("/dev/urandom".into()))?;
     // Maven.
+    permissions::add_exception(&mut birdcage, Exception::WriteAndRead(home.join(".m2")))?;
+    permissions::add_exception(&mut birdcage, Exception::WriteAndRead("/var/folders".into()))?;
     permissions::add_exception(&mut birdcage, Exception::Read("/opt/maven".into()))?;
     permissions::add_exception(&mut birdcage, Exception::Read("/etc/java-openjdk".into()))?;
     permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/maven".into()))?;
@@ -204,6 +206,7 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
         Exception::Read("/opt/homebrew/Cellar/openjdk".into()),
     )?;
     // Gradle.
+    permissions::add_exception(&mut birdcage, Exception::WriteAndRead(home.join(".gradle")))?;
     permissions::add_exception(
         &mut birdcage,
         Exception::Read("/usr/share/java/gradle/lib".into()),

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -185,6 +185,7 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
     // Add paths required by specific ecosystems.
     //
     // This will automatically resolve `~` to the user's home directory.
+    #[allow(clippy::type_complexity)]
     let path_exceptions: &[(_, fn(PathBuf) -> Exception)] = &[
         // Cargo.
         ("~/.rustup", Exception::ExecuteAndRead),

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -33,6 +33,9 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 &emsp; Lockfile type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
+`--skip-sandbox`
+&emsp; Run lockfile generation without sandbox protection
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_parse.md
+++ b/docs/commands/phylum_parse.md
@@ -21,6 +21,9 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 &emsp; Lockfile type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
+`--skip-sandbox`
+&emsp; Run lockfile generation without sandbox protection
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -442,11 +442,13 @@ export class PhylumApi {
   static parseLockfile(
     lockfile: string,
     lockfileType?: string,
+    skipSandbox?: boolean,
   ): Promise<Lockfile> {
     return DenoCore.opAsync(
       "parse_lockfile",
       lockfile,
       lockfileType,
+      skipSandbox,
     );
   }
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -22,6 +22,7 @@ pub use spdx::Spdx;
 use thiserror::Error;
 use walkdir::WalkDir;
 
+pub use lockfile_generator as generator;
 mod cargo;
 mod csharp;
 mod cyclonedx;

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -10,6 +10,7 @@ pub use golang::GoSum;
 use ignore::WalkBuilder;
 pub use java::{GradleLock, Pom};
 pub use javascript::{PackageLock, Pnpm, YarnLock};
+pub use lockfile_generator as generator;
 #[cfg(feature = "generator")]
 use lockfile_generator::Generator;
 use phylum_types::types::package::PackageType;
@@ -21,8 +22,6 @@ use serde::{Deserialize, Serialize};
 pub use spdx::Spdx;
 use thiserror::Error;
 use walkdir::WalkDir;
-
-pub use lockfile_generator as generator;
 mod cargo;
 mod csharp;
 mod cyclonedx;


### PR DESCRIPTION
This patch uses Birdcage to run lockfile generation in a restricted environment to prevent malicious actors from executing code using Phylum's lockfile generation.