### PR TITLE
Disable sandbox for extension lockfile generation

### DIFF
--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -376,7 +376,6 @@ async fn parse_lockfile(
     op_state: Rc<RefCell<OpState>>,
     lockfile: String,
     lockfile_type: Option<String>,
-    skip_sandbox: Option<bool>,
     generate_lockfiles: Option<bool>,
 ) -> Result<PackageLock> {
     // Ensure extension has file read-access.
@@ -391,13 +390,12 @@ async fn parse_lockfile(
     let project_root = current_project.as_ref().map(|p| p.root());
 
     // Attempt to parse as requested lockfile type.
-    let sandbox = !skip_sandbox.unwrap_or_default();
     let generate_lockfiles = generate_lockfiles.unwrap_or(true);
     let parsed = parse::parse_lockfile(
         lockfile,
         project_root,
         lockfile_type.as_deref(),
-        sandbox,
+        false,
         generate_lockfiles,
     )?;
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `skipSandbox` parameter for `parseLockfile` to generate lockfiles without sandbox protection
 - `generateLockfiles` parameter for `parseLockfile` to inhibit lockfile generation
 
 ## 5.8.0 - 2023-10-24

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -442,14 +442,12 @@ export class PhylumApi {
   static parseLockfile(
     lockfile: string,
     lockfileType?: string,
-    skipSandbox?: boolean,
     generateLockfiles?: boolean,
   ): Promise<Lockfile> {
     return DenoCore.opAsync(
       "parse_lockfile",
       lockfile,
       lockfileType,
-      skipSandbox,
       generateLockfiles,
     );
   }


### PR DESCRIPTION
Currently the lockfile generation sandbox does not spawn a separate process, thus enabling the sandbox for the calling process directly. Since extensions might be doing other things after generating the lockfile for a manifest, this could prevent them from operating correctly.

This patch removes the sandboxing for lockfile generation when calling `parseLockfile` from an extension. In the future it should be possible to enable this again by spawning a separate process for lockfile generation.