### PR TITLE
Fix generation error for invalid lockifests

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -135,11 +135,13 @@ pub fn parse_lockfile(
     }
 
     // Abort if generation is disabled or path is neither lockfile nor manifest.
-    if !generate_lockfiles || !parser.is_path_manifest(&path) {
+    let maybe_manifest = parser.is_path_manifest(&path);
+    if !generate_lockfiles || !maybe_manifest {
         // Return the original lockfile parsing error.
         match lockfile_error {
-            Some(err) => return Err(err.into()),
-            None => return Err(ParseError::ManifestWithoutGeneration(path)),
+            // Report parsing errors only for lockfiles.
+            Some(err) if !maybe_manifest => return Err(err.into()),
+            _ => return Err(ParseError::ManifestWithoutGeneration(path)),
         }
     }
 

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -136,7 +136,7 @@ pub fn parse_lockfile(
 
     // Abort if generation is disabled or path is neither lockfile nor manifest.
     let maybe_manifest = parser.is_path_manifest(&path);
-    if !generate_lockfiles || !maybe_manifest {
+    if !(generate_lockfiles && maybe_manifest) {
         // Return the original lockfile parsing error.
         match lockfile_error {
             // Report parsing errors only for lockfiles.


### PR DESCRIPTION
This changes the error output for lockifests which cannot be parsed as lockfiles when manifest generation is disabled with `--no-generation`. Instead of printing the parsing error of the lockfile, we now print an error that manifest generation is required.

Closes #1295.