### PR TITLE
Fix broken release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
-            protobuf_install: sudo apt install -y protobuf-compiler
+            protobuf_install: sudo apt update && sudo apt install -y protobuf-compiler
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
-            protobuf_install: cat /etc/apt/sources.list && sudo apt install -y protobuf-compiler/focal-backports
+            protobuf_install: sudo apt update && sudo apt install -y protobuf-compiler/focal-backports
           - target: x86_64-apple-darwin
             os: macos-latest
             protobuf_install: brew install cmake protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Install protoc
+        run: sudo apt install -y protobuf-compiler
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
@@ -56,6 +59,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+
+      - name: Show Ubuntu version
+        run: lsb_release -a
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
             protobuf_install: |
-              echo "deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse" \
+              sudo echo "deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse" \
               >> /etc/apt/sources.list \
               && sudo apt update \
               && sudo apt install -y protobuf-compiler/focal-backports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             protobuf_install: sudo apt install -y protobuf-compiler
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
-            protobuf_install: sudo apt install -y protobuf-compiler/focal-backports
+            protobuf_install: cat /etc/apt/sources.list && sudo apt install -y protobuf-compiler/focal-backports
           - target: x86_64-apple-darwin
             os: macos-latest
             protobuf_install: brew install cmake protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,16 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
+            protobuf_install: sudo apt install -y protobuf-compiler
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
+            protobuf_install: sudo apt install -y protobuf-compiler/focal-backports
           - target: x86_64-apple-darwin
             os: macos-latest
+            protobuf_install: brew install cmake protobuf
           - target: aarch64-apple-darwin
             os: [self-hosted, macos, arm64]
+            protobuf_install: brew install cmake protobuf
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -60,16 +64,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Show Ubuntu version
-        run: lsb_release -a
-
-      - if: ${{ runner.os == 'macOS' }}
-        name: Install protoc
-        run: brew install cmake protobuf
-
-      - if: ${{ runner.os == 'Linux' }}
-        name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+      - name: Install protoc
+        run: ${{ matrix.protobuf_install }}
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,11 @@ jobs:
             protobuf_install: sudo apt update && sudo apt install -y protobuf-compiler
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
-            protobuf_install: sudo apt update && sudo apt install -y protobuf-compiler/focal-backports
+            protobuf_install: |
+              echo "deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse" \
+              >> /etc/apt/sources.list \
+              && sudo apt update \
+              && sudo apt install -y protobuf-compiler/focal-backports
           - target: x86_64-apple-darwin
             os: macos-latest
             protobuf_install: brew install cmake protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,20 +47,12 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
-            protobuf_install: sudo apt update && sudo apt install -y protobuf-compiler
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
-            protobuf_install: |
-              sudo echo "deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse" \
-              >> /etc/apt/sources.list \
-              && sudo apt update \
-              && sudo apt install -y protobuf-compiler/focal-backports
           - target: x86_64-apple-darwin
             os: macos-latest
-            protobuf_install: brew install cmake protobuf
           - target: aarch64-apple-darwin
             os: [self-hosted, macos, arm64]
-            protobuf_install: brew install cmake protobuf
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -68,8 +60,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install protoc
-        run: ${{ matrix.protobuf_install }}
+      - if: ${{ runner.os == 'macOS' }}
+        name: Install protoc
+        run: brew install cmake protobuf
+
+      - if: ${{ runner.os == 'Linux' }}
+        name: Install protoc
+        run: sudo apt update && sudo apt install -y protobuf-compiler
 
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
The [release workflow](https://github.com/phylum-dev/cli/actions/workflows/release.yml) was broken...since [the Deno version bump](https://github.com/phylum-dev/cli/commit/ae113fad36aefec040689b885468005be0e8f2e6). This PR fixes the two failing jobs. Don't mind all the WIP commits...it worked first try...after some help from @kylewillmon !
