### PR TITLE
Switch to dependency file terminology

### DIFF
--- a/.phylum_project
+++ b/.phylum_project
@@ -1,7 +1,7 @@
-id: d84b0bb3-fb64-43cb-a473-dc96b54db662
+id: f0ea0603-6916-47bc-ad73-8156d7dc40fc
 name: cli
-created_at: 2023-01-26T20:02:11.276987834+01:00
-group_name: integrations
+created_at: 2023-12-04T20:51:24.124463210+01:00
+group_name: null
 lockfiles:
-- path: Cargo.lock
+- path: ./Cargo.lock
   type: cargo

--- a/.phylum_project
+++ b/.phylum_project
@@ -1,7 +1,7 @@
-id: f0ea0603-6916-47bc-ad73-8156d7dc40fc
+id: d84b0bb3-fb64-43cb-a473-dc96b54db662
 name: cli
-created_at: 2023-12-04T20:51:24.124463210+01:00
-group_name: null
+created_at: 2023-01-26T20:02:11.276987834+01:00
+group_name: integrations
 lockfiles:
-- path: ./Cargo.lock
+- path: Cargo.lock
   type: cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Renamed multiple CLI arguments to avoid the term `lockfile` in places where
     manifests are also accepted
+- Renamed `lockfiles` key in `phylum status --json` output to `dependency_files`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `no-generation` option for `parse`/`analyze` to disable lockfile generation
 - Optional `--project` and `--group` arguments for `phylum project status`
 
+### Changed
+
+- Renamed multiple CLI arguments to avoid the term `lockfile` in places where
+    manifests are also accepted
+
 ### Fixed
 
 - Aliased dependency names in `package-lock.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Renamed multiple CLI arguments to avoid the term `lockfile` in places where
+    manifests are also accepted
+- Renamed `lockfiles` key in `phylum status --json` output to `dependency_files`
+
 ## 5.9.0 - 2023-12-05
 
 ### Added
@@ -16,12 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `skip-sandbox` option for `parse`/`analyze` to generate lockfiles without sandbox protection
 - `no-generation` option for `parse`/`analyze` to disable lockfile generation
 - Optional `--project` and `--group` arguments for `phylum project status`
-
-### Changed
-
-- Renamed multiple CLI arguments to avoid the term `lockfile` in places where
-    manifests are also accepted
-- Renamed `lockfiles` key in `phylum status --json` output to `dependency_files`
 
 ### Fixed
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -539,7 +539,7 @@ pub fn add_subcommands(command: Command) -> Command {
                     .value_name("GROUP_NAME")
                     .help("Group which will be the owner of the project"),
                 Arg::new("depfile")
-                    .short('l') // TODO
+                    .short('d')
                     .long("dependency-file")
                     .value_name("DEPENDENCY_FILE")
                     .help("Project-relative dependency file path")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -322,19 +322,20 @@ pub fn add_subcommands(command: Command) -> Command {
         )
         .subcommand(Command::new("ping").about("Ping the remote system to verify it is available"))
         .subcommand(
-            Command::new("parse").about("Parse lockfiles and output their packages as JSON").args(
-                &[
-                    Arg::new("lockfile")
-                        .value_name("LOCKFILE")
+            Command::new("parse")
+                .about("Parse dependency files and output their packages as JSON")
+                .args(&[
+                    Arg::new("depfile")
+                        .value_name("DEPENDENCY_FILE")
                         .value_hint(ValueHint::FilePath)
-                        .help("The package lockfiles to submit")
+                        .help("Path to the dependency file to parse")
                         .action(ArgAction::Append),
-                    Arg::new("lockfile-type")
+                    Arg::new("type")
                         .short('t')
-                        .long("lockfile-type")
+                        .long("type")
                         .value_name("TYPE")
-                        .requires("lockfile")
-                        .help("Lockfile type used for all lockfiles (default: auto)")
+                        .requires("depfile")
+                        .help("Dependency file type used for all lockfiles (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                     Arg::new("skip-sandbox")
                         .action(ArgAction::SetTrue)
@@ -344,8 +345,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .action(ArgAction::SetTrue)
                         .long("no-generation")
                         .help("Disable generation of lockfiles from manifests"),
-                ],
-            ),
+                ]),
         )
         .subcommand(
             Command::new("analyze")
@@ -372,17 +372,17 @@ pub fn add_subcommands(command: Command) -> Command {
                         .value_name("GROUP_NAME")
                         .help("Specify a group to use for analysis")
                         .requires("project"),
-                    Arg::new("lockfile")
-                        .value_name("LOCKFILE")
+                    Arg::new("depfile")
+                        .value_name("DEPENDENCY_FILE")
                         .value_hint(ValueHint::FilePath)
-                        .help("The package lockfiles to submit")
+                        .help("Path to the dependency file to submit")
                         .action(ArgAction::Append),
-                    Arg::new("lockfile-type")
+                    Arg::new("type")
                         .short('t')
-                        .long("lockfile-type")
+                        .long("type")
                         .value_name("TYPE")
-                        .requires("lockfile")
-                        .help("Lockfile type used for all lockfiles (default: auto)")
+                        .requires("depfile")
+                        .help("Dependency file type used for all lockfiles (default: auto)")
                         .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                     Arg::new("base")
                         .short('b')
@@ -538,18 +538,18 @@ pub fn add_subcommands(command: Command) -> Command {
                     .long("group")
                     .value_name("GROUP_NAME")
                     .help("Group which will be the owner of the project"),
-                Arg::new("lockfile")
-                    .short('l')
-                    .long("lockfile")
-                    .value_name("LOCKFILE")
-                    .help("Project-relative lockfile path")
+                Arg::new("depfile")
+                    .short('l') // TODO
+                    .long("dependency-file")
+                    .value_name("DEPENDENCY_FILE")
+                    .help("Project-relative dependency file path")
                     .action(ArgAction::Append),
-                Arg::new("lockfile-type")
+                Arg::new("type")
                     .short('t')
-                    .long("lockfile-type")
+                    .long("type")
                     .value_name("TYPE")
-                    .requires("lockfile")
-                    .help("Lockfile type used for all lockfiles (default: auto)")
+                    .requires("depfile")
+                    .help("Dependency file type used for all lockfiles (default: auto)")
                     .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
                 Arg::new("force")
                     .short('f')
@@ -571,7 +571,7 @@ pub fn add_subcommands(command: Command) -> Command {
                 .help("Produce output in json format (default: false)")]),
         )
         .subcommand(
-            Command::new("find-lockable-files")
+            Command::new("find-dependency-files")
                 .about("Find all lockfile and manifest paths")
                 .hide(true),
         )

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -13,7 +13,7 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, extensions, find_lockable_files, generate_lockfile, group, init, jobs, packages, parse,
+    auth, extensions, find_dependency_files, generate_lockfile, group, init, jobs, packages, parse,
     project, status, CommandResult, ExitCode,
 };
 use phylum_cli::config::{self, Config};
@@ -161,7 +161,7 @@ async fn handle_commands() -> CommandResult {
         "extension" => extensions::handle_extensions(Box::pin(api), sub_matches, app_helper).await,
         #[cfg(unix)]
         "sandbox" => sandbox::handle_sandbox(sub_matches).await,
-        "find-lockable-files" => find_lockable_files::handle_command(),
+        "find-dependency-files" => find_dependency_files::handle_command(),
         "generate-lockfile" => generate_lockfile::handle_command(sub_matches),
         extension_subcmd => {
             extensions::handle_run_extension(Box::pin(api), extension_subcmd, sub_matches).await

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -382,14 +382,16 @@ async fn get_package_details(
     })
 }
 
-/// Parse a lockfile and return the package descriptors contained therein.
+/// Parse a dependency file and return the package descriptors contained
+/// therein.
+///
 /// Equivalent to `phylum parse`.
 #[op2(async)]
 #[serde]
-async fn parse_lockfile(
+async fn parse_depfile(
     op_state: Rc<RefCell<OpState>>,
-    #[string] lockfile: String,
-    #[string] lockfile_type: Option<String>,
+    #[string] depfile: String,
+    #[string] depfile_type: Option<String>,
     generate_lockfiles: Option<bool>,
     sandbox_generation: Option<bool>,
 ) -> Result<PackageLock> {
@@ -397,20 +399,20 @@ async fn parse_lockfile(
     {
         let mut state = op_state.borrow_mut();
         let permissions = state.borrow_mut::<PermissionsContainer>();
-        permissions.check_read(Path::new(&lockfile), "phylum")?;
+        permissions.check_read(Path::new(&depfile), "phylum")?;
     }
 
     // Get .phylum_project path
     let current_project = phylum_project::get_current_project();
     let project_root = current_project.as_ref().map(|p| p.root());
 
-    // Attempt to parse as requested lockfile type.
+    // Attempt to parse as requested dependency file type.
     let sandbox = sandbox_generation.unwrap_or(true);
     let generate_lockfiles = generate_lockfiles.unwrap_or(true);
-    let parsed = parse::parse_lockfile(
-        lockfile,
+    let parsed = parse::parse_depfile(
+        depfile,
         project_root,
-        lockfile_type.as_deref(),
+        depfile_type.as_deref(),
         sandbox,
         generate_lockfiles,
     )?;
@@ -550,22 +552,22 @@ async fn api_base_url(op_state: Rc<RefCell<OpState>>) -> Result<String> {
 pub(crate) fn api_decls() -> Vec<OpDecl> {
     vec![
         analyze::DECL,
+        api_base_url::DECL,
         check_packages::DECL,
         check_packages_raw::DECL,
-        get_user_info::DECL,
-        get_access_token::DECL,
-        get_refresh_token::DECL,
-        get_job_status::DECL,
-        get_job_status_raw::DECL,
-        get_current_project::DECL,
-        get_groups::DECL,
-        get_projects::DECL,
         create_project::DECL,
         delete_project::DECL,
+        get_access_token::DECL,
+        get_current_project::DECL,
+        get_groups::DECL,
+        get_job_status::DECL,
+        get_job_status_raw::DECL,
         get_package_details::DECL,
-        parse_lockfile::DECL,
-        run_sandboxed::DECL,
+        get_projects::DECL,
+        get_refresh_token::DECL,
+        get_user_info::DECL,
         op_permissions::DECL,
-        api_base_url::DECL,
+        parse_depfile::DECL,
+        run_sandboxed::DECL,
     ]
 }

--- a/cli/src/commands/find_dependency_files.rs
+++ b/cli/src/commands/find_dependency_files.rs
@@ -1,8 +1,8 @@
-//! `phylum find-lockable-files` subcommand.
+//! `phylum find-dependency-files` subcommand.
 
 use crate::commands::{CommandResult, ExitCode};
 
-/// Handle `phylum find-lockable-files` subcommand.
+/// Handle `phylum find-dependency-files` subcommand.
 pub fn handle_command() -> CommandResult {
     let depfiles = phylum_lockfile::DepFiles::find_at(".");
     let json = serde_json::to_string(&depfiles)?;

--- a/cli/src/commands/find_lockable_files.rs
+++ b/cli/src/commands/find_lockable_files.rs
@@ -4,8 +4,8 @@ use crate::commands::{CommandResult, ExitCode};
 
 /// Handle `phylum find-lockable-files` subcommand.
 pub fn handle_command() -> CommandResult {
-    let lockables = phylum_lockfile::LockableFiles::find_at(".");
-    let json = serde_json::to_string(&lockables)?;
+    let depfiles = phylum_lockfile::DepFiles::find_at(".");
+    let json = serde_json::to_string(&depfiles)?;
     println!("{}", json);
     Ok(ExitCode::Ok)
 }

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -70,8 +70,8 @@ pub async fn handle_history(api: &PhylumApi, matches: &clap::ArgMatches) -> Comm
             Ok(resp) => resp,
             Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => {
                 print_user_warning!(
-                    "No results found. Submit a lockfile for processing:\n\n\t{}\n",
-                    style("phylum analyze <lock_file>").blue()
+                    "No results found. Submit a dependency file for processing:\n\n\t{}\n",
+                    style("phylum analyze [DEPENDENCY_FILE]").blue()
                 );
                 return Ok(ExitCode::NoHistoryFound);
             },
@@ -107,27 +107,27 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
         let current_project = phylum_project::get_current_project();
         let project_root = current_project.as_ref().map(|p| p.root());
 
-        for lockfile in jobs_project.lockfiles {
+        for depfile in jobs_project.depfiles {
             let parse_result = parse::parse_depfile(
-                &lockfile.path,
+                &depfile.path,
                 project_root,
-                Some(&lockfile.depfile_type),
+                Some(&depfile.depfile_type),
                 sandbox_generation,
                 generate_lockfiles,
             );
 
             // Map dedicated exit code for failure due to disabled generation.
-            let mut parsed_lockfile = match parse_result {
-                Ok(parsed_lockfile) => parsed_lockfile,
+            let parsed_depfile = match parse_result {
+                Ok(parsed_depfile) => parsed_depfile,
                 Err(err @ ParseError::ManifestWithoutGeneration(_)) => {
-                    print_user_failure!("Could not parse lockfile: {}", err);
+                    print_user_failure!("Could not parse manifest: {}", err);
                     return Ok(ExitCode::ManifestWithoutGeneration);
                 },
                 Err(ParseError::Other(err)) => {
                     return Err(err).with_context(|| {
                         format!(
-                            "Unable to locate any valid package in lockfile {:?}",
-                            lockfile.path
+                            "Unable to locate any valid package in dependency file {:?}",
+                            depfile.path
                         )
                     });
                 },
@@ -135,13 +135,13 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
 
             if pretty_print {
                 print_user_success!(
-                    "Successfully parsed lockfile {:?} as type: {}",
-                    parsed_lockfile.path,
-                    parsed_lockfile.format.name()
+                    "Successfully parsed dependency file {:?} as type {:?}",
+                    parsed_depfile.path,
+                    parsed_depfile.format.name()
                 );
             }
 
-            packages.append(&mut parsed_lockfile.packages);
+            packages.append(&mut parsed_depfile.api_packages());
         }
 
         if let Some(base) = matches.get_one::<String>("base") {
@@ -205,7 +205,7 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
 
     // Avoid request error without dependencies.
     if packages.is_empty() {
-        print_user_warning!("No packages found in lockfile");
+        print_user_warning!("No packages found in dependency file");
         return Ok(ExitCode::Ok);
     }
 
@@ -290,7 +290,7 @@ async fn vulnreach(
 struct JobsProject {
     project_id: ProjectId,
     group: Option<String>,
-    lockfiles: Vec<DepfileConfig>,
+    depfiles: Vec<DepfileConfig>,
 }
 
 impl JobsProject {
@@ -300,14 +300,14 @@ impl JobsProject {
     /// option.
     async fn new(api: &PhylumApi, matches: &clap::ArgMatches) -> Result<JobsProject> {
         let current_project = phylum_project::get_current_project();
-        let lockfiles = config::depfiles(matches, current_project.as_ref())?;
+        let depfiles = config::depfiles(matches, current_project.as_ref())?;
 
         match matches.get_one::<String>("project") {
             // Prefer `--project` and `--group` if they were specified.
             Some(project_name) => {
                 let group = matches.get_one::<String>("group").cloned();
                 let project = api.get_project_id(project_name, group.as_deref()).await?;
-                Ok(Self { project_id: project, group, lockfiles })
+                Ok(Self { project_id: project, group, depfiles })
             },
             // Retrieve the project from the `.phylum_project` file.
             None => {
@@ -322,7 +322,7 @@ impl JobsProject {
                 Ok(Self {
                     project_id: current_project.id,
                     group: current_project.group_name,
-                    lockfiles,
+                    depfiles,
                 })
             },
         }

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -4,7 +4,7 @@ use std::{fs, io};
 use anyhow::{anyhow, Context, Result};
 use console::style;
 use log::debug;
-use phylum_project::LockfileConfig;
+use phylum_project::DepfileConfig;
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::package::{PackageDescriptor, PackageType};
 use reqwest::StatusCode;
@@ -108,10 +108,10 @@ pub async fn handle_submission(api: &PhylumApi, matches: &clap::ArgMatches) -> C
         let project_root = current_project.as_ref().map(|p| p.root());
 
         for lockfile in jobs_project.lockfiles {
-            let parse_result = parse::parse_lockfile(
+            let parse_result = parse::parse_depfile(
                 &lockfile.path,
                 project_root,
-                Some(&lockfile.lockfile_type),
+                Some(&lockfile.depfile_type),
                 sandbox_generation,
                 generate_lockfiles,
             );
@@ -290,7 +290,7 @@ async fn vulnreach(
 struct JobsProject {
     project_id: ProjectId,
     group: Option<String>,
-    lockfiles: Vec<LockfileConfig>,
+    lockfiles: Vec<DepfileConfig>,
 }
 
 impl JobsProject {
@@ -300,7 +300,7 @@ impl JobsProject {
     /// option.
     async fn new(api: &PhylumApi, matches: &clap::ArgMatches) -> Result<JobsProject> {
         let current_project = phylum_project::get_current_project();
-        let lockfiles = config::lockfiles(matches, current_project.as_ref())?;
+        let lockfiles = config::depfiles(matches, current_project.as_ref())?;
 
         match matches.get_one::<String>("project") {
             // Prefer `--project` and `--group` if they were specified.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,7 +2,7 @@ use std::process;
 
 pub mod auth;
 pub mod extensions;
-pub mod find_lockable_files;
+pub mod find_dependency_files;
 pub mod generate_lockfile;
 pub mod group;
 pub mod init;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Local};
 use clap::ArgMatches;
-use phylum_project::LockfileConfig;
+use phylum_project::DepfileConfig;
 use phylum_types::types::common::ProjectId;
 use serde::Serialize;
 
@@ -21,7 +21,7 @@ pub async fn handle_status(matches: &ArgMatches) -> CommandResult {
 
 #[derive(Serialize, Default)]
 pub struct PhylumStatus {
-    pub lockfiles: Vec<LockfileConfig>,
+    pub dependency_files: Vec<DepfileConfig>,
     pub project: Option<String>,
     pub group: Option<String>,
     pub root: Option<PathBuf>,
@@ -36,8 +36,8 @@ impl PhylumStatus {
         let mut status = PhylumStatus::default();
         let project = phylum_project::get_current_project();
 
-        // Add lockfiles.
-        status.lockfiles = config::lockfiles(matches, project.as_ref()).unwrap_or_default();
+        // Add dependency files.
+        status.dependency_files = config::depfiles(matches, project.as_ref()).unwrap_or_default();
 
         // Populate project details.
         if let Some(project) = project {

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -80,10 +80,10 @@ impl Format for PhylumStatus {
             let _ = writeln!(writer, "{depfiles_label}: {}", style("null").italic().green());
         } else {
             let _ = writeln!(writer, "{depfiles_label}:");
-            for lockfile in &self.dependency_files {
-                let path = lockfile.path.display();
+            for depfile in &self.dependency_files {
+                let path = depfile.path.display();
                 let _ = writeln!(writer, " - {}: {}", style("path").blue(), path);
-                let _ = writeln!(writer, "   {}: {}", style("type").blue(), lockfile.depfile_type);
+                let _ = writeln!(writer, "   {}: {}", style("type").blue(), depfile.depfile_type);
             }
         }
     }

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -74,16 +74,16 @@ impl Format for PhylumStatus {
         write_option(writer, "Group", self.group.as_ref());
         write_option(writer, "Project Root", root);
 
-        // Write known lockfiles.
-        let lockfiles_label = style("Lockfiles").blue();
-        if self.lockfiles.is_empty() {
-            let _ = writeln!(writer, "{lockfiles_label}: {}", style("null").italic().green());
+        // Write known dependency files.
+        let depfiles_label = style("Dependency Files").blue();
+        if self.dependency_files.is_empty() {
+            let _ = writeln!(writer, "{depfiles_label}: {}", style("null").italic().green());
         } else {
-            let _ = writeln!(writer, "{lockfiles_label}:");
-            for lockfile in &self.lockfiles {
+            let _ = writeln!(writer, "{depfiles_label}:");
+            for lockfile in &self.dependency_files {
                 let path = lockfile.path.display();
                 let _ = writeln!(writer, " - {}: {}", style("path").blue(), path);
-                let _ = writeln!(writer, "   {}: {}", style("type").blue(), lockfile.lockfile_type);
+                let _ = writeln!(writer, "   {}: {}", style("type").blue(), lockfile.depfile_type);
             }
         }
     }

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -130,7 +130,7 @@ pub async fn parse_lockfile() {
         Permissions { read: Permission::List(vec![lockfile_str]), ..Permissions::default() };
 
     let parse_lockfile = format!(
-        "const lockfile = await PhylumApi.parseLockfile({lockfile:?}, 'yarn');
+        "const lockfile = await PhylumApi.parseDependencyFile({lockfile:?}, 'yarn');
          console.log(JSON.stringify(lockfile));",
     );
     test_cli

--- a/cli/tests/end_to_end/extension.rs
+++ b/cli/tests/end_to_end/extension.rs
@@ -140,8 +140,8 @@ pub async fn parse_lockfile() {
         .run()
         .success()
         .stdout(predicates::str::contains(
-            "{\"packages\":[{\"name\":\"accepts\",\"version\":\"1.3.8\",\"type\":\"npm\",\"\
-             lockfile\":\"",
+            "{\"packages\":[{\"name\":\"accepts\",\"version\":\"1.3.8\",\"type\":\"npm\"}],\"\
+             format\":\"yarn\",\"path\":\"",
         ));
 }
 

--- a/cli/tests/fixtures/extensions/api/main.ts
+++ b/cli/tests/fixtures/extensions/api/main.ts
@@ -1,4 +1,4 @@
 import { PhylumApi } from "phylum";
 
-const lockfile = await PhylumApi.parseLockfile("../tests/fixtures/poetry.lock", "poetry");
+const lockfile = await PhylumApi.parseDependencyFile("../tests/fixtures/poetry.lock", "poetry");
 console.log(lockfile.packages.length);

--- a/deno.json
+++ b/deno.json
@@ -1,15 +1,11 @@
 {
   "importMap": "import_map.json",
   "lint": {
-    "files": {
-      "include": ["extensions/"]
-    }
+    "include": ["extensions/"]
   },
   "fmt": {
-    "files": {
-      "include": ["extensions/"],
-      "exclude": ["extensions/CHANGELOG.md"]
-    }
+    "include": ["extensions/"],
+    "exclude": ["extensions/CHANGELOG.md"]
   },
   "lock": false
 }

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -6,7 +6,7 @@
 
 The following order is used to determine which lockfile will be analyzed:
 
-- CLI `--lockfile` parameters
+- CLI `DEPENDENCY_FILE` argument
 - Lockfiles in the `.phylum_project` file specified during `phylum init`
 - Recursive filesystem search
 

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -4,15 +4,15 @@
 
 ### Details
 
-The following order is used to determine which lockfile will be analyzed:
+The following order is used to determine which dependency file will be analyzed:
 
 - CLI `DEPENDENCY_FILE` argument
-- Lockfiles in the `.phylum_project` file specified during `phylum init`
+- Dependency files in the `.phylum_project` file specified during `phylum init`
 - Recursive filesystem search
 
-If any of these locations provides a lockfile, no further search will be done.
-Recursive filesystem search takes common ignore files like `.gitignore` and
-`.ignore` into account.
+If any of these locations provides a dependency file, no further search will be
+done. Recursive filesystem search takes common ignore files like `.gitignore`
+and `.ignore` into account.
 
 ### Examples
 

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -17,13 +17,13 @@ Recursive filesystem search takes common ignore files like `.gitignore` and
 ### Examples
 
 ```sh
-# Analyze your project's default lockfile
+# Analyze your project's default dependency files
 $ phylum analyze
 
 # Analyze a Maven lockfile with a verbose json response
 $ phylum analyze --json --verbose effective-pom.xml
 
-# Analyze a PyPI lockfile and apply a label
+# Analyze a PyPI dependency file and apply a label
 $ phylum analyze --label test_branch requirements.txt
 
 # Analyze a Poetry lockfile and return the results to the 'sample' project
@@ -35,6 +35,6 @@ $ phylum analyze -p sample -g sGroup packages.lock.json
 # Analyze a RubyGems lockfile and return a verbose response with only critical malware
 $ phylum analyze --verbose --filter=crit,mal Gemfile.lock
 
-# Analyze the `Cargo.lock` and `lockfile` files as cargo lockfiles
-$ phylum analyze --lockfile-type cargo Cargo.lock lockfile
+# Analyze the `Cargo.lock` and `lockfile` files as cargo dependency files
+$ phylum analyze --type cargo Cargo.lock lockfile
 ```

--- a/doc_templates/phylum_init.md
+++ b/doc_templates/phylum_init.md
@@ -9,5 +9,5 @@
 $ phylum init
 
 # Create the `demo` project with a yarn lockfile and no associated group.
-$ phylum init --lockfile yarn.lock --lockfile-type yarn demo
+$ phylum init --dependency-file yarn.lock --type yarn demo
 ```

--- a/doc_templates/phylum_package.md
+++ b/doc_templates/phylum_package.md
@@ -9,16 +9,6 @@ automatically be submitted for [processing].
 
 [processing]: https://docs.phylum.io/docs/processing
 
-The following order is used to determine which lockfile will be parsed:
-
-- CLI `--lockfile` parameters
-- Lockfiles in the `.phylum_project` file specified during `phylum init`
-- Recursive filesystem search
-
-If any of these locations provides a lockfile, no further search will be done.
-Recursive filesystem search takes common ignore files like `.gitignore` and
-`.ignore` into account.
-
 ### Examples
 
 ```sh

--- a/doc_templates/phylum_parse.md
+++ b/doc_templates/phylum_parse.md
@@ -2,6 +2,18 @@
 
 {PH-MARKDOWN}
 
+### Details
+
+The following order is used to determine which lockfile will be parsed:
+
+- CLI `DEPENDENCY_FILE` argument
+- Lockfiles in the `.phylum_project` file specified during `phylum init`
+- Recursive filesystem search
+
+If any of these locations provides a lockfile, no further search will be done.
+Recursive filesystem search takes common ignore files like `.gitignore` and
+`.ignore` into account.
+
 ### Examples
 
 ```sh

--- a/doc_templates/phylum_parse.md
+++ b/doc_templates/phylum_parse.md
@@ -4,15 +4,15 @@
 
 ### Details
 
-The following order is used to determine which lockfile will be parsed:
+The following order is used to determine which dependency file will be parsed:
 
 - CLI `DEPENDENCY_FILE` argument
-- Lockfiles in the `.phylum_project` file specified during `phylum init`
+- Dependency files in the `.phylum_project` file specified during `phylum init`
 - Recursive filesystem search
 
-If any of these locations provides a lockfile, no further search will be done.
-Recursive filesystem search takes common ignore files like `.gitignore` and
-`.ignore` into account.
+If any of these locations provides a dependency file, no further search will be
+done. Recursive filesystem search takes common ignore files like `.gitignore`
+and `.ignore` into account.
 
 ### Examples
 

--- a/doc_templates/phylum_parse.md
+++ b/doc_templates/phylum_parse.md
@@ -5,9 +5,9 @@
 ### Examples
 
 ```sh
-# Parse a lockfile
+# Parse a dependency file
 $ phylum parse package-lock.json
 
-# Parse the `Cargo.lock` and `lockfile` files as cargo lockfiles
-$ phylum parse --lockfile-type cargo Cargo.lock lockfile
+# Parse the `Cargo.lock` and `lockfile` files as cargo dependency files
+$ phylum parse --type cargo Cargo.lock lockfile
 ```

--- a/docs/analyzing_dependencies.md
+++ b/docs/analyzing_dependencies.md
@@ -14,8 +14,8 @@ The default response will provide an overall summary result to indicate whether 
 
 ```shellsession
 ❯ phylum analyze
-✅ Successfully parsed lockfile "requirements.txt" as type: pip
-✅ Successfully parsed lockfile "package-lock.json" as type: npm
+✅ Successfully parsed dependency file "requirements.txt" as type "pip"
+✅ Successfully parsed dependency file "package-lock.json" as type "npm"
 ✅ Job ID: 3accba15-b0dc-43d2-b8ce-f5700360e3bd
 
 Phylum Supply Chain Risk Analysis — FAILURE

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -7,13 +7,13 @@ hidden: false
 Submit a request for analysis to the processing system
 
 ```sh
-Usage: phylum analyze [OPTIONS] [LOCKFILE]...
+Usage: phylum analyze [OPTIONS] [DEPENDENCY_FILE]...
 ```
 
 ### Arguments
 
-`[LOCKFILE]`
-&emsp; The package lockfiles to submit
+`[DEPENDENCY_FILE]`
+&emsp; Path to the dependency file to submit
 
 ### Options
 
@@ -29,8 +29,8 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Specify a group to use for analysis
 
-`-t`, `--lockfile-type` `<TYPE>`
-&emsp; Lockfile type used for all lockfiles (default: auto)
+`-t`, `--type` `<TYPE>`
+&emsp; Dependency file type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `--skip-sandbox`
@@ -50,26 +50,26 @@ Usage: phylum analyze [OPTIONS] [LOCKFILE]...
 
 ### Details
 
-The following order is used to determine which lockfile will be analyzed:
+The following order is used to determine which dependency file will be analyzed:
 
-- CLI `--lockfile` parameters
-- Lockfiles in the `.phylum_project` file specified during `phylum init`
+- CLI `DEPENDENCY_FILE` argument
+- Dependency files in the `.phylum_project` file specified during `phylum init`
 - Recursive filesystem search
 
-If any of these locations provides a lockfile, no further search will be done.
-Recursive filesystem search takes common ignore files like `.gitignore` and
-`.ignore` into account.
+If any of these locations provides a dependency file, no further search will be
+done. Recursive filesystem search takes common ignore files like `.gitignore`
+and `.ignore` into account.
 
 ### Examples
 
 ```sh
-# Analyze your project's default lockfile
+# Analyze your project's default dependency files
 $ phylum analyze
 
 # Analyze a Maven lockfile with a verbose json response
 $ phylum analyze --json --verbose effective-pom.xml
 
-# Analyze a PyPI lockfile and apply a label
+# Analyze a PyPI dependency file and apply a label
 $ phylum analyze --label test_branch requirements.txt
 
 # Analyze a Poetry lockfile and return the results to the 'sample' project
@@ -81,6 +81,6 @@ $ phylum analyze -p sample -g sGroup packages.lock.json
 # Analyze a RubyGems lockfile and return a verbose response with only critical malware
 $ phylum analyze --verbose --filter=crit,mal Gemfile.lock
 
-# Analyze the `Cargo.lock` and `lockfile` files as cargo lockfiles
-$ phylum analyze --lockfile-type cargo Cargo.lock lockfile
+# Analyze the `Cargo.lock` and `lockfile` files as cargo dependency files
+$ phylum analyze --type cargo Cargo.lock lockfile
 ```

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -20,11 +20,11 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group which will be the owner of the project
 
-`-l`, `--lockfile` `<LOCKFILE>`
-&emsp; Project-relative lockfile path
+`-d`, `--dependency-file` `<DEPENDENCY_FILE>`
+&emsp; Project-relative dependency file path
 
-`-t`, `--lockfile-type` `<TYPE>`
-&emsp; Lockfile type used for all lockfiles (default: auto)
+`-t`, `--type` `<TYPE>`
+&emsp; Dependency file type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `-f`, `--force`
@@ -49,5 +49,5 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 $ phylum init
 
 # Create the `demo` project with a yarn lockfile and no associated group.
-$ phylum init --lockfile yarn.lock --lockfile-type yarn demo
+$ phylum init --dependency-file yarn.lock --type yarn demo
 ```

--- a/docs/commands/phylum_package.md
+++ b/docs/commands/phylum_package.md
@@ -54,16 +54,6 @@ automatically be submitted for [processing].
 
 [processing]: https://docs.phylum.io/docs/processing
 
-The following order is used to determine which lockfile will be parsed:
-
-- CLI `--lockfile` parameters
-- Lockfiles in the `.phylum_project` file specified during `phylum init`
-- Recursive filesystem search
-
-If any of these locations provides a lockfile, no further search will be done.
-Recursive filesystem search takes common ignore files like `.gitignore` and
-`.ignore` into account.
-
 ### Examples
 
 ```sh

--- a/docs/commands/phylum_parse.md
+++ b/docs/commands/phylum_parse.md
@@ -4,21 +4,21 @@ category: 6255e67693d5200013b1fa3e
 hidden: false
 ---
 
-Parse lockfiles and output their packages as JSON
+Parse dependency files and output their packages as JSON
 
 ```sh
-Usage: phylum parse [OPTIONS] [LOCKFILE]...
+Usage: phylum parse [OPTIONS] [DEPENDENCY_FILE]...
 ```
 
 ### Arguments
 
-`[LOCKFILE]`
-&emsp; The package lockfiles to submit
+`[DEPENDENCY_FILE]`
+&emsp; Path to the dependency file to parse
 
 ### Options
 
-`-t`, `--lockfile-type` `<TYPE>`
-&emsp; Lockfile type used for all lockfiles (default: auto)
+`-t`, `--type` `<TYPE>`
+&emsp; Dependency file type used for all lockfiles (default: auto)
 &emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `nugetlock`, `msbuild`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `--skip-sandbox`
@@ -36,12 +36,24 @@ Usage: phylum parse [OPTIONS] [LOCKFILE]...
 `-h`, `--help`
 &emsp; Print help
 
+### Details
+
+The following order is used to determine which dependency file will be parsed:
+
+- CLI `DEPENDENCY_FILE` argument
+- Dependency files in the `.phylum_project` file specified during `phylum init`
+- Recursive filesystem search
+
+If any of these locations provides a dependency file, no further search will be
+done. Recursive filesystem search takes common ignore files like `.gitignore`
+and `.ignore` into account.
+
 ### Examples
 
 ```sh
-# Parse a lockfile
+# Parse a dependency file
 $ phylum parse package-lock.json
 
-# Parse the `Cargo.lock` and `lockfile` files as cargo lockfiles
-$ phylum parse --lockfile-type cargo Cargo.lock lockfile
+# Parse the `Cargo.lock` and `lockfile` files as cargo dependency files
+$ phylum parse --type cargo Cargo.lock lockfile
 ```

--- a/docs/lockfile_generation.md
+++ b/docs/lockfile_generation.md
@@ -43,7 +43,7 @@ The Phylum CLI can generate a lockfile when it is given a manifest file.
 > * `package.json` will use `npm`
 > * `pyproject.toml` will use `pip`
 >
-> This can be overridden on the command line with the `--lockfile-type` (`-t`) option. For example:
+> This can be overridden on the command line with the `--type` (`-t`) option. For example:
 >
 > ```sh
 > phylum analyze -t yarn package.json
@@ -83,7 +83,7 @@ specified, this will fail, and Phylum will silence the error and proceed to lock
    (i.e., `package-lock.json`, `npm-shrinkwrap.json`, or `yarn.lock`)
 3. If a matching lockfile is found, that file will be used instead
 4. If no matching lockfile is found, proceed to manifest file generation
-5. Since no `--lockfile-type` was specified, the fallback will be used (in this case, `npm`)
+5. Since no `--type` was specified, the fallback will be used (in this case, `npm`)
 6. The lockfile generator runs this command to generate a lockfile:
 
    ```sh

--- a/docs/supported_lockfiles.md
+++ b/docs/supported_lockfiles.md
@@ -30,7 +30,7 @@ The Phylum CLI supports processing many different lockfiles:
 >
 > The lockfile type will be automatically detected based on the filename.
 >
-> If needed, this can be overridden with the `--lockfile-type` (`-t`) option.
+> If needed, this can be overridden with the `--type` (`-t`) option.
 
 ---
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Renamed `parseLockfile` to `PhylumApi::parseDependencyFile`
+- Removed `lockfile` field from `PhylumApi::Package` type
+- Removed `PhylumApi::Lockfile` type in favor of `PhylumApi::DependencyFile`
+- Changed `PhylumApi::analyze` packages type to `PhylumApi::PackageWithOrigin`
+
 ## 5.9.0 - 2023-12-05
 
 ### Added
@@ -15,13 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `generateLockfiles` parameter for `parseLockfile` to inhibit lockfile generation
 - `sandboxGeneration` parameter for `parseLockfile` to disable the lockfile
     generation sandbox
-
-### Changed
-
-- Renamed `parseLockfile` to `PhylumApi::parseDependencyFile`
-- Removed `lockfile` field from `PhylumApi::Package` type
-- Removed `PhylumApi::Lockfile` type in favor of `PhylumApi::DependencyFile`
-- Changed `PhylumApi::analyze` packages type to `PhylumApi::PackageWithOrigin`
 
 ### Fixed
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -16,6 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `sandboxGeneration` parameter for `parseLockfile` to disable the lockfile
     generation sandbox
 
+### Changed
+
+- Renamed `parseLockfile` to `PhylumApi::parseDependencyFile`
+- Removed `lockfile` field from `PhylumApi::Package` type
+- Removed `PhylumApi::Lockfile` type in favor of `PhylumApi::DependencyFile`
+- Changed `PhylumApi::analyze` packages type `PhylumApi::PackageWithOrigin`
+
 ### Fixed
 
 - Exceptions for symlinks in `runSandboxed` on Linux

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Renamed `parseLockfile` to `PhylumApi::parseDependencyFile`
 - Removed `lockfile` field from `PhylumApi::Package` type
 - Removed `PhylumApi::Lockfile` type in favor of `PhylumApi::DependencyFile`
-- Changed `PhylumApi::analyze` packages type `PhylumApi::PackageWithOrigin`
+- Changed `PhylumApi::analyze` packages type to `PhylumApi::PackageWithOrigin`
 
 ### Fixed
 

--- a/extensions/bundle/main.ts
+++ b/extensions/bundle/main.ts
@@ -163,7 +163,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
 
   let lockfile;
   try {
-    lockfile = await PhylumApi.parseLockfile("./Gemfile.lock", "gem");
+    lockfile = await PhylumApi.parseDependencyFile("./Gemfile.lock", "gem");
   } catch (_e) {
     console.warn(`[${yellow("phylum")}] No lockfile present.\n`);
     await abort(125);

--- a/extensions/cargo/main.ts
+++ b/extensions/cargo/main.ts
@@ -176,7 +176,7 @@ async function checkDryRun() {
   console.log(`[${green("phylum")}] Parsing lockfile…`);
   let lockfile;
   try {
-    lockfile = await PhylumApi.parseLockfile("./Cargo.lock", "cargo");
+    lockfile = await PhylumApi.parseDependencyFile("./Cargo.lock", "cargo");
   } catch (e) {
     console.error(`[${red("phylum")}] Lockfile parsing failed: ${e}.\n`);
     await abort(125);

--- a/extensions/duplicates/main.ts
+++ b/extensions/duplicates/main.ts
@@ -11,7 +11,7 @@ if (Deno.args.length != 1) {
 }
 
 // Parse lockfile using Phylum's API.
-const lockfile = await PhylumApi.parseLockfile(Deno.args[0]);
+const lockfile = await PhylumApi.parseDependencyFile(Deno.args[0]);
 
 // Group all versions for the same dependency together.
 const groupedDeps = groupBy(lockfile.packages, (dep) => dep.name);

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -235,7 +235,7 @@ async function checkDryRun(subcommand: string, args: string[]) {
 
   let lockfile;
   try {
-    lockfile = await PhylumApi.parseLockfile(lockfilePath, "npm");
+    lockfile = await PhylumApi.parseDependencyFile(lockfilePath, "npm");
   } catch (_e) {
     console.warn(`[${yellow("phylum")}] No lockfile created.\n`);
     return;

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -8,7 +8,7 @@ export type Package = {
   lockfile?: string;
 };
 
-export type Lockfile = {
+export type DependencyFile = {
   packages: Package[];
   format: string;
 };
@@ -105,7 +105,7 @@ export class PhylumApi {
   }
 
   /**
-   * Analyze dependencies in a lockfile.
+   * Run Phylum analysis on a list of packages.
    *
    * Packages are expected in the following format:
    *
@@ -422,11 +422,11 @@ export class PhylumApi {
   }
 
   /**
-   * Get dependencies inside a lockfile.
+   * Get packages inside a dependency file.
    *
-   * @returns Lockfile dependencies
+   * @returns Dependency file packages
    *
-   * Lockfile dependencies example:
+   * Dependency file packages example:
    * ```
    * {
    *   format: "npm",
@@ -439,16 +439,16 @@ export class PhylumApi {
    * }
    * ```
    */
-  static parseLockfile(
-    lockfile: string,
-    lockfileType?: string,
+  static parseDependencyFile(
+    depfile: string,
+    depfileType?: string,
     generateLockfiles?: boolean,
     sandboxGeneration?: boolean,
-  ): Promise<Lockfile> {
+  ): Promise<DependencyFile> {
     return DenoCore.opAsync(
-      "parse_lockfile",
-      lockfile,
-      lockfileType,
+      "parse_depfile",
+      depfile,
+      depfileType,
       generateLockfiles,
       sandboxGeneration,
     );

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -1,16 +1,23 @@
 // @ts-ignore Deno[Deno.internal].core is not defined in types
 const DenoCore = Deno[Deno.internal].core;
 
+export type PackageWithOrigin = {
+  name: string;
+  version: string;
+  type: string;
+  origin: string;
+};
+
 export type Package = {
   name: string;
   version: string;
   type: string;
-  lockfile?: string;
 };
 
 export type DependencyFile = {
   packages: Package[];
   format: string;
+  path: string;
 };
 
 export type ProcessOutput = {
@@ -111,7 +118,7 @@ export class PhylumApi {
    *
    * ```
    * [
-   *   { name: "accepts", version: "1.3.8", type: "npm", lockfile: "/path/to/lockfile" },
+   *   { name: "accepts", version: "1.3.8", type: "npm", origin: "/path/to/lockfile" },
    *   { name: "ms", version: "2.0.0", type: "npm" },
    *   { name: "negotiator", version: "0.6.3", type: "npm" },
    *   { name: "ms", version: "2.1.3", type: "npm" }
@@ -119,7 +126,7 @@ export class PhylumApi {
    * ```
    *
    * Accepted package types are "npm", "pypi", "maven", "rubygems", "nuget", "cargo", and "golang"
-   * The `lockfile` is an optional string used to represent the path to the lockfile.
+   * The `origin` is an optional string used to represent the source of the dependency.
    *
    * @param packages - List of packages to analyze
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
@@ -129,7 +136,7 @@ export class PhylumApi {
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
-    packages: Package[],
+    packages: PackageWithOrigin[],
     project?: string,
     group?: string,
     label?: string,
@@ -430,11 +437,12 @@ export class PhylumApi {
    * ```
    * {
    *   format: "npm",
+   *   path: "package-lock.json",
    *   packages: [
-   *     { lockfile: "package-lock.json", name: "accepts", version: "1.3.8", type: "npm" },
-   *     { lockfile: "package-lock.json", name: "ms", version: "2.0.0", type: "npm" },
-   *     { lockfile: "package-lock.json", name: "negotiator", version: "0.6.3", type: "npm" },
-   *     { lockfile: "package-lock.json", name: "ms", version: "2.1.3", type: "npm" }
+   *     { name: "accepts", version: "1.3.8", type: "npm" },
+   *     { name: "ms", version: "2.0.0", type: "npm" },
+   *     { name: "negotiator", version: "0.6.3", type: "npm" },
+   *     { name: "ms", version: "2.1.3", type: "npm" }
    *   ]
    * }
    * ```

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -196,7 +196,7 @@ async function checkDryRun() {
     await abort(status.code ?? 255);
   }
 
-  const lockfile = await PhylumApi.parseLockfile("./yarn.lock", "yarn");
+  const lockfile = await PhylumApi.parseDependencyFile("./yarn.lock", "yarn");
 
   // Ensure `checkDryRun` never modifies package manager files,
   // regardless of success.


### PR DESCRIPTION
This patch makes sweeping breaking changes to change the internal and
public terminology to refer to a manifest or lockfile as "dependency
file".

This change should also clarify some CLI interfaces where the previous
terminology was asking for a lockfile, but a manifest file was accepted
without clearly stating it.

Closes https://github.com/phylum-dev/cli/issues/1271.

---

Currently there's two major unsolved things I'm aware of:
 - Types in `phylum_types` are not changed, this might be a good opportunity to get rid of it where possible since deprecation is planned?
 - `LockfileFormat` enum is unchanged, this makes some sense to me since the format is still about one specific lockfile type, but I did change the public CLI interface and some internal code to refer to it as "dependency file type"