### PR TITLE
Restore lockfile in phylum parse output

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -82,7 +82,7 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
         );
 
         // Map dedicated exit code for failure due to disabled generation.
-        let mut parsed_lockfile = match parse_result {
+        let parsed_lockfile = match parse_result {
             Ok(parsed_lockfile) => parsed_lockfile,
             Err(err @ ParseError::ManifestWithoutGeneration(_)) => {
                 print_user_failure!("Could not parse manifest: {}", err);
@@ -95,7 +95,7 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
             },
         };
 
-        pkgs.append(&mut parsed_lockfile.packages);
+        pkgs.append(&mut parsed_lockfile.api_packages());
     }
 
     serde_json::to_writer_pretty(&mut io::stdout(), &pkgs)?;


### PR DESCRIPTION
Fix #1316 

### Note

This patch causes `phylum parse` to use the same format that is currently used by API. This means using the `lockfile` key just like CLI v5.9.0 rather than a more broad `origin` key.

```
> phylum parse ./requirements.txt
Generating lockfile for manifest "requirements.txt" using Pip…
[
  {
    "name": "PyYAML",
    "version": "6.0.1",
    "type": "pypi",
    "lockfile": "requirements.txt"
  }
]                                                                                                                                                                                                                                                                                                                               
```