### PR TITLE
Fix parse output regression

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -95,7 +95,7 @@ pub fn handle_parse(matches: &clap::ArgMatches) -> CommandResult {
             },
         };
 
-        pkgs.append(&mut parsed_lockfile.packages);
+        pkgs.append(&mut parsed_lockfile.api_packages());
     }
 
     serde_json::to_writer_pretty(&mut io::stdout(), &pkgs)?;


### PR DESCRIPTION
This fixes an issue with the output of `phylum parse` no longer containing the path each dependency originated from.