### PR TITLE
Allow /opt/gradle for Lockfile generation

### DIFF
--- a/cli/src/commands/generate_lockfile.rs
+++ b/cli/src/commands/generate_lockfile.rs
@@ -128,6 +128,7 @@ fn lockfile_generation_sandbox(canonical_manifest_path: &Path) -> Result<Birdcag
     )?;
     // Gradle.
     permissions::add_exception(&mut birdcage, Exception::WriteAndRead(home.join(".gradle")))?;
+    permissions::add_exception(&mut birdcage, Exception::Read("/opt/gradle".into()))?;
     permissions::add_exception(
         &mut birdcage,
         Exception::Read("/usr/share/java/gradle/lib".into()),


### PR DESCRIPTION
Gradle [install instructions][1] list extracting to `/opt/gradle` as one method of installing the tool. This patch should make those installs function correctly.

[1]: https://gradle.org/install/