### PR TITLE
Bump to v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.0.1 - 2023-12-19
+
+### Fixed
+
+- Lockfile generation for gradle installed under `/opt/gradle`
+
 ## 6.0.0 - 2023-12-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
Release the fix for `/opt/gradle` installations

Release-Version: v6.0.1