### PR TITLE
ci: add documentation update trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,3 +257,22 @@ jobs:
               client_payload: {CLI_version: process.env.GITHUB_REF_NAME},
             });
             console.log(response);
+
+      - name: Trigger documentation update
+        # Don't trigger for pre-releases
+        if: ${{ !contains(github.ref, 'rc') }}
+        # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
+          script: |
+            const response = await github.rest.repos.createDispatchEvent({
+              owner: "phylum-dev",
+              repo: "documentation",
+              event_type: "trigger-update-submodule",
+              client_payload: {
+                repo_name: context.repo.repo,
+                tag_name: process.env.GITHUB_REF_NAME
+              },
+            });
+            console.log(response);


### PR DESCRIPTION
This change goes with the one in https://github.com/phylum-dev/documentation/pull/80 and should not be merged until after that PR, in case there are changes there that need to be reflected here.
