### PR TITLE
Accept PURLs for package submission

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -6,10 +6,8 @@ use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::group::{
     CreateGroupRequest, CreateGroupResponse, ListGroupMembersResponse, ListUserGroupsResponse,
 };
-use phylum_types::types::job::{
-    AllJobsStatusResponse, SubmitPackageRequest, SubmitPackageResponse,
-};
-use phylum_types::types::package::{PackageDescriptor, PackageDescriptorAndLockfile};
+use phylum_types::types::job::{AllJobsStatusResponse, SubmitPackageResponse};
+use phylum_types::types::package::PackageDescriptor;
 use phylum_types::types::project::{
     CreateProjectRequest, CreateProjectResponse, ProjectSummaryResponse, UpdateProjectRequest,
 };
@@ -31,8 +29,9 @@ use crate::auth::{
 };
 use crate::config::{AuthInfo, Config};
 use crate::types::{
-    HistoryJob, PackageSpecifier, PackageSubmitResponse, PingResponse, PolicyEvaluationRequest,
-    PolicyEvaluationResponse, PolicyEvaluationResponseRaw, RevokeTokenRequest, UserToken,
+    AnalysisPackageDescriptor, HistoryJob, PackageSpecifier, PackageSubmitResponse, PingResponse,
+    PolicyEvaluationRequest, PolicyEvaluationResponse, PolicyEvaluationResponseRaw,
+    RevokeTokenRequest, SubmitPackageRequest, UserToken,
 };
 
 pub mod endpoints;
@@ -310,12 +309,11 @@ impl PhylumApi {
     /// Submit a new request to the system
     pub async fn submit_request(
         &self,
-        package_list: &[PackageDescriptorAndLockfile],
+        package_list: &[AnalysisPackageDescriptor],
         project: ProjectId,
         label: Option<String>,
         group_name: Option<String>,
     ) -> Result<JobId> {
-        #[allow(deprecated)]
         let req = SubmitPackageRequest {
             packages: package_list.to_vec(),
             is_user: true,
@@ -507,7 +505,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
-    use phylum_types::types::package::PackageType;
+    use phylum_types::types::package::{PackageDescriptorAndLockfile, PackageType};
     use wiremock::http::HeaderName;
     use wiremock::matchers::{method, path, path_regex, query_param};
     use wiremock::{Mock, ResponseTemplate};
@@ -575,10 +573,10 @@ mod tests {
             package_type: PackageType::Npm,
         };
 
-        let pkg = PackageDescriptorAndLockfile {
+        let pkg = AnalysisPackageDescriptor::PackageDescriptor(PackageDescriptorAndLockfile {
             package_descriptor,
             lockfile: Some("package-lock.json".to_owned()),
-        };
+        });
 
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());
@@ -611,10 +609,10 @@ mod tests {
             package_type: PackageType::Npm,
         };
 
-        let pkg = PackageDescriptorAndLockfile {
+        let pkg = AnalysisPackageDescriptor::PackageDescriptor(PackageDescriptorAndLockfile {
             package_descriptor,
             lockfile: Some("package-lock.json".to_owned()),
-        };
+        });
 
         let project_id = ProjectId::new_v4();
         let label = Some("mylabel".to_string());

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -14,6 +14,7 @@ use phylum_lockfile::{LockfileFormat, ParseError, ParsedLockfile};
 
 use crate::commands::extensions::permissions;
 use crate::commands::{CommandResult, ExitCode};
+use crate::types::AnalysisPackageDescriptor;
 use crate::{config, dirs, print_user_failure, print_user_warning};
 
 pub fn lockfile_types(add_auto: bool) -> Vec<&'static str> {
@@ -59,7 +60,9 @@ pub fn handle_parse(matches: &ArgMatches) -> CommandResult {
             },
         };
 
-        pkgs.append(&mut parsed_lockfile.api_packages());
+        let mut analysis_packages =
+            AnalysisPackageDescriptor::descriptors_from_lockfile(parsed_lockfile);
+        pkgs.append(&mut analysis_packages);
     }
 
     serde_json::to_writer_pretty(&mut io::stdout(), &pkgs)?;

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Accept PURLs in `PhylumApi::analyze`
+
 ## 6.0.0 - 2023-12-13
 
 ### Changed

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -5,7 +5,12 @@ export type PackageWithOrigin = {
   name: string;
   version: string;
   type: string;
-  origin: string;
+  origin?: string;
+};
+
+export type PurlWithOrigin = {
+  purl: string;
+  origin?: string;
 };
 
 export type Package = {

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -141,7 +141,7 @@ export class PhylumApi {
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
-    packages: PackageWithOrigin[],
+    packages: (PackageWithOrigin|PurlWithOrigin)[],
     project?: string,
     group?: string,
     label?: string,

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -141,7 +141,7 @@ export class PhylumApi {
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */
   static analyze(
-    packages: (PackageWithOrigin|PurlWithOrigin)[],
+    packages: (PackageWithOrigin | PurlWithOrigin)[],
     project?: string,
     group?: string,
     label?: string,

--- a/lockfile/src/parse_depfile.rs
+++ b/lockfile/src/parse_depfile.rs
@@ -2,7 +2,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
-use phylum_types::types::package::{PackageDescriptor, PackageDescriptorAndLockfile};
+use phylum_types::types::package::PackageDescriptor;
 use serde::{Deserialize, Serialize};
 
 use crate::{LockfileFormat, Package, PackageVersion, Parse, ThirdPartyVersion};
@@ -32,17 +32,6 @@ impl ParsedLockfile {
         packages: Vec<PackageDescriptor>,
     ) -> Self {
         Self { path: path.into(), packages, format }
-    }
-
-    /// Convert packages to API's expected format.
-    pub fn api_packages(&self) -> Vec<PackageDescriptorAndLockfile> {
-        self.packages
-            .iter()
-            .map(|package_descriptor| PackageDescriptorAndLockfile {
-                package_descriptor: package_descriptor.clone(),
-                lockfile: Some(self.path.clone()),
-            })
-            .collect()
     }
 }
 


### PR DESCRIPTION
This patch changes the `api::submit_request` function to accept PURLs with optional dependency file in addition to the existing package descriptors.

Closes #1336.
