### PR TITLE
Fix sandbox exceptions for local pip installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Python lockfile generation with pip in ~/.local
+- Python lockfile generation with pyenv
+
 ## 6.1.0 - 2024-01-29
 
 ### Added

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -437,6 +437,13 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
     permissions::add_exception(&mut birdcage, Exception::Read("/tmp".into()))?;
     // Yarn.
     permissions::add_exception(&mut birdcage, Exception::Read(home.join("./yarn")))?;
+    // Python.
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::ExecuteAndRead("/usr/share/pyenv".into()),
+    )?;
+    permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead(home.join(".pyenv")))?;
+    permissions::add_exception(&mut birdcage, Exception::Read(home.join(".local/lib")))?;
 
     Ok(birdcage)
 }

--- a/extensions/pip/PhylumExt.toml
+++ b/extensions/pip/PhylumExt.toml
@@ -3,8 +3,8 @@ description = "pip package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"]
+run = ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv", "/usr/share/pyenv"]
 write = ["./", "~/Library/Caches", "~/Library/Python", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
-read = ["~/Library/Caches", "~/Library/Python", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd"]
+read = ["~/Library/Caches", "~/Library/Python", "~/.cache", "~/.local", "/tmp", "/etc/passwd"]
 net = true
 unsandboxed_run = ["pip3"]

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -39,7 +39,7 @@ const installStatus = PhylumApi.runSandboxed({
   cmd: "pip3",
   args: Deno.args,
   exceptions: {
-    run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
+    run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
     write: [
       "./",
       "~/Library/Caches",
@@ -54,7 +54,6 @@ const installStatus = PhylumApi.runSandboxed({
       "~/Library/Python",
       "~/.cache",
       "~/.local",
-      "~/.pyenv",
       "/tmp",
       "/etc/passwd",
     ],
@@ -71,7 +70,7 @@ async function checkDryRun() {
     cmd: "pip3",
     args: [...Deno.args, "--quiet", "--report", "-", "--dry-run"],
     exceptions: {
-      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
+      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
       write: [
         "./",
         "~/Library/Caches",
@@ -183,7 +182,7 @@ function checkPipVersion() {
     cmd: "pip3",
     args: ["--version"],
     exceptions: {
-      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
+      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
     },
     stdout: "piped",
   });

--- a/extensions/pip/main.ts
+++ b/extensions/pip/main.ts
@@ -39,7 +39,14 @@ const installStatus = PhylumApi.runSandboxed({
   cmd: "pip3",
   args: Deno.args,
   exceptions: {
-    run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
+    run: [
+      "./",
+      "/bin",
+      "/usr/bin",
+      "/usr/local/bin",
+      "/usr/share/pyenv",
+      "~/.pyenv",
+    ],
     write: [
       "./",
       "~/Library/Caches",
@@ -70,7 +77,14 @@ async function checkDryRun() {
     cmd: "pip3",
     args: [...Deno.args, "--quiet", "--report", "-", "--dry-run"],
     exceptions: {
-      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
+      run: [
+        "./",
+        "/bin",
+        "/usr/bin",
+        "/usr/local/bin",
+        "/usr/share/pyenv",
+        "~/.pyenv",
+      ],
       write: [
         "./",
         "~/Library/Caches",
@@ -182,7 +196,14 @@ function checkPipVersion() {
     cmd: "pip3",
     args: ["--version"],
     exceptions: {
-      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "/usr/share/pyenv", "~/.pyenv"],
+      run: [
+        "./",
+        "/bin",
+        "/usr/bin",
+        "/usr/local/bin",
+        "/usr/share/pyenv",
+        "~/.pyenv",
+      ],
     },
     stdout: "piped",
   });


### PR DESCRIPTION
This fixes lockfile generation with pip when it is installed in `~/.local/lib/python*/site-packages/pip`.

It also fixes an issue where `pyenv` installed through the package manager wouldn't allow for lockfile generation.

Closes #1349.
