### PR TITLE
docs: update macOS CLI install command

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,8 +17,7 @@ curl https://sh.phylum.io/ | sh -
 On macOS, we recommend installing phylum with [Homebrew](https://brew.sh/):
 
 ```sh
-brew tap phylum-dev/cli
-brew install phylum
+brew install phylum-cli
 ```
 
 > **Note:** When using Homebrew, [official extensions][] must be installed separately.


### PR DESCRIPTION
There is now official support from Homebrew for the Phylum CLI. That means it can be installed for macOS users alongside their other homebrew applications as simply as `brew install phylum-cli`. This PR reflects that new option as the preferred one.
