### PR TITLE
ci: remove trigger for `homebrew-cli` formula bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,22 +242,6 @@ jobs:
             });
             console.log(response);
 
-      - name: Trigger homebrew-cli Formula bump
-        # Don't trigger for pre-releases
-        if: ${{ !contains(github.ref, 'rc') }}
-        # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.GH_RELEASE_PAT }}
-          script: |
-            const response = await github.rest.repos.createDispatchEvent({
-              owner: "phylum-dev",
-              repo: "homebrew-cli",
-              event_type: "trigger-bump-formula-pr",
-              client_payload: {CLI_version: process.env.GITHUB_REF_NAME},
-            });
-            console.log(response);
-
       - name: Trigger documentation update
         # Don't trigger for pre-releases
         if: ${{ !contains(github.ref, 'rc') }}

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ curl https://sh.phylum.io/ | sh -
 
 ### Install on macOS
 
-On macOS, we recommend installing phylum with [Homebrew](https://brew.sh/):
+On macOS, we recommend installing the Phylum CLI with [Homebrew](https://brew.sh/):
 
 ```sh
-brew tap phylum-dev/cli
-brew install phylum
+brew install phylum-cli
 ```
 
 > **Note:** When using Homebrew, [official extensions][] must be installed separately.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,7 @@ curl https://sh.phylum.io/ | sh -
 
 ### Install on macOS
 
-On macOS, we recommend installing phylum with [Homebrew](https://brew.sh/):
+On macOS, we recommend installing the Phylum CLI with [Homebrew](https://brew.sh/):
 
 ```sh
 brew install phylum-cli


### PR DESCRIPTION
The trigger is no longer needed now that:

* The `phylum-cli` formula is included in `homebrew-core`
  * https://github.com/Homebrew/homebrew-core/blob/master/Formula/p/phylum-cli.rb
* The `phylum-cli` formula is included in the `autobump` workflow
  * https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/autobump.yml
  * https://github.com/Homebrew/homebrew-core/blob/master/.github/autobump.txt#L1011
  * This workflow runs once every three hours
  * It will automatically create new update PRs for outdated formula

Some documentation updates were made to be more consistent in wording.


## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
  - See https://github.com/phylum-dev/roadmap/issues/409
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] ~Have you created sufficient tests?~
  - N/A 
- [x] Have you updated all affected documentation?
- [x] ~Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable~
  - N/A
