### PR TITLE
Bump to v6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Improved sandboxing error message for unsupported kernel versions
+
 ## 6.1.1 - 2024-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.1.2 - 2024-02-22
+
 ### Fixed
 
 - Improved sandboxing error message for unsupported kernel versions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.1.1"
+version = "6.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.1.1"
+version = "6.1.2"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"


### PR DESCRIPTION
## 6.1.2 - 2024-02-22

### Fixed

- Improved sandboxing error message for unsupported kernel versions
