### PR TITLE
docs: use "phylum" to refer to CLI and formula for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ curl https://sh.phylum.io/ | sh -
 
 ### Install on macOS
 
-On macOS, we recommend installing the Phylum CLI with [Homebrew](https://brew.sh/):
+On macOS, we recommend installing phylum with [Homebrew](https://brew.sh/):
 
 ```sh
-brew install phylum-cli
+brew install phylum
 ```
 
 > **Note:** When using Homebrew, [official extensions][] must be installed separately.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,10 +14,10 @@ curl https://sh.phylum.io/ | sh -
 
 ### Install on macOS
 
-On macOS, we recommend installing the Phylum CLI with [Homebrew](https://brew.sh/):
+On macOS, we recommend installing phylum with [Homebrew](https://brew.sh/):
 
 ```sh
-brew install phylum-cli
+brew install phylum
 ```
 
 > **Note:** When using Homebrew, [official extensions][] must be installed separately.


### PR DESCRIPTION
This change reverts "the Phylum CLI" language to simply "phylum" when discussing the install instructions. Some more discussion can be found in #1362, where the change was initially made.

Also, the Homebrew formula for `phylum-cli` has an alias to `phylum` now so changing the install instructions to `brew install phylum` is simpler and more intuitive for users.
