### PR TITLE
Bump to v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.2.0 - 2024-03-19
+
 ### Fixed
 
 - Crashes when parsing invalid lockfiles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.1.2"
+version = "6.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.1.2"
+version = "6.2.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.2.0 - 2024-03-19
+
 ## 6.1.0 - 2024-01-29
 
 - Accept PURLs in `PhylumApi::analyze`


### PR DESCRIPTION
## 6.2.0 - 2024-03-19

### Fixed

- Crashes when parsing invalid lockfiles

### Removed

- `phylum group transfer` subcommand
- Owner email from `phylum group list` results
