### PR TITLE
Use `SPDX` package relationships to filter out the project added a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Improve parsing of non-UTF-8 encoded pom.xml files
+- `SPDX` parsing adding the described package as a dependency
+- `SPDX` parsing certain text files with optional package fields
 
 ## 6.2.0 - 2024-03-19
 
@@ -57,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Renamed multiple CLI arguments to avoid the term `lockfile` in places where
-    manifests are also accepted
+  manifests are also accepted
 - Renamed `lockfiles` key in `phylum status --json` output to `dependency_files`
 
 ## 5.9.0 - 2023-12-05
@@ -99,7 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Automatic manifest resolution with `init`, `parse`, `analyze`, and `status`
-    will no longer return manifests in subdirectories of other manifests
+  will no longer return manifests in subdirectories of other manifests
 
 ### Fixed
 
@@ -339,7 +341,7 @@ before, the existing project ID will be re-linked.
 ### Fixed
 
 - Fix parser lockfile consistency by @cd-work (#882)
-- Add deno.window lib reference to extension\_api.ts by @kylewillmon (#890)
+- Add deno.window lib reference to extension_api.ts by @kylewillmon (#890)
 
 ## 4.1.0 - 2022-12-20
 
@@ -375,7 +377,7 @@ before, the existing project ID will be re-linked.
 - `phylum auth set-token` by @kylewillmon (#786)
 - Add `--lockfile-type` option to `phylum analyze` by @cd-work (#798)
 - Add `phylum init` subcommand by @cd-work (#801)
-- Add lockfile path and type to .phylum\_project by @cd-work (#806)
+- Add lockfile path and type to .phylum_project by @cd-work (#806)
 - Add `unsandboxed_run` manifest permission by @cd-work (#777)
 - Add group member management subcommands by @cd-work (#809)
 
@@ -492,7 +494,7 @@ before, the existing project ID will be re-linked.
 
 ### Fixed
 
-- Fix PHYLUM\_API\_KEY overwriting config token by @cd-work in #631
+- Fix PHYLUM_API_KEY overwriting config token by @cd-work in #631
 - Fix parsing gradle lockfile without classpath by @cd-work in #627
 - Fix link dependencies in yarn parser by @cd-work in #621
 
@@ -565,7 +567,7 @@ before, the existing project ID will be re-linked.
 - Ignore certs everywhere when requested by @kylewillmon (#389)
 - Remove Web UI link from analyze output by @cd-work (#397)
 - Don't use streaming parsers by @kylewillmon (#401)
-- Bump phylum\_types version by @kylewillmon (#409)
+- Bump phylum_types version by @kylewillmon (#409)
 
 ## 3.4.0 - 2022-05-19
 
@@ -589,7 +591,7 @@ before, the existing project ID will be re-linked.
 ### Fixed
 
 - Fix non-frozen Pipfile suffix by @cd-work (#366)
-- Use new endpoint for ping  by @kylewillmon (#369)
+- Use new endpoint for ping by @kylewillmon (#369)
 
 ## 3.2.0 - 2022-05-06
 
@@ -665,7 +667,7 @@ before, the existing project ID will be re-linked.
 
 - Continue install/upgrade even if quarantine flag isn't found by @kylewillmon (#249)
 - Replace Language/Type with Ecosystem by @cd-work (#248)
-- Use git\_version for version numbers by @kylewillmon (#243)
+- Use git_version for version numbers by @kylewillmon (#243)
 - Use Ecosystem in `phylum package` output by @cd-work (#255)
 - Add support for new npm package-lock format by @cd-work (#242)
 
@@ -696,7 +698,7 @@ before, the existing project ID will be re-linked.
 
 - Bring Oauth Support to CLI by @DanielJoyce (#118)
 - Better error handling by @DanielJoyce (#145)
-- Swap out static\_init module for lazy\_static by @DanielJoyce (#146)
+- Swap out static_init module for lazy_static by @DanielJoyce (#146)
 - Gather files from static builder by @louislang (#147)
 - Adding release script by @eeclfrei (#150)
 - Updates for recent api changes by @eeclfrei (#160)

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -18,16 +18,23 @@ use crate::{
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-struct SpdxInfo {
-    packages: Vec<PackageInformation>,
+pub(crate) struct SpdxInfo {
+    #[serde(rename = "SPDXID")]
+    pub(crate) spdx_id: String,
+    pub(crate) packages: Vec<PackageInformation>,
+    #[serde(default)]
+    pub(crate) relationships: Vec<Relationship>,
 }
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PackageInformation {
     pub(crate) name: String,
+    #[serde(rename = "SPDXID")]
+    pub(crate) spdx_id: String,
     pub(crate) version_info: Option<String>,
     pub(crate) download_location: String,
+    #[serde(default)]
     pub(crate) external_refs: Vec<ExternalRefs>,
 }
 
@@ -52,6 +59,14 @@ pub(crate) enum ReferenceCategory {
     PackageManager,
     #[serde(other)]
     Unknown,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Relationship {
+    pub(crate) spdx_element_id: Option<String>,
+    pub(crate) related_spdx_element: Option<String>,
+    pub(crate) relationship_type: Option<String>,
 }
 
 fn type_from_url(url: &str) -> anyhow::Result<PackageType> {
@@ -105,7 +120,7 @@ fn from_locator(registry: &str, locator: &str) -> anyhow::Result<Package> {
         PackageType::Nuget => locator.rsplit_once('/'),
         PackageType::Maven => locator.rsplit_once(':').filter(|(name, _)| name.contains(':')),
         _ => {
-            // Not in the spec, but included for compatibility with our API
+            // Not in the spec, but included for compatibility with our API.
             locator.rsplit_once('@')
         },
     }
@@ -145,16 +160,29 @@ pub struct Spdx;
 
 impl Parse for Spdx {
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>> {
-        let packages_info = if let Ok(lock) = serde_json::from_str::<serde_json::Value>(data) {
-            serde_json::from_value::<SpdxInfo>(lock)?.packages
+        let spdx_info = if let Ok(lock) = serde_json::from_str::<serde_json::Value>(data) {
+            serde_json::from_value::<SpdxInfo>(lock)?
         } else if let Ok(lock) = serde_yaml::from_str::<serde_yaml::Value>(data) {
-            serde_yaml::from_value::<SpdxInfo>(lock)?.packages
+            serde_yaml::from_value::<SpdxInfo>(lock)?
         } else {
             spdx::parse(data).finish().map_err(|e| anyhow!(convert_error(data, e)))?.1
         };
 
+        let spdx_id = spdx_info
+            .relationships
+            .into_iter()
+            .find(|r| {
+                r.relationship_type.as_ref().map_or(false, |t| t == "DESCRIBES")
+                    && r.spdx_element_id.as_ref().map_or(false, |t| t == &spdx_info.spdx_id)
+            })
+            .map(|r| r.related_spdx_element.unwrap_or_default())
+            .unwrap_or_default();
+
         let mut packages = Vec::new();
-        for package_info in packages_info {
+        for package_info in spdx_info.packages {
+            if package_info.spdx_id == spdx_id {
+                continue;
+            }
             match Package::try_from(&package_info) {
                 Ok(pkg) => packages.push(pkg),
                 Err(e) => {
@@ -471,6 +499,66 @@ mod tests {
     }
 
     #[test]
+    fn removes_self_identified_package() {
+        let data = r##"SPDXVersion: SPDX-2.3
+            DataLicense: CC0-1.0
+            SPDXID: SPDXRef-DOCUMENT
+            DocumentName: Python-cve-bin-tool
+            DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-4137f958-709e-4f44-940e-f477ded25cbd
+            LicenseListVersion: 3.22
+            Creator: Tool: sbom4python-0.10.4
+            Created: 2024-04-01T00:28:13Z
+            CreatorComment: <text>This document has been automatically generated.</text>
+            ##### 
+
+            PackageName: cve-bin-tool
+            SPDXID: SPDXRef-Package-1-cve-bin-tool
+            PackageVersion: 3.3rc2
+            PrimaryPackagePurpose: APPLICATION
+            PackageSupplier: Person: Terri Oda (terri.oda@intel.com)
+            PackageDownloadLocation: https://pypi.org/project/cve-bin-tool/3.3rc2
+            FilesAnalyzed: false
+            PackageChecksum: SHA1: c491590aeea36235930d1c6b8480d2489a470ece
+            PackageLicenseDeclared: GPL-3.0-or-later
+            PackageLicenseConcluded: GPL-3.0-or-later
+            PackageCopyrightText: NOASSERTION
+            PackageSummary: <text>CVE Binary Checker Tool</text>
+            ExternalRef: PACKAGE_MANAGER purl pkg:pypi/cve-bin-tool@3.3rc2
+            ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.3rc2:*:*:*:*:*:*:*
+            ##### 
+
+            PackageName: aiohttp
+            SPDXID: SPDXRef-Package-2-aiohttp
+            PackageVersion: 3.9.3
+            PrimaryPackagePurpose: LIBRARY
+            PackageSupplier: NOASSERTION
+            PackageDownloadLocation: https://pypi.org/project/aiohttp/3.9.3
+            FilesAnalyzed: false
+            PackageLicenseDeclared: NOASSERTION
+            PackageLicenseConcluded: Apache-2.0
+            PackageLicenseComments: <text>aiohttp declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
+            PackageCopyrightText: NOASSERTION
+            PackageSummary: <text>Async http client/server framework (asyncio)</text>
+            ExternalRef: PACKAGE_MANAGER purl pkg:pypi/aiohttp@3.9.3
+            #####
+            
+            Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
+            Relationship: SPDXRef-Package-1-cve-bin-tool DEPENDS_ON SPDXRef-Package-2-aiohttp
+            "##;
+
+        let pkgs = Spdx.parse(data).unwrap();
+        assert_eq!(pkgs.len(), 1);
+
+        let expected_pkgs = Package {
+            name: "aiohttp".into(),
+            version: PackageVersion::FirstParty("3.9.3".into()),
+            package_type: PackageType::PyPi,
+        };
+
+        assert_eq!(expected_pkgs, pkgs[0]);
+    }
+
+    #[test]
     fn parse_spdx_2_2_tag_value() {
         let pkgs = Spdx.parse(include_str!("../../tests/fixtures/spdx-2.2.spdx")).unwrap();
         assert_eq!(pkgs.len(), 2673);
@@ -591,7 +679,7 @@ mod tests {
     fn test_file_type() {
         let parse_results =
             Spdx.parse(include_str!("../../tests/fixtures/appbomination.spdx.json"));
-        let expected = anyhow!("missing field `externalRefs`").to_string();
+        let expected = anyhow!("Missing package locator for Gradle").to_string();
         let actual = parse_results.err().unwrap().to_string();
 
         assert_eq!(actual, expected)


### PR DESCRIPTION
In SPDX documents, it's possible to have a self-descriptive structure where the document describes itself as a package. This change uses the package relationships to remove that package from the list. Also fixed an issue where parsing certain text files with additional package info causes the parsing to fail.

Closes https://github.com/phylum-dev/cli/issues/1381
Cloess https://github.com/phylum-dev/cli/issues/1382

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable