### PR TITLE
Use `SPDX` download location to determine package registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Improve parsing of non-UTF-8 encoded pom.xml files
+- `SPDX` SBOM registry determination from downloadLocation
 
 ## 6.2.0 - 2024-03-19
 

--- a/lockfile/src/parsers/spdx.rs
+++ b/lockfile/src/parsers/spdx.rs
@@ -2,10 +2,9 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while};
 use nom::character::complete::{line_ending, multispace0, not_line_ending, space0};
 use nom::combinator::{eof, map_opt, opt, recognize};
-use nom::error::{context, VerboseError, VerboseErrorKind};
+use nom::error::context;
 use nom::multi::{many1, many_till};
 use nom::sequence::{delimited, tuple};
-use nom::Err as NomErr;
 
 use crate::parsers::{take_till_blank_line, take_till_line_end, IResult};
 use crate::spdx::{ExternalRefs, PackageInformation, ReferenceCategory};
@@ -43,16 +42,16 @@ fn package_info(input: &str) -> IResult<&str, PackageInformation> {
 
     // PackageName is required
     let (i, _) = tag("PackageName:")(i)?;
-
     let (i, name) = recognize(ws(take_till_line_end))(i)?;
+    let name = name.trim();
 
     // SPDXID is required
     let (i, _) = tag("SPDXID:")(i)?;
     let (tail, _) = recognize(ws(take_till_line_end))(i)?;
 
     // PackageVersion is optional
-    // Version can be obtained from PURL if present, so we don't return an error
-    // here
+    // The version can be obtained from PURL if present, so we don't return an
+    // error
     let (i, has_version) = opt(tag("PackageVersion:"))(tail)?;
     let (i, v) = recognize(ws(take_till_line_end))(i)?;
     let version = has_version.map(|_| v.trim().to_string());
@@ -66,28 +65,21 @@ fn package_info(input: &str) -> IResult<&str, PackageInformation> {
     // PackageDownloadLocation is required
     let (i, _) = tag("PackageDownloadLocation:")(i)?;
     let (i, download_location) = recognize(ws(take_till_line_end))(i)?;
+    let download_location = download_location.trim();
 
     // Look for external references
     let (i, next_input) = extern_ref(i)?;
     let (_, external_ref) = opt(recognize(ws(take_till_line_end)))(i)?;
+    let external_refs = external_ref
+        .map(|er| parse_external_refs(er).map(|(_, external_ref)| vec![external_ref]))
+        .unwrap_or_else(|| Ok(Vec::new()))?;
 
-    // Package name
-    let name = name.trim();
-
-    if let Some(external_ref) = external_ref {
-        let (_, external_ref) = parse_external_refs(external_ref)?;
-
-        Ok((next_input, PackageInformation {
-            name: name.into(),
-            version_info: version,
-            download_location: download_location.into(),
-            external_refs: vec![external_ref],
-        }))
-    } else {
-        let kind = VerboseErrorKind::Context("Missing package locator");
-        let error = VerboseError { errors: vec![(input, kind)] };
-        Err(NomErr::Failure(error))
-    }
+    Ok((next_input, PackageInformation {
+        name: name.into(),
+        version_info: version,
+        download_location: download_location.into(),
+        external_refs,
+    }))
 }
 
 fn extern_ref(input: &str) -> IResult<&str, &str> {

--- a/lockfile/src/parsers/spdx.rs
+++ b/lockfile/src/parsers/spdx.rs
@@ -110,9 +110,9 @@ fn package_info(input: &str) -> IResult<&str, PackageInformation> {
     let (i, _) = tag("SPDXID:")(i)?;
     let (tail, spdx_id) = recognize(ws(take_till_line_end))(i)?;
 
-    // PackageVersion is optional
+    // PackageVersion is optional.
     // The version can be obtained from PURL if present, so we don't return an
-    // error
+    // error.
     let (i, has_version) = opt(tag("PackageVersion:"))(tail)?;
     let (i, v) = recognize(ws(take_till_line_end))(i)?;
     let version = has_version.map(|_| v.trim().to_string());

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -74,7 +74,7 @@ pub(crate) struct Relationship {
 
 fn type_from_url(url: &str) -> anyhow::Result<PackageType> {
     if url.starts_with("https://registry.npmjs.org")
-        | url.starts_with("https://registry.yarnpkg.com")
+        || url.starts_with("https://registry.yarnpkg.com")
     {
         Ok(PackageType::Npm)
     } else if url.starts_with("https://rubygems.org") {
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn fail_missing_version() {
+    fn tag_value_fail_missing_version() {
         let data = json!({
               "spdxVersion": "SPDX-2.3",
               "dataLicense": "CC0-1.0",
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_ecosystem() {
+    fn spdx_2_3_unsupported_ecosystem() {
         let data = json!({
               "spdxVersion": "SPDX-2.3",
               "dataLicense": "CC0-1.0",
@@ -442,34 +442,6 @@ mod tests {
     }
 
     #[test]
-    fn tag_value_fail_missing_version() {
-        let data = r##"SPDXVersion: SPDX-2.3
-            DataLicense: CC0-1.0
-            DocumentNamespace: http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
-            DocumentName: SPDX-Tools-v2.0
-            SPDXID: SPDXRef-DOCUMENT
-            DocumentComment: <text>This document was created using SPDX 2.0 using licenses from the web site.</text>
-
-            ## Package Information
-            PackageName: Jena
-            SPDXID: SPDXRef-fromDoap-0
-            PackageDownloadLocation: https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz
-            PackageHomePage: http://www.openjena.org/
-            ExternalRef: PACKAGE-MANAGER purl pkg:maven/org.apache.jena/apache-jena
-            FilesAnalyzed: false
-
-            ## Package Information
-            PackageName: @colors/colors
-            SPDXID: SPDXRef-Package-npm--colors-colors-2f307524f9ea3c7b
-            PackageVersion: 1.5.0
-            PackageDownloadLocation: http://github.com/DABH/colors.js.git
-            "##;
-
-        let error = Spdx.parse(data).err().unwrap();
-        assert!(error.to_string().contains("version"))
-    }
-
-    #[test]
     fn tag_value_unsupported_ecosystem() {
         let data = r##"SPDXVersion: SPDX-2.3
             DataLicense: CC0-1.0
@@ -499,61 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn ignore_unknown_ecosystem() {
-        let data = json!({
-              "spdxVersion": "SPDX-2.3",
-              "dataLicense": "CC0-1.0",
-              "SPDXID": "SPDXRef-DOCUMENT",
-              "name": "sbom-example",
-              "packages": [ {
-                "name": "@colors/colors",
-                "SPDXID": "SPDXRef-Package-npm--colors-colors-2f307524f9ea3c7b",
-                "versionInfo": "1.5.0",
-                "originator": "Person: DABH",
-                "downloadLocation": "http://github.com/DABH/colors.js.git",
-                "homepage": "https://github.com/DABH/colors.js",
-                "sourceInfo": "acquired package info from installed node module manifest file: /usr/local/lib/node_modules/npm/node_modules/@colors/colors/package.json",
-                "licenseConcluded": "MIT",
-                "licenseDeclared": "MIT",
-                "copyrightText": "NOASSERTION",
-                "externalRefs": [
-                {
-                  "referenceCategory": "SECURITY",
-                  "referenceType": "cpe23Type",
-                  "referenceLocator": "cpe:2.3:a:\\@colors\\/colors:\\@colors\\/colors:1.5.0:*:*:*:*:*:*:*"
-                },
-                {
-                  "referenceCategory": "SECURITY",
-                  "referenceType": "cpe23Type",
-                  "referenceLocator": "cpe:2.3:a:*:\\@colors\\/colors:1.5.0:*:*:*:*:*:*:*"
-                }]
-                },
-                {
-                  "SPDXID" : "SPDXRef-22",
-                  "comment" : "Package info from Maven Central POM file",
-                  "copyrightText" : "NOASSERTION",
-                  "downloadLocation" : "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
-                  "filesAnalyzed" : false,
-                  "homepage" : "http://junit.org",
-                  "licenseConcluded" : "EPL-1.0",
-                  "licenseDeclared" : "EPL-1.0",
-                  "name" : "junit",
-                  "packageFileName" : "junit-4.12.jar",
-                  "versionInfo" : "4.12"
-                }]
-         }).to_string();
-
-        let pkgs = Spdx.parse(&data).unwrap();
-        let expected_pkg = [Package {
-            name: "junit".into(),
-            version: PackageVersion::FirstParty("4.12".into()),
-            package_type: PackageType::Maven,
-        }];
-        assert_eq!(pkgs, expected_pkg)
-    }
-
-    #[test]
-    fn ecosystem_from_download_location() {
+    fn tag_value_ecosystem_from_download_location() {
         let data = json!({
               "spdxVersion": "SPDX-2.3",
               "dataLicense": "CC0-1.0",


### PR DESCRIPTION
This uses the download location to match with known package registries for packages without an external ref.

Closes https://github.com/phylum-dev/cli/issues/1384

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
