### PR TITLE
Only set content-type header with content

### DIFF
--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -64,8 +64,8 @@ export type RejectionSource = {
   reason: string | null;
 };
 
-async function requestHeaders(headersInit?: HeadersInit): Promise<Headers> {
-  const headers = new Headers(headersInit);
+async function ensureRequestHeaders(init: RequestInit) {
+  const headers = init.headers = new Headers(init.headers);
 
   // Set Authorization header if it is missing.
   if (!headers.has("Authorization")) {
@@ -74,11 +74,9 @@ async function requestHeaders(headersInit?: HeadersInit): Promise<Headers> {
   }
 
   // Set Content-Type header if it is missing.
-  if (!headers.has("Content-Type")) {
+  if (init.body && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
-
-  return headers;
 }
 
 export class PhylumApi {
@@ -98,7 +96,7 @@ export class PhylumApi {
     // Ensure header object is initialized.
     const fetchInit = init ?? {};
 
-    fetchInit.headers = await requestHeaders(fetchInit.headers);
+    await ensureRequestHeaders(fetchInit);
 
     // Get API base URI without version.
     const baseUrl = await PhylumApi.apiBaseUrl();


### PR DESCRIPTION
This PR changes the `PhylumApi.fetch` method to only set the `Content-Type` header when it is sending content. Most API endpoints either expect a JSON request body with `Content-Type: application/json`, or expect no content (and don't care about `Content-Type` at all). There are a couple API endpoints that optionally accept a request body which may or may not be JSON, and for those endpoints the `Content-Type` header must be set to JSON if and only if the request body is JSON. A null body is not JSON, so sending a request to one of those endpoints using the usual `PhylumApi.fetch("v0", "/endpoint", { method: "POST" })` results in a 400 error when the server tries to decode a 0-byte body as JSON.

This PR doesn't attempt to do any sort of autodetection to determine if a request body is actually JSON. If there is a body and the type is not explicitly specified, it gets sent as JSON. This means if you want to send a text body you still need to set `Content-Type: text/plain`.

See this extension PR comment thread https://github.com/phylum-dev/community-extensions/pull/43#discussion_r1554221398

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
- [ ] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
