### PR TITLE
Accomodate API endpoint response cleanup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "phylum_types"
 version = "0.1.0"
-source = "git+https://github.com/phylum-dev/phylum-types?branch=development#7c8eeb98e17ee7297086d4252b2026dd9f1cfcfe"
+source = "git+https://github.com/phylum-dev/phylum-types?branch=development#22a5b615e80d161f60ae0e596748b86501348a0d"
 dependencies = [
  "chrono",
  "purl",

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -633,10 +633,8 @@ mod tests {
                      ],
                     "msg": "Project met threshold requirements",
                     "pass": true,
-                    "action": "warn",
                     "project": "test-project",
                     "total_jobs": 1,
-                    "score": 1.0,
                     "ecosystem": "npm"
                 },
                 {
@@ -653,10 +651,8 @@ mod tests {
                      ],
                     "msg": "Project met threshold requirements",
                     "pass": true,
-                    "action": "break",
                     "project": "test-project",
                     "total_jobs": 1,
-                    "score": 1.0,
                     "ecosystem": "npm"
                 }
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -716,12 +716,6 @@ mod tests {
                 "total_pull_request_count": 476,
                 "open_pull_request_avg_duration": 474
             },
-            "issueImpacts": {
-                "low": 0,
-                "medium": 0,
-                "high": 0,
-                "critical": 0
-            },
             "complete": false
           }
         }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -164,7 +164,6 @@ pub struct Package {
     pub issues: Vec<Issue>,
     pub authors: Vec<Author>,
     pub developer_responsiveness: Option<DeveloperResponsiveness>,
-    pub issue_impacts: IssueImpacts,
     pub complete: bool,
     pub release_data: Option<PackageReleaseData>,
     pub repo_url: Option<String>,
@@ -269,17 +268,6 @@ pub struct DeveloperResponsiveness {
     pub open_pull_request_count: Option<usize>,
     pub total_pull_request_count: Option<usize>,
     pub open_pull_request_avg_duration: Option<u32>,
-}
-
-/// The number of issues a package has, broken down by severity.
-#[derive(Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-#[serde(default)]
-pub struct IssueImpacts {
-    pub low: u32,
-    pub medium: u32,
-    pub high: u32,
-    pub critical: u32,
 }
 
 /// Information about when package releases have happened.

--- a/extensions/phylum.ts
+++ b/extensions/phylum.ts
@@ -411,7 +411,6 @@ export class PhylumApi {
    *     total_pull_request_count: 0,
    *     open_pull_request_avg_duration: null
    *   },
-   *   issueImpacts: { low: 0, medium: 0, high: 0, critical: 0 },
    *   complete: true
    * }
    * ```


### PR DESCRIPTION
These changes are not in API yet (not until I update `phylum-types`, as I did here), but we can pre-empt them here in CLI.

The only affected type from `phylum-types` that we were using here seems to be `JobDescriptor` (through `AllJobsStatusResponse`). There was a test fixture related to that type that needed to be updated (also, we previously were not returning `action` in that response, so I went ahead and removed that too).

We are using our own local `Package` type here as we begin to transition from `phylum-types`, so I had to remove `issue_impacts` locally, too.

ref https://github.com/phylum-dev/roadmap/issues/400