### PR TITLE
Update go lockfile generator to use output from `go list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Use `go list` instead of `go get -d` for go lockfile generation
+
 ## 6.3.0 - 2024-04-18
 
 ### Fixed

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -66,4 +66,69 @@ mod tests {
             assert!(pkgs.contains(&expected_pkg));
         }
     }
+
+    #[cfg(feature = "generator")]
+    #[test]
+    fn lock_generate_goproj() {
+        let path = Path::new("../tests/fixtures/lock_generate_go/go.mod");
+        let lockfile = GoGenerator.generate_lockfile(path).unwrap();
+
+        let pkgs = GoSum.parse(&lockfile).unwrap();
+        assert_eq!(pkgs.len(), 9);
+
+        let expected_pkgs = [
+            // Go.mod direct dependencies.
+            Package {
+                name: "github.com/go-chi/chi/v5".into(),
+                version: PackageVersion::FirstParty("v5.0.12".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "github.com/rs/zerolog".into(),
+                version: PackageVersion::FirstParty("v1.32.0".into()),
+                package_type: PackageType::Golang,
+            },
+            // Go.mod indirect dependencies.
+            Package {
+                name: "github.com/mattn/go-colorable".into(),
+                version: PackageVersion::FirstParty("v0.1.13".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "github.com/mattn/go-isatty".into(),
+                version: PackageVersion::FirstParty("v0.0.19".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "golang.org/x/sys".into(),
+                version: PackageVersion::FirstParty("v0.12.0".into()),
+                package_type: PackageType::Golang,
+            },
+            // Transitive dependencies.
+            Package {
+                name: "github.com/coreos/go-systemd/v22".into(),
+                version: PackageVersion::FirstParty("v22.5.0".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "github.com/godbus/dbus/v5".into(),
+                version: PackageVersion::FirstParty("v5.0.4".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "github.com/pkg/errors".into(),
+                version: PackageVersion::FirstParty("v0.9.1".into()),
+                package_type: PackageType::Golang,
+            },
+            Package {
+                name: "github.com/rs/xid".into(),
+                version: PackageVersion::FirstParty("v1.5.0".into()),
+                package_type: PackageType::Golang,
+            },
+        ];
+
+        for expected_pkg in expected_pkgs {
+            assert!(pkgs.contains(&expected_pkg), "missing package {expected_pkg:?}");
+        }
+    }
 }

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -73,10 +73,9 @@ mod tests {
         let path = Path::new("../tests/fixtures/lock_generate_go/go.mod");
         let lockfile = GoGenerator.generate_lockfile(path).unwrap();
 
-        let pkgs = GoSum.parse(&lockfile).unwrap();
-        assert_eq!(pkgs.len(), 9);
+        let mut actual_pkgs = GoSum.parse(&lockfile).unwrap();
 
-        let expected_pkgs = [
+        let mut expected_pkgs = [
             // Go.mod direct dependencies.
             Package {
                 name: "github.com/go-chi/chi/v5".into(),
@@ -127,8 +126,9 @@ mod tests {
             },
         ];
 
-        for expected_pkg in expected_pkgs {
-            assert!(pkgs.contains(&expected_pkg), "missing package {expected_pkg:?}");
-        }
+        expected_pkgs.sort();
+        actual_pkgs.sort();
+
+        assert_eq!(expected_pkgs, *actual_pkgs);
     }
 }

--- a/lockfile_generator/src/go.rs
+++ b/lockfile_generator/src/go.rs
@@ -1,29 +1,99 @@
 //! Go ecosystem.
 
 use std::ffi::OsStr;
+use std::fmt::Write;
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+
+use serde::{Deserialize, Serialize};
 
 use crate::{Error, Generator, Result};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct Module {
+    path: String,
+    main: Option<bool>,
+    version: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GoDep {
+    name: String,
+    version: String,
+}
+
+fn create_go_dep(module: Module) -> Option<GoDep> {
+    // Skip main module.
+    if module.main.unwrap_or(false) {
+        return None;
+    }
+
+    let version = module.version?;
+
+    Some(GoDep { name: module.path, version })
+}
 
 pub struct Go;
 
 impl Generator for Go {
-    fn lockfile_path(&self, manifest_path: &Path) -> Result<PathBuf> {
-        let project_path = manifest_path
-            .parent()
-            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
-        Ok(project_path.join("go.sum"))
+    fn lockfile_path(&self, _manifest_path: &Path) -> Result<PathBuf> {
+        // NOTE: Go's `generate_lockfile` will never write to disk.
+        unreachable!()
     }
 
     fn command(&self, _manifest_path: &Path) -> Command {
         let mut command = Command::new("go");
-        command.args(["get", "-d"]);
+        command.args(["list", "-m", "-json", "all"]);
         command
     }
 
     fn tool(&self) -> &'static str {
         "Go"
+    }
+
+    /// Generate dependencies from `go list` output.
+    ///
+    /// Since the `go list` never writes any actual lockfile to the disk, we
+    /// provide a custom method here which parses this output and transforms it
+    /// into a `go.sum` format our lockfile parser expects.
+    fn generate_lockfile(&self, manifest_path: &Path) -> Result<String> {
+        let canonicalized = fs::canonicalize(manifest_path)?;
+        let project_path = canonicalized
+            .parent()
+            .ok_or_else(|| Error::InvalidManifest(manifest_path.to_path_buf()))?;
+
+        // Execute go list inside the project.
+        //
+        // We still change directory here since it could impact go's list generation.
+        let mut command = self.command(&canonicalized);
+        command.current_dir(project_path);
+        command.stdin(Stdio::null());
+
+        // Provide better error message, including the failed program's name.
+        let output = command.output().map_err(|err| {
+            let program = format!("{:?}", command.get_program());
+            Error::ProcessCreation(program, self.tool().to_string(), err)
+        })?;
+
+        // Ensure generation was successful.
+        if !output.status.success() {
+            let code = output.status.code();
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::NonZeroExit(code, stderr.into()));
+        }
+        // Parse go list STDOUT.
+        let stdout = String::from_utf8(output.stdout)?;
+        let stream = serde_json::Deserializer::from_str(&stdout).into_iter::<Module>();
+        let packages = stream.filter_map(|res| res.ok()).filter_map(create_go_dep);
+
+        let mut lockfile = String::new();
+        for pkg in packages {
+            let _ = writeln!(lockfile, "{} {} h1:h1", pkg.name, pkg.version);
+        }
+
+        Ok(lockfile)
     }
 
     fn check_prerequisites(&self, manifest_path: &Path) -> Result<()> {

--- a/tests/fixtures/lock_generate_go/go.mod
+++ b/tests/fixtures/lock_generate_go/go.mod
@@ -1,0 +1,14 @@
+module cli/example
+
+go 1.22.2
+
+require (
+	github.com/go-chi/chi/v5 v5.0.12
+	github.com/rs/zerolog v1.32.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	golang.org/x/sys v0.12.0 // indirect
+)

--- a/tests/fixtures/lock_generate_go/go.sum
+++ b/tests/fixtures/lock_generate_go/go.sum
@@ -1,0 +1,17 @@
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
+github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Changes the `go` lockfile generator to use the output of `go list -m -json all` from the previous `go.sum` generation using `go get -d`.

Closes https://github.com/phylum-dev/cli/issues/1396

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
