### PR TITLE
Bump to v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.3.0 - 2024-04-18
+
 ### Fixed
 
 - Improve parsing of non-UTF-8 encoded pom.xml files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.2.0"
+version = "6.3.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## 6.2.0 - 2024-03-19
-
 ## 6.1.0 - 2024-01-29
 
 - Accept PURLs in `PhylumApi::analyze`


### PR DESCRIPTION
## 6.3.0 - 2024-04-18

### Fixed

- Improve parsing of non-UTF-8 encoded pom.xml files
- `SPDX` SBOM registry determination from downloadLocation
- `SPDX` parsing adding the described package as a dependency
- `SPDX` parsing certain text files with optional package fields