### PR TITLE
Fix termination of sandboxed processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `SPDX` SBOM registry determination from downloadLocation
 - `SPDX` parsing adding the described package as a dependency
 - `SPDX` parsing certain text files with optional package fields
+- Sandboxed processes sticking around after CLI is killed with a signal
 
 ## 6.2.0 - 2024-03-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,13 +396,14 @@ dependencies = [
 
 [[package]]
 name = "birdcage"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed46d13ad2637d8609d5614963ebccde3dcb554e995a86bd4ff9d800b4bf14d"
+checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
  "log",
+ "rustix",
  "seccompiler",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.12.0"
 deno_runtime = { version = "0.134.0" }
 deno_core = { version = "0.232.0" }
 deno_ast = { version = "0.31.2", features = ["transpiling"] }
-birdcage = { version = "0.7.0" }
+birdcage = { version = "0.8.1" }
 libc = "0.2.135"
 ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -2,12 +2,13 @@
 
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command as StdCommand;
 use std::result::Result as StdResult;
 use std::str::FromStr;
 use std::{env, fs, io};
 
 use anyhow::{anyhow, Context, Result};
+use birdcage::process::{Command, Stdio};
 use birdcage::{Birdcage, Exception, Sandbox};
 use clap::ArgMatches;
 use phylum_lockfile::{LockfileFormat, ParseError, ParsedLockfile};
@@ -179,7 +180,9 @@ pub fn parse_depfile(
             false,
         )?;
         command.stderr(Stdio::inherit());
-        let output = command.output().map_err(anyhow::Error::from)?;
+        #[allow(clippy::useless_conversion)]
+        let mut std_command: StdCommand = command.into();
+        let output = std_command.output().map_err(anyhow::Error::from)?;
 
         if !output.status.success() {
             // Forward STDOUT to the user on failure.

--- a/cli/src/commands/sandbox.rs
+++ b/cli/src/commands/sandbox.rs
@@ -1,9 +1,9 @@
 //! Sandbox subcommand handling.
 
 use std::os::unix::process::ExitStatusExt;
-use std::process::Command;
 
 use anyhow::{anyhow, Result};
+use birdcage::process::Command;
 use birdcage::{Birdcage, Exception, Sandbox};
 use clap::ArgMatches;
 


### PR DESCRIPTION
Subprocesses spawned inside a sandbox for extensions or lockfile generation would keep running when the CLI is killed, since signals were not propagated to the child process.

This patch updates CLI to use Birdcage 0.8.0 which spawns a separate init process for PID 1 inside the PID namespace automatically terminating any child even if unresponsive.

Closes #1370.