### PR TITLE
Improve `go.sum` parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 
-- Improved `go.sum` file parsing to ensure only actively used modules are 
-  reported and prevent the parser from listing unused packages
+- Improved `go.sum` file parsing to prevent the parser from listing unused packages
 
 ## 6.3.0 - 2024-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## Changed
+
+- Improved `go.sum` file parsing to ensure only actively used modules are 
+  reported and prevent the parser from listing unused packages
+
 ## 6.3.0 - 2024-04-18
 
 ### Fixed

--- a/cli/src/deno.rs
+++ b/cli/src/deno.rs
@@ -209,8 +209,8 @@ impl ModuleLoader for ExtensionsModuleLoader {
 
             if should_transpile {
                 let transpiled =
-                    source_mapper.transpile(module_specifier.to_string(), code, media_type)?;
-                code = transpiled.text.clone();
+                    source_mapper.transpile(module_specifier.to_string(), &code, media_type)?;
+                code.clone_from(&transpiled.text);
             } else {
                 source_mapper.source_cache.insert(module_specifier.to_string(), code.clone());
             }

--- a/lockfile/src/golang.rs
+++ b/lockfile/src/golang.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn parse_go_sum() {
         let pkgs = GoSum.parse(include_str!("../../tests/fixtures/go.sum")).unwrap();
-        assert_eq!(pkgs.len(), 1711);
+        assert_eq!(pkgs.len(), 674);
 
         let expected_pkgs = [
             Package {
@@ -56,8 +56,8 @@ mod tests {
                 package_type: PackageType::Golang,
             },
             Package {
-                name: "sourcegraph.com/sourcegraph/appdash".into(),
-                version: PackageVersion::FirstParty("v0.0.0-20190731080439-ebfcffb1b5c0".into()),
+                name: "sigs.k8s.io/yaml".into(),
+                version: PackageVersion::FirstParty("v1.2.0".into()),
                 package_type: PackageType::Golang,
             },
         ];

--- a/lockfile/src/parse_depfile.rs
+++ b/lockfile/src/parse_depfile.rs
@@ -1,7 +1,9 @@
 //! Parse generic dependency files.
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context};
+#[cfg(feature = "generator")]
+use anyhow::anyhow;
+use anyhow::Context;
 use phylum_types::types::package::PackageDescriptor;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Updates the `go.sum` parser to filter out modules with `<version>/go.mod`. These modules aren't not used to build the package but used to perform [minimal version selection](https://go.dev/ref/mod#minimal-version-selection).

Part of https://github.com/phylum-dev/cli/issues/1396

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
