### PR TITLE
Use the `go.sum` parser as the default lockfile format for golang

### DIFF
--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -237,8 +237,7 @@ pub struct ThirdPartyVersion {
 ///
 /// The file does not need to exist.
 pub fn get_path_format<P: AsRef<Path>>(path: P) -> Option<LockfileFormat> {
-    LockfileFormat::iter()
-        .find(|f| f != &LockfileFormat::GoMod && f.parser().is_path_lockfile(path.as_ref()))
+    LockfileFormat::iter().find(|f| f.parser().is_path_lockfile(path.as_ref()))
 }
 
 /// Identify a dependency file's format based on its path.
@@ -250,8 +249,7 @@ pub fn get_depfile_path_format<P: AsRef<Path>>(path: P) -> Option<LockfileFormat
     let path = path.as_ref();
     LockfileFormat::iter().find(|format| {
         let parser = format.parser();
-        format != &LockfileFormat::GoMod
-            && (parser.is_path_lockfile(path) || parser.is_path_manifest(path))
+        parser.is_path_lockfile(path) || parser.is_path_manifest(path)
     })
 }
 
@@ -270,7 +268,7 @@ pub fn find_manifest_lockfile<P: AsRef<Path>>(path: P) -> Option<(PathBuf, Lockf
     // Find matching format and lockfile in the manifest's directory.
     LockfileFormat::iter()
         // Check if file is a valid manifest.
-        .filter(|format| format != &LockfileFormat::GoMod && format.parser().is_path_manifest(path))
+        .filter(|format| format.parser().is_path_manifest(path))
         // Try to find the associated lockfile.
         .find_map(|format| {
             let lockfile_path = WalkDir::new(manifest_dir)

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -331,8 +331,8 @@ impl DepFiles {
                 let parser = format.parser();
 
                 let mut format_found = false;
-                // GoMod can reprsent a manifest and lockfile which causes duplicate
-                // lockfiles being submitted when a go.sum is present. This removees
+                // GoMod can represent a manifest and lockfile which causes duplicate
+                // lockfiles being submitted when a go.sum is present. This removes
                 // go.mod files from being automatically recognized as a lockfile.
                 if format != LockfileFormat::GoMod && parser.is_path_lockfile(path) {
                     depfiles.lockfiles.push((path.to_path_buf(), format));


### PR DESCRIPTION
Updates the lockfile detection to ignore go.mod files and default to the go.sum parser.

If the go.sum is missing, the go.mod file is recognized and can be parsed if the go directive is >= 1.17.

If the go directive criteria is not satisfied, the user will receive a message that the lockfile generation is required.

```bash
❯ phylum analyze -p test

❗ Could not parse manifest: Parsing "go.mod" requires lockfile generation, but it was disabled
```


Closes https://github.com/phylum-dev/cli/issues/1421

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?
- [x] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
