### PR TITLE
Add STDOUT to lockfile generation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Sandboxed processes sticking around after CLI is killed with a signal
 - Lockfiles with local versions breaking the pip parser
+- Lockfile generation not emitting errors for tools writing them to STDOUT
 
 ## 6.3.0 - 2024-04-18
 

--- a/lockfile_generator/src/cargo.rs
+++ b/lockfile_generator/src/cargo.rs
@@ -18,8 +18,7 @@ impl Generator for Cargo {
 
         // Ensure command was successful.
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::NonZeroExit(output.status.code(), stderr.into()));
+            return Err(Error::NonZeroExit(output));
         }
 
         // Parse metadata output.

--- a/lockfile_generator/src/pip.rs
+++ b/lockfile_generator/src/pip.rs
@@ -79,9 +79,7 @@ impl Generator for Pip {
 
         // Ensure generation was successful.
         if !output.status.success() {
-            let code = output.status.code();
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::NonZeroExit(code, stderr.into()));
+            return Err(Error::NonZeroExit(output));
         }
 
         // Parse pip install report STDOUT.
@@ -122,9 +120,7 @@ fn check_pip_version(project_path: &Path) -> Result<()> {
 
     // Report errors with `pip` version check.
     if !version_output.status.success() {
-        let exit_code = version_output.status.code();
-        let version_stderr = String::from_utf8_lossy(&version_output.stderr).trim().to_owned();
-        return Err(Error::NonZeroExit(exit_code, version_stderr));
+        return Err(Error::NonZeroExit(version_output));
     }
 
     let version_stdout = String::from_utf8(version_output.stdout)?.trim().to_owned();

--- a/lockfile_generator/src/yarn.rs
+++ b/lockfile_generator/src/yarn.rs
@@ -51,7 +51,6 @@ fn yarn_version(manifest_path: &Path) -> Result<String> {
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).into())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(Error::NonZeroExit(output.status.code(), stderr.into()))
+        Err(Error::NonZeroExit(output))
     }
 }


### PR DESCRIPTION
Previously only the STDERR was printed whenever lockfile generation encountered a non-zero exit code from the package manager, however some package managers like `dotnet` print their errors to STDOUT.

This patch reworks the output in these error cases to print both STDERR and STDOUT and formats things a little nicer to make it easy to keep the two apart.

Closes #1425.