### PR TITLE
Bump to v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.4.0 - 2024-05-28
+
 ### Added
 
 - PNPM v9 lockfile support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.3.0"
+version = "6.4.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.4.0 - 2024-05-28
+
 ### Changed
 
 - Expose API via global `Phylum` object


### PR DESCRIPTION
## 6.4.0 - 2024-05-28

### Added

- PNPM v9 lockfile support
- Support for parsing `go.mod` files with a Go directive of version 1.17 and higher

### Changed

- Improved `go.sum` file parsing to prevent the parser from listing unused packages

### Fixed

- Sandboxed processes sticking around after CLI is killed with a signal
- Lockfiles with local versions breaking the pip parser
- Lockfile generation not emitting errors for tools writing them to STDOUT

---

Release-Version: v6.4.0