### PR TITLE
Update project management endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Organization management under the `phylum org` subcommand
+- `phylum project update --default-label` option to set a project's default label
+- `phylum project list --no-group` flag to only show personal projects
 
 ## 6.6.6 - 2024-07-12
 
@@ -58,7 +60,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - PNPM v5 lockfile support
-- `phylum project update --default-label`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - PNPM v5 lockfile support
+- `phylum project update --default-label`
 
 ### Fixed
 

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -97,25 +97,18 @@ pub fn get_group_project_history(
     Ok(url)
 }
 
-/// GET /data/projects/overview
-pub fn get_project_summary(api_uri: &str) -> Result<Url, BaseUriError> {
-    Ok(get_api_path(api_uri)?.join("data/projects/overview")?)
+/// GET /projects
+pub fn projects(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_api_path(api_uri)?.join("projects")?)
 }
 
 /// POST /data/projects
-pub fn post_create_project(api_uri: &str) -> Result<Url, BaseUriError> {
+pub fn create_project(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join("data/projects")?)
 }
 
-/// PUT /data/projects/<project_id>
-pub fn update_project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
-    let mut url = get_api_path(api_uri)?;
-    url.path_segments_mut().unwrap().pop_if_empty().extend(["data", "projects", project_id]);
-    Ok(url)
-}
-
-/// DELETE /data/projects/<project_id>
-pub fn delete_project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+/// GET/PUT/DELETE /data/projects/<project_id>
+pub fn project(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;
     url.path_segments_mut().unwrap().pop_if_empty().extend(["data", "projects", project_id]);
     Ok(url)
@@ -135,13 +128,6 @@ pub(crate) fn group_create(api_uri: &str) -> Result<Url, BaseUriError> {
 pub(crate) fn group_delete(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
     let mut url = get_api_path(api_uri)?;
     url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group]);
-    Ok(url)
-}
-
-/// GET /groups/<groupName>/projects
-pub fn group_project_summary(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
-    let mut url = get_api_path(api_uri)?;
-    url.path_segments_mut().unwrap().pop_if_empty().extend(["groups", group, "projects"]);
     Ok(url)
 }
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -188,6 +188,10 @@ pub fn add_subcommands(command: Command) -> Command {
                             .long("repository-url")
                             .value_name("REPOSITORY_URL")
                             .help("New repository URL"),
+                        Arg::new("default-label")
+                            .short('l')
+                            .long("default-label")
+                            .help("Default project label"),
                     ]),
                 )
                 .subcommand(
@@ -202,6 +206,11 @@ pub fn add_subcommands(command: Command) -> Command {
                             .long("group")
                             .value_name("GROUP_NAME")
                             .help("Group to list projects for"),
+                        Arg::new("no-group")
+                            .action(ArgAction::SetTrue)
+                            .long("no-group")
+                            .help("Exclude all group projects from the output")
+                            .conflicts_with("group"),
                     ]),
                 )
                 .subcommand(

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -21,7 +21,6 @@ use phylum_project::ProjectConfig;
 use phylum_types::types::auth::{AccessToken, RefreshToken};
 use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::package::{PackageDescriptor, PackageDescriptorAndLockfile};
-use phylum_types::types::project::ProjectSummaryResponse;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +36,8 @@ use crate::dirs;
 use crate::permissions::{self, Permission};
 use crate::types::{
     AnalysisPackageDescriptor, ListUserGroupsResponse, Package, PackageSpecifier,
-    PackageSubmitResponse, PolicyEvaluationResponse, PolicyEvaluationResponseRaw, PurlWithOrigin,
+    PackageSubmitResponse, PolicyEvaluationResponse, PolicyEvaluationResponseRaw, ProjectListEntry,
+    PurlWithOrigin,
 };
 
 /// Package format accepted by extension API.
@@ -329,11 +329,11 @@ async fn get_groups(op_state: Rc<RefCell<OpState>>) -> Result<ListUserGroupsResp
 async fn get_projects(
     op_state: Rc<RefCell<OpState>>,
     #[string] group: Option<String>,
-) -> Result<Vec<ProjectSummaryResponse>> {
+) -> Result<Vec<ProjectListEntry>> {
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
-    api.get_projects(group.as_deref()).await.map_err(Error::from)
+    api.get_projects(group.as_deref(), None).await.map_err(Error::from)
 }
 
 #[derive(Serialize)]

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -325,7 +325,10 @@ async fn prompt_project(
 
     // Get all projects.
     let mut projects = api.get_projects(group_name.as_deref(), None).await?;
+
+    // Remove group projects if the user didn't select any group.
     projects.retain(|project| project.group_name.is_some() == group_name.is_some());
+
     let project_names: Vec<_> = projects.iter().map(|project| &project.name).collect();
 
     // Prompt for project selection.

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -33,7 +33,7 @@ pub async fn get_project_list(
     // Sort response for nicer output.
     resp.sort_unstable_by(|a, b| match a.group_name.cmp(&b.group_name) {
         Ordering::Equal => a.name.cmp(&b.name),
-        ordering => return ordering,
+        ordering => ordering,
     });
 
     resp.write_stdout(pretty_print);
@@ -123,10 +123,7 @@ pub async fn status(api: &PhylumApi, matches: &ArgMatches) -> StdResult<(), Phyl
 
     let project_id = match project {
         // If project is passed on CLI, lookup its ID.
-        Some(project) => {
-            let project_id = lookup_project(api, project, group.map(|g| g.as_str())).await?;
-            project_id
-        },
+        Some(project) => lookup_project(api, project, group.map(|g| g.as_str())).await?,
         // If no project is passed, use `.phylum_project`.
         None => match phylum_project::get_current_project() {
             Some(project_config) => project_config.id,

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::path::Path;
 use std::result::Result as StdResult;
 
@@ -20,8 +21,20 @@ pub async fn get_project_list(
     api: &PhylumApi,
     pretty_print: bool,
     group: Option<&str>,
+    no_group: bool,
 ) -> Result<()> {
-    let resp = api.get_projects(group).await?;
+    let mut resp = api.get_projects(group, None).await?;
+
+    // Remove group projects if requested.
+    if no_group {
+        resp.retain(|project| project.group_name.is_none());
+    }
+
+    // Sort response for nicer output.
+    resp.sort_unstable_by(|a, b| match a.group_name.cmp(&b.group_name) {
+        Ordering::Equal => a.name.cmp(&b.name),
+        ordering => return ordering,
+    });
 
     resp.write_stdout(pretty_print);
 
@@ -73,7 +86,8 @@ pub async fn handle_project(
     } else if let Some(matches) = matches.subcommand_matches("list") {
         let group = matches.get_one::<String>("group");
         let pretty_print = !matches.get_flag("json");
-        get_project_list(api, pretty_print, group.map(String::as_str)).await?;
+        let no_group = matches.get_flag("no-group");
+        get_project_list(api, pretty_print, group.map(String::as_str), no_group).await?;
     } else if let Some(matches) = matches.subcommand_matches("link") {
         let project_name = matches.get_one::<String>("name").unwrap();
         let group_name = matches.get_one::<String>("group").cloned();
@@ -107,16 +121,15 @@ pub async fn status(api: &PhylumApi, matches: &ArgMatches) -> StdResult<(), Phyl
     let project = matches.get_one::<String>("project");
     let group = matches.get_one::<String>("group");
 
-    let (project_id, group_name) = match project {
+    let project_id = match project {
         // If project is passed on CLI, lookup its ID.
         Some(project) => {
-            let group = group.cloned();
-            let project_id = lookup_project(api, project, group.as_deref()).await?;
-            (project_id, group)
+            let project_id = lookup_project(api, project, group.map(|g| g.as_str())).await?;
+            project_id
         },
         // If no project is passed, use `.phylum_project`.
         None => match phylum_project::get_current_project() {
-            Some(project_config) => (project_config.id, project_config.group_name),
+            Some(project_config) => project_config.id,
             None => {
                 if pretty_print {
                     print_user_success!("No project set");
@@ -129,7 +142,7 @@ pub async fn status(api: &PhylumApi, matches: &ArgMatches) -> StdResult<(), Phyl
         },
     };
 
-    let project = api.get_project(&project_id.to_string(), group_name.as_deref()).await?;
+    let project = api.get_project(&project_id.to_string()).await?;
 
     project.write_stdout(pretty_print);
 
@@ -166,6 +179,7 @@ pub async fn update_project(
     matches: &ArgMatches,
 ) -> StdResult<(), PhylumApiError> {
     let repository_url_cli = matches.get_one::<String>("repository-url");
+    let default_label_cli = matches.get_one::<String>("default-label");
     let project_id_cli = matches.get_one::<String>("project-id");
     let name_cli = matches.get_one::<String>("name");
 
@@ -173,7 +187,11 @@ pub async fn update_project(
     let interactive = project_id_cli.is_none();
 
     // Sanity check non-interactive usage.
-    if !interactive && repository_url_cli.is_none() && name_cli.is_none() {
+    if !interactive
+        && name_cli.is_none()
+        && repository_url_cli.is_none()
+        && default_label_cli.is_none()
+    {
         print_user_warning!("No changes requested, nothing to do.\n");
         print::print_sc_help(app, &["project", "update"])?;
         return Ok(());
@@ -187,10 +205,18 @@ pub async fn update_project(
     };
 
     // Get existing project information from the API.
-    let project = api.get_project(&project_id, group_name.as_deref()).await?;
+    let project = api.get_project(&project_id).await?;
+
+    // Prompt for name, defaulting to the existing one if empty.
+    let name = match name_cli {
+        None if interactive => {
+            prompt_optional("New Project Name", Some(project.name.clone()))?.unwrap()
+        },
+        name => name.cloned().unwrap_or(project.name.clone()),
+    };
 
     // Check if repository URL should be changed.
-    let change_repository_url = if interactive {
+    let change_repository_url = if interactive && repository_url_cli.is_none() {
         let change_repository_url = Confirm::new()
             .with_prompt("Change repository URL?")
             .default(false)
@@ -211,16 +237,36 @@ pub async fn update_project(
         Some(repository_url) => Some(repository_url.clone()),
     };
 
-    // Prompt for name, defaulting to the existing one if empty.
-    let name = match name_cli {
-        None if interactive => {
-            prompt_optional("New Project Name", Some(project.name.clone()))?.unwrap()
-        },
-        name => name.cloned().unwrap_or(project.name.clone()),
+    // Check if default label should be changed.
+    let change_default_label = if interactive && default_label_cli.is_none() {
+        let change_default_label = Confirm::new()
+            .with_prompt("Change default label?")
+            .default(false)
+            .interact()
+            .map_err(|err| anyhow!(err))?;
+
+        println!();
+
+        change_default_label
+    } else {
+        false
     };
 
-    api.update_project(&project_id, group_name.clone(), name.clone(), repository_url.clone())
-        .await?;
+    // Prompt for default label if necessary.
+    let default_label = match default_label_cli {
+        None if change_default_label => prompt_optional("New Default Label", None)?,
+        None => project.default_label.clone(),
+        Some(default_label) => Some(default_label.clone()),
+    };
+
+    api.update_project(
+        &project_id,
+        group_name.clone(),
+        name.clone(),
+        repository_url.clone(),
+        default_label.clone(),
+    )
+    .await?;
 
     // Output success message.
     let fmt_option = |opt| match opt {
@@ -234,9 +280,14 @@ pub async fn update_project(
     success_msg += ":\n";
     success_msg += &format!("      Name: {:?} -> {name:?}\n", project.name);
     success_msg += &format!(
-        "      Repository URL: {} -> {}",
+        "      Repository URL: {} -> {}\n",
         fmt_option(project.repository_url),
         fmt_option(repository_url)
+    );
+    success_msg += &format!(
+        "      Default Label: {} -> {}",
+        fmt_option(project.default_label),
+        fmt_option(default_label),
     );
     print_user_success!("{}", success_msg);
 
@@ -276,7 +327,8 @@ async fn prompt_project(
     };
 
     // Get all projects.
-    let projects = api.get_projects(group_name.as_deref()).await?;
+    let mut projects = api.get_projects(group_name.as_deref(), None).await?;
+    projects.retain(|project| project.group_name.is_some() == group_name.is_some());
     let project_names: Vec<_> = projects.iter().map(|project| &project.name).collect();
 
     // Prompt for project selection.

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -178,7 +178,7 @@ impl Format for Vec<ProjectListEntry> {
             let table = format_table::<fn(&ProjectListEntry) -> String, _>(self, &[
                 ("Group Name", |project| {
                     let group_name = project.group_name.as_deref().unwrap_or("");
-                    print::truncate(&group_name, MAX_NAME_WIDTH).into_owned()
+                    print::truncate(group_name, MAX_NAME_WIDTH).into_owned()
                 }),
                 ("Project Name", |project| {
                     print::truncate(&project.name, MAX_NAME_WIDTH).into_owned()

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use phylum_lockfile::ParsedLockfile;
-use phylum_types::types::common::ProjectId;
+use phylum_types::types::common::{JobId, ProjectId};
 use phylum_types::types::package::{
-    PackageDescriptor, PackageDescriptorAndLockfile, RiskDomain as PTRiskDomain,
+    PackageDescriptor, PackageDescriptorAndLockfile, PackageType, RiskDomain as PTRiskDomain,
     RiskLevel as PTRiskLevel,
 };
 use serde::{Deserialize, Serialize};
@@ -239,7 +239,7 @@ pub struct VulnDetails {
 }
 
 /// The user-specified reason for an issue to be ignored.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum IgnoredReason {
     /// It is not ignored.
@@ -472,4 +472,51 @@ pub struct OrgMember {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct AddOrgUserRequest {
     pub email: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_label: Option<String>,
+}
+pub type UpdateProjectRequest = CreateProjectRequest;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct ProjectListEntry {
+    pub id: ProjectId,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub name: String,
+    pub ecosystems: Vec<PackageType>,
+    pub group_name: Option<String>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct Paginated<T> {
+    /// The curent page of values.
+    pub values: Vec<T>,
+    /// Indication of whether the current query has more values past the last
+    /// element in `values`.
+    pub has_more: bool,
+}
+
+/// Response to the GET /data/project/<project_id> endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProjectResponse {
+    pub id: ProjectId,
+    pub name: String,
+    pub registries: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub latest_job_created_at: Option<DateTime<Utc>>,
+    pub latest_job_id: Option<JobId>,
+    pub label: Option<String>,
+    pub default_label: Option<String>,
+    pub repository_url: Option<String>,
 }

--- a/docs/commands/phylum_project_list.md
+++ b/docs/commands/phylum_project_list.md
@@ -14,6 +14,9 @@ Usage: phylum project list [OPTIONS]
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group to list projects for
 
+`--no-group`
+&emsp; Exclude all group projects from the output
+
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization
 

--- a/docs/commands/phylum_project_update.md
+++ b/docs/commands/phylum_project_update.md
@@ -20,6 +20,9 @@ Usage: phylum project update [OPTIONS]
 `-r`, `--repository-url` `<REPOSITORY_URL>`
 &emsp; New repository URL
 
+`-l`, `--default-label` `<default-label>`
+&emsp; Default project label
+
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Group projects are included in `PhylumApi::getProjects` with no group specified
+
 ## 6.4.0 - 2024-05-28
 
 ### Changed


### PR DESCRIPTION
This patch updates the endpoints used for the project management
subcommands to avoid the soon-to-be deprecated overview endpoint.

The `phylum project update` subcommand has been updated to make use of
the new `default_label` field, which can now be updated.

The `phylum project list` subcommand now lists all projects by default,
including group projects. To still allow listing only non-group projects
the new `--no-group` flag has been added to this subcommand
specifically. The `repository_url` has been removed from the command
output, since it is not included in the API response.

The group name has been removed from `phylum project status`, since the
new endpoint used by the subcommand does not return this information.
However the `default_label` field was added instead.

Closes #1439.