### PR TITLE
Allow execute for maven for lockfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - PNPM v5 lockfile support
 
+### Fixed
+
+- Sandbox exceptions for maven when installed via Homebrew
+
 ## 6.5.0 - 2024-06-04
 
 ### Changed

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -412,13 +412,16 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
     // Maven.
     permissions::add_exception(&mut birdcage, Exception::WriteAndRead(home.join(".m2")))?;
     permissions::add_exception(&mut birdcage, Exception::WriteAndRead("/var/folders".into()))?;
-    permissions::add_exception(&mut birdcage, Exception::Read("/opt/maven".into()))?;
+    permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead("/opt/maven".into()))?;
     permissions::add_exception(&mut birdcage, Exception::Read("/etc/java-openjdk".into()))?;
-    permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/maven".into()))?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::ExecuteAndRead("/usr/local/Cellar/maven".into()),
+    )?;
     permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/openjdk".into()))?;
     permissions::add_exception(
         &mut birdcage,
-        Exception::Read("/opt/homebrew/Cellar/maven".into()),
+        Exception::ExecuteAndRead("/opt/homebrew/Cellar/maven".into()),
     )?;
     permissions::add_exception(
         &mut birdcage,

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -421,11 +421,19 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
     permissions::add_exception(&mut birdcage, Exception::Read("/usr/local/Cellar/openjdk".into()))?;
     permissions::add_exception(
         &mut birdcage,
+        Exception::ExecuteAndRead("/usr/local/opt/openjdk".into()),
+    )?;
+    permissions::add_exception(
+        &mut birdcage,
         Exception::ExecuteAndRead("/opt/homebrew/Cellar/maven".into()),
     )?;
     permissions::add_exception(
         &mut birdcage,
         Exception::Read("/opt/homebrew/Cellar/openjdk".into()),
+    )?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::ExecuteAndRead("/opt/homebrew/opt/openjdk".into()),
     )?;
     // Gradle.
     permissions::add_exception(&mut birdcage, Exception::WriteAndRead(home.join(".gradle")))?;


### PR DESCRIPTION
Maven has a `libexec` folder that contains scripts that get executed when generating lockfiles. This patch allows execute so that those scripts are not blocked.