### PR TITLE
Allow execution for apt-installed `maven`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Sandbox exceptions for `maven` when installed via `apt`
+
 ## 6.6.0 - 2024-06-11
 
 ### Added

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -429,6 +429,10 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
     )?;
     permissions::add_exception(
         &mut birdcage,
+        Exception::ExecuteAndRead("/usr/share/maven".into()),
+    )?;
+    permissions::add_exception(
+        &mut birdcage,
         Exception::Read("/opt/homebrew/Cellar/openjdk".into()),
     )?;
     permissions::add_exception(


### PR DESCRIPTION
When Maven is installed on Debian-based systems via `apt`, it gets installed in `/usr/share/maven`, which is not included in the current sandbox exceptions. This patch allows execute so that it will work... hopefully.

If it still doesn't, there is a procedure for determining the complete set of exceptions needed...

## Procedure for finding required exceptions

I was holding off on submitting this PR because I wanted to use the `find-permissions` extension in the `phylumio/phylum-ci` Docker image first...to confirm there aren't any other exceptions needed for an `apt install maven` environment. I couldn't get it to work since Docker blocks access to the `/` root directory for mounting.

The best scenario is having the user run the extension for us, **in their environment**. The general documentation on this process [is here](https://docs.phylum.io/cli/extensions/extension_sandboxing#finding-required-exceptions), but here is a custom summary of the steps to do so:

1. Install the [`find-permissions` extension](https://github.com/phylum-dev/cli/tree/main/extensions/find-permissions). The instructions can be further simplified if they don't want to clone the repo...they just need to download/copy the `PhylumExt.toml` and `main.ts` files into a directory named `find-permissions` and then `phylum extension install /path/to/find-permissions`

2. Create a script (named whatever...I'll call it `perm_check.sh`) and ensure it is executable. It should contain the lockfile generation command that Phylum uses internally, like this:
```
#!/usr/bin/bash
mvn help:effective-pom -Doutput=effective-pom.xml
```

3. Run the extension from the same directory as the `pom.xml` file:

```
phylum find-permissions --read --write --bin ./perm_check.sh
```

4. Capture the output and provide it to Phylum engineers. If the extension/script does not run to completion, it may be necessary to identify where it stopped and add entries for those locations (assuming they are trusted):

```
phylum find-permissions --read --write --allow-read dir1 --allow-write dir2 --bin ./perm_check.sh
```
