### PR TITLE
Add missing /etc/maven sandbox exception

### DIFF
--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -442,6 +442,7 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
         &mut birdcage,
         Exception::ExecuteAndRead("/etc/alternatives".into()),
     )?;
+    permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead("/etc/maven".into()))?;
     for jdk_path in jdk_paths()? {
         permissions::add_exception(&mut birdcage, Exception::Read(jdk_path))?;
     }


### PR DESCRIPTION
Follow-up to c198a44c6ad0ef84a2167352799216cf71aa8015.