### PR TITLE
Improve robustness of find-permissions extensions

### DIFF
--- a/extensions/find-permissions/main.ts
+++ b/extensions/find-permissions/main.ts
@@ -109,7 +109,7 @@ const requiredPaths: string[] = [];
 
 // Abort if it doesn't work with all paths allowed.
 if (!test(["/"])) {
-  let msg =
+  const msg =
     "Executable failed with full permissions, ensure its exit code is 0 on success";
   console.error(`${red(msg)}`);
   Deno.exit(444);


### PR DESCRIPTION
This patch adds two minor changes that should make the `find-permissions` extensions easier to use for people unfamiliar with it.

To ensure we don't incorrectly log that `/` is required when the command always fails, the extension now does an explicit check on `/` and outputs a detailed error on the issue.

While I wasn't able to reproduce this issue myself, there have been some reports on failures due to permission errors. To avoid the possibility of that we now explicitly handle `Deno.readDir` failures and just assume the corresponding directory is wholly required.

To improve consistency, all `console.error` calls have been changed to use red color.