### PR TITLE
Remove extraneous output from maven generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Sandbox exceptions for `maven` when installed via `apt`
+- Log output leaking into `effective-pom.xml` during lockfile generation
 
 ## 6.6.0 - 2024-06-11
 

--- a/lockfile_generator/src/maven.rs
+++ b/lockfile_generator/src/maven.rs
@@ -18,7 +18,11 @@ impl Generator for Maven {
     fn command(&self, manifest_path: &Path) -> Command {
         let lockfile_path = self.lockfile_path(manifest_path).unwrap();
         let mut command = Command::new("mvn");
-        command.args(["help:effective-pom", &format!("-Doutput={}", lockfile_path.display())]);
+        command.args([
+            "-q",
+            "help:effective-pom",
+            &format!("-Doutput={}", lockfile_path.display()),
+        ]);
         command
     }
 


### PR DESCRIPTION
This patch silences the maven lockfile generator to avoid part of this output ending up in the target effective-pom.xml.