### PR TITLE
Add init script for gradle lockfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Gradle not generating lockfiles without `dependencyLocking` in the manifest
+
 ## 6.6.1 - 2024-06-18
 
 ### Fixed

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -456,7 +456,7 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
         Exception::Read("/opt/homebrew/Cellar/gradle".into()),
     )?;
     // Pnpm.
-    permissions::add_exception(&mut birdcage, Exception::Read("/tmp".into()))?;
+    permissions::add_exception(&mut birdcage, Exception::WriteAndRead("/tmp".into()))?;
     // Yarn.
     permissions::add_exception(&mut birdcage, Exception::Read(home.join("./yarn")))?;
     // Python.

--- a/lockfile_generator/Cargo.toml
+++ b/lockfile_generator/Cargo.toml
@@ -12,6 +12,4 @@ serde_json = "1.0.96"
 anyhow = "1.0.75"
 glob = "0.3.1"
 thiserror = "1.0.49"
-
-[dev-dependencies]
 tempfile = "3.3.0"


### PR DESCRIPTION
This patch adds a temporary init script using Gradle's `--init-script` CLI parameter to force enable lockfile writing during lockfile generation.