### PR TITLE
Add support for older Gradle lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Support for gradle lockfiles in `gradle/dependency-locks/`
+
 ## 6.6.2 - 2024-06-25
 
 ### Fixed

--- a/docs/lockfile_generation.md
+++ b/docs/lockfile_generation.md
@@ -25,7 +25,7 @@ and which tools must be installed to facilitate automatic lockfile generation:
 | `poetry`      | `pyproject.toml` | [`poetry`][poetry]          |
 | `gem`         | `Gemfile`        | `bundle` (from [Bundler][]) |
 | `mvn`         | `pom.xml`        | `mvn` (from [Maven][])      |
-| `gradle`      | `build.gradle` <br/> `build.gradle.kts`   | [`gradle`][gradle]          |
+| `gradle`      | `build.gradle` <br/> `build.gradle.kts`   | [`gradle`][gradle] version 7.0.0+ |
 | `go`          | `go.mod`         | [`go`][go]                  |
 | `cargo`       | `Cargo.toml`     | [`cargo`][cargo]            |
 | `nugetlock`   | `*.csproj`       | [`dotnet`][dotnet]          |

--- a/docs/supported_lockfiles.md
+++ b/docs/supported_lockfiles.md
@@ -14,7 +14,7 @@ The Phylum CLI supports processing many different lockfiles:
 | `msbuild`     | `*.csproj`                                                             |
 | `nugetlock`   | `packages.lock.json` <br /> `packages.*.lock.json`                     |
 | `mvn`         | `effective-pom.xml`                                                    |
-| `gradle`      | `gradle.lockfile`                                                      |
+| `gradle`      | `gradle.lockfile` <br /> `gradle/dependency-locks/*.lockfile`          |
 | `go`          | `go.sum`                                                               |
 | `gomod`       | `go.mod`                                                               |
 | `cargo`       | `Cargo.lock`                                                           |

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -31,7 +31,9 @@ impl Parse for GradleLock {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name() == Some(OsStr::new("gradle.lockfile"))
+        path.file_name()
+            .and_then(|f| f.to_str())
+            .map_or(false, |file_name| file_name.ends_with(".lockfile"))
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -510,6 +510,7 @@ mod tests {
             ("sample.csproj", LockfileFormat::Msbuild),
             ("packages.lock.json", LockfileFormat::NugetLock),
             ("gradle.lockfile", LockfileFormat::Gradle),
+            ("default.lockfile", LockfileFormat::Gradle),
             ("effective-pom.xml", LockfileFormat::Maven),
             ("requirements.txt", LockfileFormat::Pip),
             ("Pipfile.lock", LockfileFormat::Pipenv),


### PR DESCRIPTION
This patch accepts Gradle lockfiles inside the `gradle/dependency-locks` directory, which all share Gradle's `.lockfile` suffix but have various different file names.

Closes #1459.