### PR TITLE
Fix Gradle 5 lockfiles not overriding manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Gradle 5 lockfiles not overriding manifest files in the same project
+
 ## 6.6.3 - 2024-06-26
 
 ### Fixed


### PR DESCRIPTION
This fixes an issue where Gradle 5 lockfiles would not override manifest files in the same directory since the lockfiles themselves are stored in a subdirectory.
