### PR TITLE
Bump to v6.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.6.4 - 2024-06-27
+
 ### Fixed
 
 - Gradle 5 lockfiles not overriding manifest files in the same project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Gradle 5 lockfiles not overriding manifest files in the same project
+- Legacy Gradle lockfiles not overriding manifest files in the same project
 
 ## 6.6.3 - 2024-06-26
 
 ### Fixed
 
-- Support for gradle lockfiles in `gradle/dependency-locks/`
+- Support for legacy Gradle lockfiles in `gradle/dependency-locks/`
 
 ## 6.6.2 - 2024-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.6.3"
+version = "6.6.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.6.3"
+version = "6.6.4"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/docs/lockfile_generation.md
+++ b/docs/lockfile_generation.md
@@ -68,9 +68,9 @@ will automatically switch to `go.sum` if available. To override this, simply spe
 analyze -t go go.mod`)
 
 Second, without explicitly specifying dependency files, manifest files will only be used if there is no corresponding
-lockfile in the same directory or any parent directory. For example, a single `Cargo.lock` file at the root of the
-repository will be used instead of looking at any `Cargo.toml` files anywhere in the repository. To avoid this, run
-`phylum init` and specify all files that you want analyzed.
+lockfile. For example, a single `Cargo.lock` file at the root of the repository will be used instead of looking at any
+`Cargo.toml` files anywhere in the repository. To avoid this, run `phylum init` and specify all files that you want
+analyzed.
 
 ## Lockifests
 

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## 6.6.4 - 2024-06-27
-
 ## 6.4.0 - 2024-05-28
 
 ### Changed

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 6.6.4 - 2024-06-27
+
 ## 6.4.0 - 2024-05-28
 
 ### Changed

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -362,7 +362,7 @@ impl DepFiles {
 ///
 /// This will filter out manifests if there is a manifest or lockfile in a
 /// directory above them. To get all lockfiles and manifests, see
-/// [`LockableFiles::find_at`].
+/// [`DepFiles::find_at`].
 ///
 /// Paths excluded by gitignore are automatically ignored.
 pub fn find_depfiles_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileFormat)> {
@@ -378,8 +378,9 @@ pub fn find_depfiles_at(root: impl AsRef<Path>) -> Vec<(PathBuf, LockfileFormat)
         let mut lockfile_dirs =
             depfiles.lockfiles.iter().filter_map(|(path, format)| Some((path.parent()?, format)));
         remove |= lockfile_dirs.any(|(mut lockfile_dir, lockfile_format)| {
-            // Gradle 5 lockfiles are in a subdirectory, so we truncate these directories to
-            // get the effective directory these lockfiles were created for.
+            // Legacy Gradle (before v7) lockfiles are in a subdirectory,
+            // so we truncate these directories to get the effective
+            // directory these lockfiles were created for.
             let dir_str = lockfile_dir.to_string_lossy();
             if lockfile_format == &LockfileFormat::Gradle
                 && dir_str.ends_with("/gradle/dependency-locks")


### PR DESCRIPTION
Some language changes were made to the `CHANGELOG` and comments,
to be more precise about the affected Gradle versions and how the
dependency file detection logic works.

Release-Version: v6.6.4