### PR TITLE
Fix package-lock.json lockfile parsing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- `package-lock.json` parsing failing for dependencies without `resolved` field
+
 ## 6.6.4 - 2024-06-27
 
 ### Fixed

--- a/tests/fixtures/package-lock.json
+++ b/tests/fixtures/package-lock.json
@@ -576,6 +576,14 @@
     "node_modules/netlify-cli/tools/lint-rules": {
       "name": "eslint-plugin-workspace",
       "extraneous": true
+    },
+    "node_modules/cdk-assets/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "2.142.1",
+      "dev": true,
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.0"
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes an issue where the lockfile parser for JavaScript's `package-lock.json` was too restrictive and would fail parsing valid lockfiles.

As a solution all packages without explicit `resolved` field are now ignored, since these are the only packages we're capable of analyzing anyway.