### PR TITLE
ci: use GitHub-hosted macOS runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
-            os: [self-hosted, macos, arm64]
+            os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: aarch64-apple-darwin
             os: macos-14
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, [self-hosted, macos, arm64]]
+        os: [ubuntu-20.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, [self-hosted, macos, arm64]]
+        os: [ubuntu-20.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -78,7 +78,7 @@ jobs:
   oldstable:
     strategy:
       matrix:
-        os: [ubuntu-20.04, [self-hosted, macos, arm64]]
+        os: [ubuntu-20.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -103,7 +103,7 @@ jobs:
     if: github.secret_source == 'Actions'
     strategy:
       matrix:
-        os: [ubuntu-20.04, [self-hosted, macos, arm64]]
+        os: [ubuntu-20.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
The GitHub-hosted macOS runners have been updated to include arm64 M1 options now. This PR switches our workflows to use them instead of the self-hosted runner. There is more availability for these runners and they run just about as fast, if not faster when accounting for parallel jobs. The `release` workflow was updated to change `macos-latest` to `macos-14` to be specific about the version in the matrix and allow for adding additional versions in the future.

Resources:
* [Standard GitHub-hosted runners for public repos](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
* [Latest `macos-14` image release](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240701.9)
* [SW included in latest `macos-14` image](https://github.com/actions/runner-images/blob/macos-14-arm64/20240701.9/images/macos/macos-14-arm64-Readme.md)