### PR TITLE
Infer repository URL from git info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- `phylum init` will infer the repository URL from `git`
+
 ## 6.6.5 - 2024-07-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,11 @@ name = "cc"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -2688,6 +2693,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +3577,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,12 +3638,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4082,6 +4140,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4421,7 @@ dependencies = [
  "env_logger",
  "futures",
  "git-version",
+ "git2",
  "home",
  "ignore",
  "lazy_static",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,31 +21,39 @@ end-to-end-tests = []
 anyhow = "1.0.44"
 axum = "0.7.4"
 base64 = "0.21.1"
+birdcage = { version = "0.8.1" }
 bytes = "1.1.0"
 chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
 cidr = "0.2.0"
 clap = { version = "4.0.9", features = ["string", "wrap_help"] }
 console = "0.15.2"
+dashmap = "6.0.1"
+deno_ast = { version = "0.38.1", features = ["transpiling"] }
+deno_core = { version = "0.280.0" }
+deno_runtime = { version = "0.159.0" }
 dialoguer = { version = "0.10.0", features = ["fuzzy-select"] }
 env_logger = "0.10.0"
 futures = "^0.3"
+git2 = "0.19.0"
 git-version = "0.3.5"
 home = "0.5.3"
+ignore = { version = "0.4.20", optional = true }
 lazy_static = "1.4.0"
+libc = "0.2.135"
 log = "0.4.6"
 maplit = "1.0.2"
+once_cell = "1.12.0"
 open = "5.0.0"
 phylum_lockfile = { path = "../lockfile", features = ["generator"] }
 phylum_project = { path = "../phylum_project" }
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
-vuln-reach = { git = "https://github.com/phylum-dev/vuln-reach", optional = true }
-vulnreach_types = { path = "../vulnreach_types", optional = true }
 prettytable-rs = "0.10.0"
 rand = "0.8.4"
+regex = "1.5.5"
 reqwest = { version = "0.11.3", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-webpki-roots"], default-features = false }
 rsa = { version = "0.9.2", features = ["sha2"] }
-serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
+serde = { version = "1.0.144", features = ["derive"] }
 serde_yaml = "0.9.2"
 sha2 = "0.10.2"
 shellexpand = "3.0.0"
@@ -56,18 +64,11 @@ tokio = { version = "^1.0", features = ["full"] }
 toml = "0.7.4"
 unicode-width = "0.1.9"
 url = { version = "2", features = ["serde"] }
-zip = { version = "2.1.0", default-features = false, features = ["deflate"] }
-walkdir = "2.3.2"
-regex = "1.5.5"
-once_cell = "1.12.0"
-deno_runtime = { version = "0.159.0" }
-deno_core = { version = "0.280.0" }
-deno_ast = { version = "0.38.1", features = ["transpiling"] }
-birdcage = { version = "0.8.1" }
-libc = "0.2.135"
-ignore = { version = "0.4.20", optional = true }
 uuid = "1.4.1"
-dashmap = "6.0.1"
+vuln-reach = { git = "https://github.com/phylum-dev/vuln-reach", optional = true }
+vulnreach_types = { path = "../vulnreach_types", optional = true }
+walkdir = "2.3.2"
+zip = { version = "2.1.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"


### PR DESCRIPTION
Closes #1465.

---

This uses the `git2` crate, which is pretty big. But I think it's the most sensible implementation for this feature.
