### PR TITLE
Fix msbuild parsing with lowercase version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `phylum init` will infer the repository URL from `git`
 
+### Fixed
+
+- `msbuild` parser ignoring uppercase `Version` fields on `PackageReference`
+
 ## 6.6.5 - 2024-07-09
 
 ### Fixed

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -248,14 +248,24 @@ mod tests {
     #[test]
     fn lock_parse_csproj() {
         let pkgs = CSProj.parse(include_str!("../../tests/fixtures/sample.csproj")).unwrap();
+        assert_eq!(pkgs.len(), 6);
 
-        assert_eq!(pkgs.len(), 5);
-        assert_eq!(pkgs[0].name, "Microsoft.NETFramework.ReferenceAssemblies");
-        assert_eq!(pkgs[0].version, PackageVersion::FirstParty("1.0.0".into()));
+        let expected_pkgs = [
+            Package {
+                name: "Microsoft.NETFramework.ReferenceAssemblies".into(),
+                version: PackageVersion::FirstParty("4.5.0".into()),
+                package_type: PackageType::Nuget,
+            },
+            Package {
+                name: "Microsoft.NETCore.UniversalWindowsPlatform".into(),
+                version: PackageVersion::FirstParty("6.2.10".into()),
+                package_type: PackageType::Nuget,
+            },
+        ];
 
-        let last = pkgs.last().unwrap();
-        assert_eq!(last.name, "System.ValueTuple");
-        assert_eq!(last.version, PackageVersion::FirstParty("4.5.0".into()));
+        for expected_pkg in expected_pkgs {
+            assert!(pkgs.contains(&expected_pkg));
+        }
     }
 
     #[test]

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -97,7 +97,7 @@ pub struct PackageReference {
     #[serde(alias = "@Include", default)]
     pub name: String,
 
-    #[serde(alias = "@Version", alias = "@version", default)]
+    #[serde(alias = "@Version", alias = "@version", alias = "Version", default)]
     pub version: String,
 }
 
@@ -253,12 +253,22 @@ mod tests {
         let expected_pkgs = [
             Package {
                 name: "Microsoft.NETFramework.ReferenceAssemblies".into(),
+                version: PackageVersion::FirstParty("1.0.0".into()),
+                package_type: PackageType::Nuget,
+            },
+            Package {
+                name: "System.ValueTuple".into(),
                 version: PackageVersion::FirstParty("4.5.0".into()),
                 package_type: PackageType::Nuget,
             },
             Package {
                 name: "Microsoft.NETCore.UniversalWindowsPlatform".into(),
                 version: PackageVersion::FirstParty("6.2.10".into()),
+                package_type: PackageType::Nuget,
+            },
+            Package {
+                name: "System.Collections.Immutable".into(),
+                version: PackageVersion::FirstParty("1.5.0".into()),
                 package_type: PackageType::Nuget,
             },
         ];

--- a/tests/fixtures/sample.csproj
+++ b/tests/fixtures/sample.csproj
@@ -15,6 +15,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple" version="4.5.0" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.2.10</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/fixtures/sample.csproj
+++ b/tests/fixtures/sample.csproj
@@ -13,10 +13,12 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple" version="4.5.0" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
+    </PackageReference>
+    <PackageReference Include="System.Collections.Immutable">
+      <version>1.5.0</version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
This fixes an issue where the `.csproj` parser would ignore uppercase
version fields on `PackageReference`.