### PR TITLE
Add organization management subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Organization management under the `phylum org` subcommand
+
 ## 6.6.6 - 2024-07-12
 
 ### Added

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -159,6 +159,30 @@ pub fn group_members(api_uri: &str, group: &str) -> Result<Url, BaseUriError> {
     Ok(url)
 }
 
+/// GET /organizations
+pub fn orgs(api_uri: &str) -> Result<Url, BaseUriError> {
+    Ok(get_api_path(api_uri)?.join("organizations")?)
+}
+
+/// GET /organizations/<orgName>/members
+pub fn org_members(api_uri: &str, org: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["organizations", org, "members"]);
+    Ok(url)
+}
+
+/// DELETE /organizations/<orgName>/members/<email>
+pub fn org_member_remove(api_uri: &str, org: &str, email: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "organizations",
+        org,
+        "members",
+        email,
+    ]);
+    Ok(url)
+}
+
 /// GET /.well-known/openid-configuration
 pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/openid-configuration")?)

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -29,9 +29,10 @@ use crate::auth::{
 };
 use crate::config::{AuthInfo, Config};
 use crate::types::{
-    AnalysisPackageDescriptor, HistoryJob, ListUserGroupsResponse, PackageSpecifier,
-    PackageSubmitResponse, PingResponse, PolicyEvaluationRequest, PolicyEvaluationResponse,
-    PolicyEvaluationResponseRaw, RevokeTokenRequest, SubmitPackageRequest, UserToken,
+    AddOrgUserRequest, AnalysisPackageDescriptor, HistoryJob, ListUserGroupsResponse,
+    OrgMembersResponse, OrgsResponse, PackageSpecifier, PackageSubmitResponse, PingResponse,
+    PolicyEvaluationRequest, PolicyEvaluationResponse, PolicyEvaluationResponseRaw,
+    RevokeTokenRequest, SubmitPackageRequest, UserToken,
 };
 
 pub mod endpoints;
@@ -473,6 +474,33 @@ impl PhylumApi {
         let url = endpoints::revoke_token(&self.config.connection.uri)?;
         let body = RevokeTokenRequest { name };
         self.send_request_raw(Method::POST, url, Some(body)).await?;
+        Ok(())
+    }
+
+    /// Get organizations the user is part of.
+    pub async fn orgs(&self) -> Result<OrgsResponse> {
+        let url = endpoints::orgs(&self.config.connection.uri)?;
+        self.get(url).await
+    }
+
+    /// Get members of an organization.
+    pub async fn org_members(&self, org: &str) -> Result<OrgMembersResponse> {
+        let url = endpoints::org_members(&self.config.connection.uri, org)?;
+        self.get(url).await
+    }
+
+    /// Add a member to an organization.
+    pub async fn org_member_add(&self, org: &str, email: &str) -> Result<()> {
+        let body = AddOrgUserRequest { email: email.into() };
+        let url = endpoints::org_members(&self.config.connection.uri, org)?;
+        self.send_request_raw(Method::POST, url, Some(body)).await?;
+        Ok(())
+    }
+
+    /// Remove a member from an organization.
+    pub async fn org_member_remove(&self, org: &str, email: &str) -> Result<()> {
+        let url = endpoints::org_member_remove(&self.config.connection.uri, org, email)?;
+        self.send_request_raw(Method::DELETE, url, None::<()>).await?;
         Ok(())
     }
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -652,8 +652,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .about("Select an organization as default for all operations")
                         .args(&[Arg::new("org")
                             .value_name("ORG")
-                            .help("Organization to use as default")
-                            .required(true)]),
+                            .help("Organization to use as default")]),
                 )
                 .subcommand(
                     Command::new("unlink").about("Clear the configured default organization"),

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -55,6 +55,12 @@ pub fn app() -> Command {
                 .action(ArgAction::SetTrue)
                 .long("no-check-certificate")
                 .help("Don't validate the server certificate when performing api requests"),
+            Arg::new("org")
+                .short('o')
+                .long("org")
+                .value_name("ORG")
+                .help("Phylum organization")
+                .global(true),
             Arg::new("verbose")
                 .short('v')
                 .long("verbose")
@@ -486,8 +492,9 @@ pub fn add_subcommands(command: Command) -> Command {
                             .short('g')
                             .long("group")
                             .value_name("GROUP")
-                            .help("Group to list the members for")
+                            .help("Group to manage the members for")
                             .required(true)])
+                        .arg_required_else_help(true)
                         .subcommand_required(true)
                         .subcommand(
                             Command::new("list").about("List group members").args(&[Arg::new(
@@ -591,6 +598,66 @@ pub fn add_subcommands(command: Command) -> Command {
                 ])
                 .about("Run lockfile generation inside sandbox and write it to STDOUT")
                 .hide(true),
+        )
+        .subcommand(
+            Command::new("org")
+                .about("Manage organizations")
+                .arg_required_else_help(true)
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("list")
+                        .about("List all organizations the user is a member of")
+                        .args(&[Arg::new("json")
+                            .action(ArgAction::SetTrue)
+                            .short('j')
+                            .long("json")
+                            .help("Produce output in json format (default: false)")]),
+                )
+                .subcommand(
+                    Command::new("member")
+                        .about("Manage organization members")
+                        .arg_required_else_help(true)
+                        .subcommand_required(true)
+                        .subcommand(
+                            Command::new("list").about("List organization members").args(&[
+                                Arg::new("json")
+                                    .action(ArgAction::SetTrue)
+                                    .short('j')
+                                    .long("json")
+                                    .help("Produce member list in json format (default: false)"),
+                            ]),
+                        )
+                        .subcommand(
+                            Command::new("add").about("Add user to organization").args(&[
+                                Arg::new("user")
+                                    .value_name("USER")
+                                    .help("User(s) to be added")
+                                    .action(ArgAction::Append)
+                                    .required(true),
+                            ]),
+                        )
+                        .subcommand(
+                            Command::new("remove")
+                                .alias("rm")
+                                .about("Remove user from organization")
+                                .args(&[Arg::new("user")
+                                    .value_name("USER")
+                                    .help("User(s) to be removed")
+                                    .action(ArgAction::Append)
+                                    .required(true)]),
+                        ),
+                )
+                .subcommand(
+                    Command::new("link")
+                        .about("Select an organization as default for all operations")
+                        .args(&[Arg::new("org")
+                            .value_name("ORG")
+                            .help("Organization to use as default")
+                            .required(true)]),
+                )
+                .subcommand(
+                    Command::new("unlink").about("Clear the configured default organization"),
+                ),
         );
 
     #[cfg(feature = "extensions")]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -14,7 +14,7 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, find_dependency_files, group, init, jobs, packages, parse, project, status,
+    auth, find_dependency_files, group, init, jobs, org, packages, parse, project, status,
     CommandResult, ExitCode,
 };
 use phylum_cli::config::{self, Config};
@@ -142,6 +142,7 @@ async fn handle_commands() -> CommandResult {
         "analyze" | "batch" => jobs::handle_submission(&Spinner::wrap(api).await?, &matches).await,
         "init" => init::handle_init(&Spinner::wrap(api).await?, sub_matches).await,
         "status" => status::handle_status(sub_matches).await,
+        "org" => org::handle_org(&Spinner::wrap(api).await?, sub_matches, config).await,
 
         #[cfg(feature = "selfmanage")]
         "uninstall" => uninstall::handle_uninstall(sub_matches),

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -396,7 +396,7 @@ async fn get_package_details(
     #[string] name: String,
     #[string] version: String,
     #[string] package_type: String,
-) -> Result<Package> {
+) -> Result<Box<Package>> {
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod find_dependency_files;
 pub mod group;
 pub mod init;
 pub mod jobs;
+pub mod org;
 pub mod packages;
 pub mod parse;
 pub mod project;
@@ -35,6 +36,7 @@ pub enum ExitCode {
     InvalidTokenExpiration,
     ManifestWithoutGeneration,
     UnknownManifestFormat,
+    MissingOrg,
     FailedPolicy,
     SandboxStart,
     SandboxStartCollision,
@@ -64,6 +66,7 @@ impl From<&ExitCode> for i32 {
             ExitCode::InvalidTokenExpiration => 19,
             ExitCode::ManifestWithoutGeneration => 20,
             ExitCode::UnknownManifestFormat => 21,
+            ExitCode::MissingOrg => 22,
             ExitCode::FailedPolicy => 100,
             ExitCode::SandboxStart => 117,
             ExitCode::SandboxStartCollision => 118,

--- a/cli/src/commands/org.rs
+++ b/cli/src/commands/org.rs
@@ -146,11 +146,23 @@ pub async fn handle_member_remove(
 
 /// Prompt user for org selection.
 async fn prompt_org(api: &PhylumApi) -> Result<Option<String>> {
-    // Check if user is part of any organizations.
+    // Get orgs the user is a member of.
     let orgs_response = api.orgs().await?;
-    if orgs_response.organizations.is_empty() {
-        print_user_failure!("User is not part of any organizations");
-        return Ok(None);
+    match orgs_response.organizations.as_slice() {
+        // Print error if user is not part of any orgs.
+        [] => {
+            print_user_failure!("User is not part of any organizations");
+            return Ok(None);
+        },
+        // Short-circuit if user is only part of one org.
+        [org] => {
+            print_user_success!(
+                "Automatically selected the only organization you are a member of: {:?}",
+                org.name
+            );
+            return Ok(Some(org.name.clone()));
+        },
+        _ => (),
     }
 
     // Ask user to select one of their orgs.

--- a/cli/src/commands/org.rs
+++ b/cli/src/commands/org.rs
@@ -1,0 +1,133 @@
+//! Subcommand `phylum org`.
+
+use clap::ArgMatches;
+use reqwest::StatusCode;
+
+use crate::api::PhylumApi;
+use crate::commands::{CommandResult, ExitCode};
+use crate::config::Config;
+use crate::format::Format;
+use crate::{print_user_failure, print_user_success, print_user_warning};
+
+/// Handle `phylum org` subcommand.
+pub async fn handle_org(api: &PhylumApi, matches: &ArgMatches, config: Config) -> CommandResult {
+    match matches.subcommand() {
+        Some(("list", matches)) => handle_org_list(api, matches).await,
+        Some(("link", matches)) => handle_org_link(api, matches, config).await,
+        Some(("unlink", _)) => handle_org_unlink(config).await,
+        Some(("member", sub_matches)) => {
+            let org = match config.org() {
+                Some(org) => org,
+                None => {
+                    print_user_failure!("Arguments missing target organization");
+                    print_user_failure!("Either add `--org` flag, or update your configuration:");
+                    print_user_failure!("    phylum org link <ORG>");
+                    return Ok(ExitCode::MissingOrg);
+                },
+            };
+
+            match sub_matches.subcommand() {
+                Some(("list", sub_matches)) => handle_member_list(api, sub_matches, org).await,
+                Some(("add", sub_matches)) => handle_member_add(api, sub_matches, org).await,
+                Some(("remove", sub_matches)) => handle_member_remove(api, sub_matches, org).await,
+                _ => unreachable!("invalid clap configuration"),
+            }
+        },
+        _ => unreachable!("invalid clap configuration"),
+    }
+}
+
+/// Handle `phylum org list` subcommand.
+pub async fn handle_org_list(api: &PhylumApi, matches: &ArgMatches) -> CommandResult {
+    let response = api.orgs().await?;
+
+    let pretty = !matches.get_flag("json");
+    response.write_stdout(pretty);
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum org link` subcommand.
+pub async fn handle_org_link(
+    api: &PhylumApi,
+    matches: &ArgMatches,
+    mut config: Config,
+) -> CommandResult {
+    let org = matches.get_one::<String>("org").unwrap();
+
+    // Attempt org access, to simplify troubleshooting.
+    if api.org_members(org).await.is_err() {
+        print_user_warning!(
+            "Could not access organization {org:?}, future Phylum commands may fail unexpectedly"
+        );
+    }
+
+    config.set_org(Some(org.into()));
+    config.save()?;
+
+    print_user_success!("Successfully set default organization to {org:?}");
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum org unlink` subcommand.
+pub async fn handle_org_unlink(mut config: Config) -> CommandResult {
+    config.set_org(None);
+    config.save()?;
+
+    print_user_success!("Successfully cleared default organization");
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum org member list` subcommand.
+pub async fn handle_member_list(api: &PhylumApi, matches: &ArgMatches, org: &str) -> CommandResult {
+    let response = api.org_members(org).await?;
+
+    let pretty = !matches.get_flag("json");
+    response.write_stdout(pretty);
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum org member add` subcommand.
+pub async fn handle_member_add(api: &PhylumApi, matches: &ArgMatches, org: &str) -> CommandResult {
+    let users = matches.get_many::<String>("user").unwrap();
+
+    for user in users {
+        match api.org_member_add(org, user).await {
+            Ok(()) => print_user_success!("Successfully added {user:?} to organization {org:?}"),
+            Err(err) if err.status() == Some(StatusCode::CONFLICT) => {
+                print_user_warning!("User {user:?} is already a member of organization {org:?}");
+                return Ok(ExitCode::AlreadyExists);
+            },
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum org member remove` subcommand.
+pub async fn handle_member_remove(
+    api: &PhylumApi,
+    matches: &ArgMatches,
+    org: &str,
+) -> CommandResult {
+    let users = matches.get_many::<String>("user").unwrap();
+
+    for user in users {
+        match api.org_member_remove(org, user).await {
+            Ok(()) => {
+                print_user_success!("Successfully removed {user:?} from organization {org:?}")
+            },
+            Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => {
+                print_user_warning!("User {user:?} is not a member of organization {org:?}");
+                return Ok(ExitCode::NotFound);
+            },
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok(ExitCode::Ok)
+}

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -367,9 +367,6 @@ impl Format for OrgsResponse {
 
 impl Format for OrgMembersResponse {
     fn pretty<W: Write>(&self, writer: &mut W) {
-        // Maximum length of email column.
-        const MAX_EMAIL_WIDTH: usize = 25;
-
         let table = format_table::<fn(&OrgMember) -> String, _>(&self.members, &[
             ("E-Mail", |member| print::truncate(&member.email, MAX_EMAIL_WIDTH).into_owned()),
             ("Role", |member| member.role.to_string()),

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
@@ -136,7 +136,7 @@ pub struct RevokeTokenRequest<'a> {
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "status", content = "data")]
 pub enum PackageSubmitResponse {
-    AlreadyProcessed(Package),
+    AlreadyProcessed(Box<Package>),
     AlreadySubmitted,
     New,
 }
@@ -427,8 +427,49 @@ pub enum GroupRole {
     Member,
     Admin,
 }
+pub type OrgRole = GroupRole;
+
+impl Display for GroupRole {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Member => write!(f, "Member"),
+            Self::Admin => write!(f, "Admin"),
+        }
+    }
+}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct ListUserGroupsResponse {
     pub groups: Vec<UserGroup>,
+}
+
+/// Response from Phylum's GET /organizations endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct OrgsResponse {
+    pub organizations: Vec<Org>,
+}
+
+/// Organization returned by Phylum's GET /organizations endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct Org {
+    pub name: String,
+}
+
+/// Response from Phylum's GET /organizations/<org>/members endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct OrgMembersResponse {
+    pub members: Vec<OrgMember>,
+}
+
+/// Member returned by Phylum's GET /organizations/<org>/members endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct OrgMember {
+    pub email: String,
+    pub role: OrgRole,
+}
+
+/// Request body for Phylum's POST /organizations/<org>/members endpoint.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct AddOrgUserRequest {
+    pub email: String,
 }

--- a/doc_templates/phylum_analyze.md
+++ b/doc_templates/phylum_analyze.md
@@ -26,10 +26,10 @@ $ phylum analyze --json --verbose effective-pom.xml
 # Analyze a PyPI dependency file and apply a label
 $ phylum analyze --label test_branch requirements.txt
 
-# Analyze a Poetry lockfile and return the results to the 'sample' project
+# Analyze a Poetry lockfile and return the results to the `sample` project
 $ phylum analyze -p sample poetry.lock
 
-# Analyze a NuGet lockfile using the 'sample' project and 'sGroup' group
+# Analyze a NuGet lockfile using the `sample` project and `sGroup` group
 $ phylum analyze -p sample -g sGroup packages.lock.json
 
 # Analyze a RubyGems lockfile and return a verbose response with only critical malware

--- a/doc_templates/phylum_group_create.md
+++ b/doc_templates/phylum_group_create.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Create a new group named 'sample'
+# Create a new group named `sample`
 $ phylum group create sample
 ```

--- a/doc_templates/phylum_group_delete.md
+++ b/doc_templates/phylum_group_delete.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Delete an existing group named 'sample'
+# Delete an existing group named `sample`
 $ phylum group delete sample
 ```

--- a/doc_templates/phylum_group_member_list.md
+++ b/doc_templates/phylum_group_member_list.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# List all group members for the 'sample' group
+# List all group members for the `sample` group
 $ phylum group member --group sample list
 ```

--- a/doc_templates/phylum_history.md
+++ b/doc_templates/phylum_history.md
@@ -11,6 +11,6 @@ $ phylum history
 # View the analysis results of a historical job
 $ phylum history 338ea79f-0e82-4422-9769-4e583a84599f
 
-# View a list of analysis runs for the 'sample' project
+# View a list of analysis runs for the `sample` project
 $ phylum history --project sample
 ```

--- a/doc_templates/phylum_org_link.md
+++ b/doc_templates/phylum_org_link.md
@@ -1,0 +1,10 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# Set `sample` as the default organization for all future operations
+$ phylum org link sample
+```

--- a/doc_templates/phylum_org_link.md
+++ b/doc_templates/phylum_org_link.md
@@ -5,6 +5,9 @@
 ## Examples
 
 ```sh
+# Interactively select an organization for all future operations
+$ phylum org link
+
 # Set `sample` as the default organization for all future operations
 $ phylum org link sample
 ```

--- a/doc_templates/phylum_org_list.md
+++ b/doc_templates/phylum_org_list.md
@@ -1,0 +1,13 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# List all organizations the user is a member of
+$ phylum org list
+
+# List all organizations the user is a member of with json output
+$ phylum org list --json
+```

--- a/doc_templates/phylum_org_member_add.md
+++ b/doc_templates/phylum_org_member_add.md
@@ -1,0 +1,10 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# Add user `demo@phylum.io` to the `sample` organization
+$ phylum org -o sample member add demo@phylum.io
+```

--- a/doc_templates/phylum_org_member_list.md
+++ b/doc_templates/phylum_org_member_list.md
@@ -1,0 +1,10 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# List all organization members for the `sample` organization
+$ phylum org -o sample member list
+```

--- a/doc_templates/phylum_org_member_remove.md
+++ b/doc_templates/phylum_org_member_remove.md
@@ -1,0 +1,10 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# Remove user `demo@phylum.io` from the `sample` organization
+$ phylum org -o sample member remove demo@phylum.io
+```

--- a/doc_templates/phylum_org_unlink.md
+++ b/doc_templates/phylum_org_unlink.md
@@ -1,0 +1,10 @@
+{PH-HEADER}
+
+{PH-MARKDOWN}
+
+## Examples
+
+```sh
+# Clear the default organization used by the CLI
+$ phylum org unlink
+```

--- a/doc_templates/phylum_project_create.md
+++ b/doc_templates/phylum_project_create.md
@@ -5,9 +5,9 @@
 ## Examples
 
 ```sh
-# Create a new project named 'sample'
+# Create a new project named `sample`
 $ phylum project create sample
 
-# Create a new project named 'sample' owned by the group 'sGroup'
+# Create a new project named `sample` owned by the group `sGroup`
 $ phylum project create -g sGroup sample
 ```

--- a/doc_templates/phylum_project_link.md
+++ b/doc_templates/phylum_project_link.md
@@ -5,9 +5,9 @@
 ## Examples
 
 ```sh
-# Link current folder to an existing project named 'sample'
+# Link current folder to an existing project named `sample`
 $ phylum project link sample
 
-# Link current folder to an existing project named 'sample' owned by the group 'sGroup'
+# Link current folder to an existing project named `sample` owned by the group `sGroup`
 $ phylum project link -g sGroup sample
 ```

--- a/doc_templates/phylum_project_list.md
+++ b/doc_templates/phylum_project_list.md
@@ -11,6 +11,6 @@ $ phylum project list
 # List all existing projects with json output
 $ phylum project list --json
 
-# List all existing projects for the 'sample' group
+# List all existing projects for the `sample` group
 $ phylum project list -g sample
 ```

--- a/docs/commands/phylum.md
+++ b/docs/commands/phylum.md
@@ -20,6 +20,9 @@ Usage: phylum [OPTIONS] [COMMAND]
 `--no-check-certificate`
 &emsp; Don't validate the server certificate when performing api requests
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 
@@ -40,6 +43,7 @@ Usage: phylum [OPTIONS] [COMMAND]
 * [phylum group](./phylum_group.md)
 * [phylum history](./phylum_history.md)
 * [phylum init](./phylum_init.md)
+* [phylum org](./phylum_org.md)
 * [phylum package](./phylum_package.md)
 * [phylum parse](./phylum_parse.md)
 * [phylum ping](./phylum_ping.md)

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -35,6 +35,9 @@ Usage: phylum analyze [OPTIONS] [DEPENDENCY_FILE]...
 `--no-generation`
 &emsp; Disable generation of lockfiles from manifests
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -71,10 +71,10 @@ $ phylum analyze --json --verbose effective-pom.xml
 # Analyze a PyPI dependency file and apply a label
 $ phylum analyze --label test_branch requirements.txt
 
-# Analyze a Poetry lockfile and return the results to the 'sample' project
+# Analyze a Poetry lockfile and return the results to the `sample` project
 $ phylum analyze -p sample poetry.lock
 
-# Analyze a NuGet lockfile using the 'sample' project and 'sGroup' group
+# Analyze a NuGet lockfile using the `sample` project and `sGroup` group
 $ phylum analyze -p sample -g sGroup packages.lock.json
 
 # Analyze a RubyGems lockfile and return a verbose response with only critical malware

--- a/docs/commands/phylum_auth.md
+++ b/docs/commands/phylum_auth.md
@@ -8,6 +8,9 @@ Usage: phylum auth [OPTIONS] <COMMAND>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_list-tokens.md
+++ b/docs/commands/phylum_auth_list-tokens.md
@@ -11,6 +11,9 @@ Usage: phylum auth list-tokens [OPTIONS]
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_login.md
+++ b/docs/commands/phylum_auth_login.md
@@ -14,6 +14,9 @@ Usage: phylum auth login [OPTIONS]
 `-n`, `--token-name` `<token-name>`
 &emsp; Unique name for the new token that will be created
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_register.md
+++ b/docs/commands/phylum_auth_register.md
@@ -11,6 +11,9 @@ Usage: phylum auth register [OPTIONS]
 `-n`, `--token-name` `<token-name>`
 &emsp; Unique name for the new token that will be created
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_revoke-token.md
+++ b/docs/commands/phylum_auth_revoke-token.md
@@ -13,6 +13,9 @@ Usage: phylum auth revoke-token [OPTIONS] [TOKEN_NAME]...
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_set-token.md
+++ b/docs/commands/phylum_auth_set-token.md
@@ -13,6 +13,9 @@ Usage: phylum auth set-token [OPTIONS] [TOKEN]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_status.md
+++ b/docs/commands/phylum_auth_status.md
@@ -8,6 +8,9 @@ Usage: phylum auth status [OPTIONS]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_auth_token.md
+++ b/docs/commands/phylum_auth_token.md
@@ -11,6 +11,9 @@ Usage: phylum auth token [OPTIONS]
 `-b`, `--bearer`
 &emsp; Output the short-lived bearer token for the Phylum API
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_extension.md
+++ b/docs/commands/phylum_extension.md
@@ -8,6 +8,9 @@ Usage: phylum extension [OPTIONS] [COMMAND]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_extension_install.md
+++ b/docs/commands/phylum_extension_install.md
@@ -21,6 +21,9 @@ Usage: phylum extension install [OPTIONS] <PATH>
 `--overwrite`
 &emsp; Overwrite existing extension
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_extension_new.md
+++ b/docs/commands/phylum_extension_new.md
@@ -12,6 +12,9 @@ Usage: phylum extension new [OPTIONS] <PATH>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_extension_run.md
+++ b/docs/commands/phylum_extension_run.md
@@ -18,6 +18,9 @@ Usage: phylum extension run [OPTIONS] <PATH> [OPTIONS]...
 `-y`, `--yes`
 &emsp; Automatically accept requested permissions
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_extension_uninstall.md
+++ b/docs/commands/phylum_extension_uninstall.md
@@ -12,6 +12,9 @@ Usage: phylum extension uninstall [OPTIONS] <NAME>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_group_create.md
+++ b/docs/commands/phylum_group_create.md
@@ -28,6 +28,6 @@ Usage: phylum group create [OPTIONS] <GROUP_NAME>
 ## Examples
 
 ```sh
-# Create a new group named 'sample'
+# Create a new group named `sample`
 $ phylum group create sample
 ```

--- a/docs/commands/phylum_group_create.md
+++ b/docs/commands/phylum_group_create.md
@@ -13,6 +13,9 @@ Usage: phylum group create [OPTIONS] <GROUP_NAME>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_group_delete.md
+++ b/docs/commands/phylum_group_delete.md
@@ -13,6 +13,9 @@ Usage: phylum group delete [OPTIONS] <GROUP_NAME>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_group_delete.md
+++ b/docs/commands/phylum_group_delete.md
@@ -28,6 +28,6 @@ Usage: phylum group delete [OPTIONS] <GROUP_NAME>
 ## Examples
 
 ```sh
-# Delete an existing group named 'sample'
+# Delete an existing group named `sample`
 $ phylum group delete sample
 ```

--- a/docs/commands/phylum_group_list.md
+++ b/docs/commands/phylum_group_list.md
@@ -11,6 +11,9 @@ Usage: phylum group list [OPTIONS]
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_group_member.md
+++ b/docs/commands/phylum_group_member.md
@@ -9,7 +9,10 @@ Usage: phylum group member [OPTIONS] --group <GROUP> <COMMAND>
 ## Options
 
 `-g`, `--group` `<GROUP>`
-&emsp; Group to list the members for
+&emsp; Group to manage the members for
+
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
 
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/commands/phylum_group_member_add.md
+++ b/docs/commands/phylum_group_member_add.md
@@ -13,6 +13,9 @@ Usage: phylum group member --group <GROUP> add [OPTIONS] <USER>...
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_group_member_list.md
+++ b/docs/commands/phylum_group_member_list.md
@@ -26,6 +26,6 @@ Usage: phylum group member --group <GROUP> list [OPTIONS]
 ## Examples
 
 ```sh
-# List all group members for the 'sample' group
+# List all group members for the `sample` group
 $ phylum group member --group sample list
 ```

--- a/docs/commands/phylum_group_member_list.md
+++ b/docs/commands/phylum_group_member_list.md
@@ -11,6 +11,9 @@ Usage: phylum group member --group <GROUP> list [OPTIONS]
 `-j`, `--json`
 &emsp; Produce member list in json format (default: false)
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_history.md
+++ b/docs/commands/phylum_history.md
@@ -22,6 +22,9 @@ Usage: phylum history [OPTIONS] [JOB_ID]
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group to be queried
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_history.md
+++ b/docs/commands/phylum_history.md
@@ -43,6 +43,6 @@ $ phylum history
 # View the analysis results of a historical job
 $ phylum history 338ea79f-0e82-4422-9769-4e583a84599f
 
-# View a list of analysis runs for the 'sample' project
+# View a list of analysis runs for the `sample` project
 $ phylum history --project sample
 ```

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -29,6 +29,9 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 `-r`, `--repository-url` `<REPOSITORY_URL>`
 &emsp; Repository URL of the project
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_org.md
+++ b/docs/commands/phylum_org.md
@@ -1,20 +1,12 @@
-# phylum auth create-token
+# phylum org
 
-Create a new API token
+Manage organizations
 
 ```sh
-Usage: phylum auth create-token [OPTIONS] <TOKEN_NAME>
+Usage: phylum org [OPTIONS] <COMMAND>
 ```
 
-## Arguments
-
-`<TOKEN_NAME>`
-&emsp; Unique name to identify the new token
-
 ## Options
-
-`-e`, `--expiry` `<DAYS>`
-&emsp; Number of days the token will be valid
 
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization
@@ -27,3 +19,10 @@ Usage: phylum auth create-token [OPTIONS] <TOKEN_NAME>
 
 `-h`, `--help`
 &emsp; Print help
+
+## Commands
+
+* [phylum org link](./phylum_org_link.md)
+* [phylum org list](./phylum_org_list.md)
+* [phylum org member](./phylum_org_member.md)
+* [phylum org unlink](./phylum_org_unlink.md)

--- a/docs/commands/phylum_org_link.md
+++ b/docs/commands/phylum_org_link.md
@@ -1,15 +1,17 @@
-# phylum extension list
+# phylum org link
 
-List installed extensions
+Select an organization as default for all operations
 
 ```sh
-Usage: phylum extension list [OPTIONS]
+Usage: phylum org link [OPTIONS] <ORG>
 ```
 
-## Options
+## Arguments
 
-`-o`, `--org` `<ORG>`
-&emsp; Phylum organization
+`<ORG>`
+&emsp; Organization to use as default
+
+## Options
 
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)

--- a/docs/commands/phylum_org_link.md
+++ b/docs/commands/phylum_org_link.md
@@ -25,6 +25,9 @@ Usage: phylum org link [OPTIONS] [ORG]
 ## Examples
 
 ```sh
+# Interactively select an organization for all future operations
+$ phylum org link
+
 # Set `sample` as the default organization for all future operations
 $ phylum org link sample
 ```

--- a/docs/commands/phylum_org_link.md
+++ b/docs/commands/phylum_org_link.md
@@ -21,3 +21,10 @@ Usage: phylum org link [OPTIONS] <ORG>
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# Set `sample` as the default organization for all future operations
+$ phylum org link sample
+```

--- a/docs/commands/phylum_org_link.md
+++ b/docs/commands/phylum_org_link.md
@@ -3,12 +3,12 @@
 Select an organization as default for all operations
 
 ```sh
-Usage: phylum org link [OPTIONS] <ORG>
+Usage: phylum org link [OPTIONS] [ORG]
 ```
 
 ## Arguments
 
-`<ORG>`
+`[ORG]`
 &emsp; Organization to use as default
 
 ## Options

--- a/docs/commands/phylum_org_list.md
+++ b/docs/commands/phylum_org_list.md
@@ -22,3 +22,13 @@ Usage: phylum org list [OPTIONS]
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# List all organizations the user is a member of
+$ phylum org list
+
+# List all organizations the user is a member of with json output
+$ phylum org list --json
+```

--- a/docs/commands/phylum_org_list.md
+++ b/docs/commands/phylum_org_list.md
@@ -1,20 +1,15 @@
-# phylum auth create-token
+# phylum org list
 
-Create a new API token
+List all organizations the user is a member of
 
 ```sh
-Usage: phylum auth create-token [OPTIONS] <TOKEN_NAME>
+Usage: phylum org list [OPTIONS]
 ```
-
-## Arguments
-
-`<TOKEN_NAME>`
-&emsp; Unique name to identify the new token
 
 ## Options
 
-`-e`, `--expiry` `<DAYS>`
-&emsp; Number of days the token will be valid
+`-j`, `--json`
+&emsp; Produce output in json format (default: false)
 
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization

--- a/docs/commands/phylum_org_member.md
+++ b/docs/commands/phylum_org_member.md
@@ -1,9 +1,9 @@
-# phylum group
+# phylum org member
 
-Interact with user groups
+Manage organization members
 
 ```sh
-Usage: phylum group [OPTIONS] <COMMAND>
+Usage: phylum org member [OPTIONS] <COMMAND>
 ```
 
 ## Options
@@ -22,7 +22,6 @@ Usage: phylum group [OPTIONS] <COMMAND>
 
 ## Commands
 
-* [phylum group create](./phylum_group_create.md)
-* [phylum group delete](./phylum_group_delete.md)
-* [phylum group list](./phylum_group_list.md)
-* [phylum group member](./phylum_group_member.md)
+* [phylum org member add](./phylum_org_member_add.md)
+* [phylum org member list](./phylum_org_member_list.md)
+* [phylum org member remove](./phylum_org_member_remove.md)

--- a/docs/commands/phylum_org_member_add.md
+++ b/docs/commands/phylum_org_member_add.md
@@ -24,3 +24,10 @@ Usage: phylum org member add [OPTIONS] <USER>...
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# Add user `demo@phylum.io` to the `sample` organization
+$ phylum org -o sample member add demo@phylum.io
+```

--- a/docs/commands/phylum_org_member_add.md
+++ b/docs/commands/phylum_org_member_add.md
@@ -1,15 +1,15 @@
-# phylum group member remove
+# phylum org member add
 
-Remove user from group
+Add user to organization
 
 ```sh
-Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
+Usage: phylum org member add [OPTIONS] <USER>...
 ```
 
 ## Arguments
 
 `<USER>`
-&emsp; User(s) to be removed
+&emsp; User(s) to be added
 
 ## Options
 
@@ -24,10 +24,3 @@ Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
 
 `-h`, `--help`
 &emsp; Print help
-
-## Examples
-
-```sh
-# Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group sample remove demo@phylum.io
-```

--- a/docs/commands/phylum_org_member_list.md
+++ b/docs/commands/phylum_org_member_list.md
@@ -22,3 +22,10 @@ Usage: phylum org member list [OPTIONS]
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# List all organization members for the `sample` organization
+$ phylum org -o sample member list
+```

--- a/docs/commands/phylum_org_member_list.md
+++ b/docs/commands/phylum_org_member_list.md
@@ -1,20 +1,15 @@
-# phylum auth create-token
+# phylum org member list
 
-Create a new API token
+List organization members
 
 ```sh
-Usage: phylum auth create-token [OPTIONS] <TOKEN_NAME>
+Usage: phylum org member list [OPTIONS]
 ```
-
-## Arguments
-
-`<TOKEN_NAME>`
-&emsp; Unique name to identify the new token
 
 ## Options
 
-`-e`, `--expiry` `<DAYS>`
-&emsp; Number of days the token will be valid
+`-j`, `--json`
+&emsp; Produce member list in json format (default: false)
 
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization

--- a/docs/commands/phylum_org_member_remove.md
+++ b/docs/commands/phylum_org_member_remove.md
@@ -24,3 +24,10 @@ Usage: phylum org member remove [OPTIONS] <USER>...
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# Remove user `demo@phylum.io` from the `sample` organization
+$ phylum org -o sample member remove demo@phylum.io
+```

--- a/docs/commands/phylum_org_member_remove.md
+++ b/docs/commands/phylum_org_member_remove.md
@@ -1,9 +1,9 @@
-# phylum group member remove
+# phylum org member remove
 
-Remove user from group
+Remove user from organization
 
 ```sh
-Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
+Usage: phylum org member remove [OPTIONS] <USER>...
 ```
 
 ## Arguments
@@ -24,10 +24,3 @@ Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
 
 `-h`, `--help`
 &emsp; Print help
-
-## Examples
-
-```sh
-# Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group sample remove demo@phylum.io
-```

--- a/docs/commands/phylum_org_unlink.md
+++ b/docs/commands/phylum_org_unlink.md
@@ -1,20 +1,12 @@
-# phylum auth create-token
+# phylum org unlink
 
-Create a new API token
+Clear the configured default organization
 
 ```sh
-Usage: phylum auth create-token [OPTIONS] <TOKEN_NAME>
+Usage: phylum org unlink [OPTIONS]
 ```
 
-## Arguments
-
-`<TOKEN_NAME>`
-&emsp; Unique name to identify the new token
-
 ## Options
-
-`-e`, `--expiry` `<DAYS>`
-&emsp; Number of days the token will be valid
 
 `-o`, `--org` `<ORG>`
 &emsp; Phylum organization

--- a/docs/commands/phylum_org_unlink.md
+++ b/docs/commands/phylum_org_unlink.md
@@ -19,3 +19,10 @@ Usage: phylum org unlink [OPTIONS]
 
 `-h`, `--help`
 &emsp; Print help
+
+## Examples
+
+```sh
+# Clear the default organization used by the CLI
+$ phylum org unlink
+```

--- a/docs/commands/phylum_package.md
+++ b/docs/commands/phylum_package.md
@@ -34,6 +34,9 @@ Usage: phylum package [OPTIONS] <TYPE> <NAME> <VERSION>
 &nbsp;&nbsp;&nbsp;&nbsp;and 'engineering' domains
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;--filter=crit,aut,eng
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_parse.md
+++ b/docs/commands/phylum_parse.md
@@ -23,6 +23,9 @@ Usage: phylum parse [OPTIONS] [DEPENDENCY_FILE]...
 `--no-generation`
 &emsp; Disable generation of lockfiles from manifests
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_ping.md
+++ b/docs/commands/phylum_ping.md
@@ -8,6 +8,9 @@ Usage: phylum ping [OPTIONS]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project.md
+++ b/docs/commands/phylum_project.md
@@ -8,6 +8,9 @@ Usage: phylum project [OPTIONS] <COMMAND>
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_create.md
+++ b/docs/commands/phylum_project_create.md
@@ -19,6 +19,9 @@ Usage: phylum project create [OPTIONS] <NAME>
 `-r`, `--repository-url` `<repository_url>`
 &emsp; Repository URL of the project
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_create.md
+++ b/docs/commands/phylum_project_create.md
@@ -34,9 +34,9 @@ Usage: phylum project create [OPTIONS] <NAME>
 ## Examples
 
 ```sh
-# Create a new project named 'sample'
+# Create a new project named `sample`
 $ phylum project create sample
 
-# Create a new project named 'sample' owned by the group 'sGroup'
+# Create a new project named `sample` owned by the group `sGroup`
 $ phylum project create -g sGroup sample
 ```

--- a/docs/commands/phylum_project_delete.md
+++ b/docs/commands/phylum_project_delete.md
@@ -16,6 +16,9 @@ Usage: phylum project delete [OPTIONS] <NAME>
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group that owns the project
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_link.md
+++ b/docs/commands/phylum_project_link.md
@@ -31,9 +31,9 @@ Usage: phylum project link [OPTIONS] <NAME>
 ## Examples
 
 ```sh
-# Link current folder to an existing project named 'sample'
+# Link current folder to an existing project named `sample`
 $ phylum project link sample
 
-# Link current folder to an existing project named 'sample' owned by the group 'sGroup'
+# Link current folder to an existing project named `sample` owned by the group `sGroup`
 $ phylum project link -g sGroup sample
 ```

--- a/docs/commands/phylum_project_link.md
+++ b/docs/commands/phylum_project_link.md
@@ -16,6 +16,9 @@ Usage: phylum project link [OPTIONS] <NAME>
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group owning the project
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_list.md
+++ b/docs/commands/phylum_project_list.md
@@ -14,6 +14,9 @@ Usage: phylum project list [OPTIONS]
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Group to list projects for
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_list.md
+++ b/docs/commands/phylum_project_list.md
@@ -35,6 +35,6 @@ $ phylum project list
 # List all existing projects with json output
 $ phylum project list --json
 
-# List all existing projects for the 'sample' group
+# List all existing projects for the `sample` group
 $ phylum project list -g sample
 ```

--- a/docs/commands/phylum_project_status.md
+++ b/docs/commands/phylum_project_status.md
@@ -17,6 +17,9 @@ Usage: phylum project status [OPTIONS]
 `-g`, `--group` `<GROUP_NAME>`
 &emsp; Specify a group to use for analysis
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_project_update.md
+++ b/docs/commands/phylum_project_update.md
@@ -20,6 +20,9 @@ Usage: phylum project update [OPTIONS]
 `-r`, `--repository-url` `<REPOSITORY_URL>`
 &emsp; New repository URL
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_status.md
+++ b/docs/commands/phylum_status.md
@@ -11,6 +11,9 @@ Usage: phylum status [OPTIONS]
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_uninstall.md
+++ b/docs/commands/phylum_uninstall.md
@@ -11,6 +11,9 @@ Usage: phylum uninstall [OPTIONS]
 `-p`, `--purge`
 &emsp; Remove all files, including configuration files (default: false)
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_update.md
+++ b/docs/commands/phylum_update.md
@@ -8,6 +8,9 @@ Usage: phylum update [OPTIONS]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 

--- a/docs/commands/phylum_version.md
+++ b/docs/commands/phylum_version.md
@@ -8,6 +8,9 @@ Usage: phylum version [OPTIONS]
 
 ## Options
 
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
 `-v`, `--verbose`...
 &emsp; Increase the level of verbosity (the maximum is -vvv)
 


### PR DESCRIPTION
This patch adds the new `phylum org` subcommand, which allows for listing organizations (`phylum org list`) and managing organization members (`phylum org member`).

Since the organization will likely be relevant for most of the subcommands in the future, a global `-o`/`--org` option has been added to allow for easily overriding the target operation.

Most users will likely always operate under the same organization, so the `phylum org link` and `phylum org unlink` subcommands were added to allow for managing a default organization for all subcommands.