### PR TITLE
Build without sandboxing on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
   # This job reports the results of the matrixes above
   test:
     if: always()
-    needs: [clippy, test-matrix, all-features, oldstable]
+    needs: [windows, clippy, test-matrix, all-features, oldstable]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,18 @@ on:
     - cron: '30 5 * * 1'
 
 jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update stable --profile minimal
+
+      - name: Test
+        run: cargo +stable test --workspace --exclude xtask --locked --no-default-features
+
   rustfmt:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup toolchain install --no-self-update stable --profile minimal
 
       - name: Test
-        run: cargo +stable test --workspace --exclude xtask --locked --no-default-features
+        run: cargo +stable test --locked --no-default-features
 
   rustfmt:
     if: github.event_name != 'schedule'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,13 +702,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.105"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -5630,6 +5630,12 @@ checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,6 @@ end-to-end-tests = ["extensions"]
 anyhow = "1.0.44"
 axum = "0.7.4"
 base64 = "0.21.1"
-birdcage = { version = "0.8.1" }
 bytes = "1.1.0"
 chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
 cidr = "0.2.0"
@@ -70,6 +69,9 @@ vuln-reach = { git = "https://github.com/phylum-dev/vuln-reach", optional = true
 vulnreach_types = { path = "../vulnreach_types", optional = true }
 walkdir = "2.3.2"
 zip = { version = "2.1.0", default-features = false, features = ["deflate"] }
+
+[target.'cfg(unix)'.dependencies]
+birdcage = { version = "0.8.1" }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -88,6 +88,7 @@ pub fn app() -> Command {
 
 /// Add non-extension subcommands.
 pub fn add_subcommands(command: Command) -> Command {
+    #[allow(unused_mut)]
     let mut app = command
         .subcommand(
             Command::new("history").about("Return information about historical jobs").args(&[

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -572,34 +572,6 @@ pub fn add_subcommands(command: Command) -> Command {
                 .hide(true),
         )
         .subcommand(
-            Command::new("parse-sandboxed")
-                .args(&[
-                    Arg::new("depfile")
-                        .value_name("DEPENDENCY_FILE")
-                        .required(true)
-                        .help("Canonical dependency file path"),
-                    Arg::new("display-path")
-                        .value_name("DISPLAY_PATH")
-                        .required(true)
-                        .help("Dependency file display path"),
-                    Arg::new("type")
-                        .long("type")
-                        .value_name("TYPE")
-                        .help("Dependency file type used (default: auto)")
-                        .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
-                    Arg::new("generate-lockfile")
-                        .long("generate-lockfile")
-                        .help("Whether lockfile generation should be performed")
-                        .action(ArgAction::SetTrue),
-                    Arg::new("skip-sandbox")
-                        .long("skip-sandbox")
-                        .help("Skip sandbox initialization")
-                        .action(ArgAction::SetTrue),
-                ])
-                .about("Run lockfile generation inside sandbox and write it to STDOUT")
-                .hide(true),
-        )
-        .subcommand(
             Command::new("org")
                 .about("Manage organizations")
                 .arg_required_else_help(true)
@@ -666,50 +638,84 @@ pub fn add_subcommands(command: Command) -> Command {
 
     #[cfg(unix)]
     {
-        app = app.subcommand(
-            Command::new("sandbox").hide(true).about("Run an application in a sandbox").args(&[
-                Arg::new("allow-read")
-                    .help("Add filesystem read sandbox exception")
-                    .long("allow-read")
-                    .value_name("PATH")
-                    .value_hint(ValueHint::FilePath)
-                    .action(ArgAction::Append),
-                Arg::new("allow-write")
-                    .help("Add filesystem write sandbox exception")
-                    .long("allow-write")
-                    .value_name("PATH")
-                    .value_hint(ValueHint::FilePath)
-                    .action(ArgAction::Append),
-                Arg::new("allow-run")
-                    .help("Add filesystem execute sandbox exception")
-                    .long("allow-run")
-                    .value_name("PATH")
-                    .value_hint(ValueHint::FilePath)
-                    .action(ArgAction::Append),
-                Arg::new("allow-env")
-                    .help("Add environment variable access sandbox exception")
-                    .long("allow-env")
-                    .value_name("ENV_VAR")
-                    .num_args(0..=1)
-                    .default_missing_value("*")
-                    .action(ArgAction::Append),
-                Arg::new("allow-net")
-                    .help("Add network access sandbox exception")
-                    .long("allow-net")
-                    .action(ArgAction::SetTrue),
-                Arg::new("strict")
-                    .help("Do not add any default sandbox exceptions")
-                    .long("strict")
-                    .action(ArgAction::SetTrue),
-                Arg::new("cmd").help("Command to be executed").value_name("CMD").required(true),
-                Arg::new("args")
-                    .help("Command arguments")
-                    .value_name("ARG")
-                    .trailing_var_arg(true)
-                    .allow_hyphen_values(true)
-                    .action(ArgAction::Append),
-            ]),
-        )
+        app = app
+            .subcommand(
+                Command::new("sandbox").hide(true).about("Run an application in a sandbox").args(
+                    &[
+                        Arg::new("allow-read")
+                            .help("Add filesystem read sandbox exception")
+                            .long("allow-read")
+                            .value_name("PATH")
+                            .value_hint(ValueHint::FilePath)
+                            .action(ArgAction::Append),
+                        Arg::new("allow-write")
+                            .help("Add filesystem write sandbox exception")
+                            .long("allow-write")
+                            .value_name("PATH")
+                            .value_hint(ValueHint::FilePath)
+                            .action(ArgAction::Append),
+                        Arg::new("allow-run")
+                            .help("Add filesystem execute sandbox exception")
+                            .long("allow-run")
+                            .value_name("PATH")
+                            .value_hint(ValueHint::FilePath)
+                            .action(ArgAction::Append),
+                        Arg::new("allow-env")
+                            .help("Add environment variable access sandbox exception")
+                            .long("allow-env")
+                            .value_name("ENV_VAR")
+                            .num_args(0..=1)
+                            .default_missing_value("*")
+                            .action(ArgAction::Append),
+                        Arg::new("allow-net")
+                            .help("Add network access sandbox exception")
+                            .long("allow-net")
+                            .action(ArgAction::SetTrue),
+                        Arg::new("strict")
+                            .help("Do not add any default sandbox exceptions")
+                            .long("strict")
+                            .action(ArgAction::SetTrue),
+                        Arg::new("cmd")
+                            .help("Command to be executed")
+                            .value_name("CMD")
+                            .required(true),
+                        Arg::new("args")
+                            .help("Command arguments")
+                            .value_name("ARG")
+                            .trailing_var_arg(true)
+                            .allow_hyphen_values(true)
+                            .action(ArgAction::Append),
+                    ],
+                ),
+            )
+            .subcommand(
+                Command::new("parse-sandboxed")
+                    .args(&[
+                        Arg::new("depfile")
+                            .value_name("DEPENDENCY_FILE")
+                            .required(true)
+                            .help("Canonical dependency file path"),
+                        Arg::new("display-path")
+                            .value_name("DISPLAY_PATH")
+                            .required(true)
+                            .help("Dependency file display path"),
+                        Arg::new("type")
+                            .long("type")
+                            .value_name("TYPE")
+                            .help("Dependency file type used (default: auto)")
+                            .value_parser(PossibleValuesParser::new(parse::lockfile_types(true))),
+                        Arg::new("generate-lockfile")
+                            .long("generate-lockfile")
+                            .help("Whether lockfile generation should be performed")
+                            .action(ArgAction::SetTrue),
+                        Arg::new("skip-sandbox")
+                            .long("skip-sandbox")
+                            .help("Skip sandbox initialization")
+                            .action(ArgAction::SetTrue),
+                    ])
+                    .about("Run lockfile generation inside sandbox and write it to STDOUT")
+                    .hide(true),
+            );
     }
 
     #[cfg(feature = "selfmanage")]

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -131,6 +131,7 @@ async fn handle_commands() -> CommandResult {
         },
         "version" => handle_version(&app_name, &ver),
         "parse" => parse::handle_parse(sub_matches),
+        #[cfg(unix)]
         "parse-sandboxed" => parse::handle_parse_sandboxed(sub_matches),
         "ping" => handle_ping(Spinner::wrap(api).await?).await,
         "project" => {

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -127,6 +127,7 @@ fn spawn_sandbox(
 }
 
 /// Handle dependency file parsing inside of our sandbox.
+#[cfg(unix)]
 fn child_parse_depfile(
     path: &PathBuf,
     display_path: &str,
@@ -501,6 +502,7 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
 }
 
 /// Get all JDK paths in `/etc`.
+#[cfg(unix)]
 fn jdk_paths() -> Result<Vec<PathBuf>> {
     let paths: Vec<_> = fs::read_dir("/etc")?
         .flatten()

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -160,9 +160,7 @@ impl Display for Error {
             Self::NonZeroExit(output) => {
                 write!(f, "package manager quit unexpectedly (code: {:?}", output.status.code())?;
                 #[cfg(unix)]
-                {
-                    write!(f, ", signal: {:?}", output.status.signal())?;
-                }
+                write!(f, ", signal: {:?}", output.status.signal())?;
                 write!(f, ")")?;
 
                 if !output.stderr.is_empty() {

--- a/lockfile_generator/src/lib.rs
+++ b/lockfile_generator/src/lib.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
+#[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf, StripPrefixError};
 use std::process::{Command, Output, Stdio};
@@ -157,12 +158,12 @@ impl Display for Error {
             Self::Io(_) => write!(f, "I/O error"),
             Self::Json(_) => write!(f, "json parsing error"),
             Self::NonZeroExit(output) => {
-                write!(
-                    f,
-                    "package manager quit unexpectedly (code: {:?}, signal: {:?})",
-                    output.status.code(),
-                    output.status.signal()
-                )?;
+                write!(f, "package manager quit unexpectedly (code: {:?}", output.status.code())?;
+                #[cfg(unix)]
+                {
+                    write!(f, ", signal: {:?}", output.status.signal())?;
+                }
+                write!(f, ")")?;
 
                 if !output.stderr.is_empty() {
                     write!(f, "\n    STDERR:")?;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["selfmanage"]
-selfmanage = ["phylum-cli/selfmanage"]
+default = ["full-docs"]
+# Enable any CLI features that change the available commands
+full-docs = ["phylum-cli/selfmanage", "phylum-cli/extensions"]
 
 [dependencies]
 anyhow = "1.0.53"

--- a/xtask/src/gendocs.rs
+++ b/xtask/src/gendocs.rs
@@ -73,6 +73,7 @@ mod tests {
     use super::*;
 
     /// Ensure the generate CLI docs are always up-to-date.
+    #[cfg(feature = "full-docs")]
     #[test]
     fn docs_up_to_date() {
         // Move to project root.


### PR DESCRIPTION
With this patch, all sandboxing code is guarded by `#[cfg(unix)]`.