### PR TITLE
Add org support for init/project/analyze/history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Organization management under the `phylum org` subcommand
+- Organization support for existing subcommands
 - `phylum project update --default-label` option to set a project's default label
 - `phylum project list --no-group` flag to only show personal projects
-- Organization support for `phylum group` subcommands
 
 ### Removed
 

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -261,14 +261,21 @@ impl PhylumApi {
     pub async fn create_project(
         &self,
         name: impl Into<String>,
+        org: Option<&str>,
         group: Option<String>,
         repository_url: Option<String>,
     ) -> Result<ProjectId> {
+        let group_name = match (org, group) {
+            (Some(org), Some(group)) => Some(format!("{org}/{group}")),
+            (None, Some(group)) => Some(group),
+            (Some(_), None) | (None, None) => None,
+        };
+
         let url = endpoints::create_project(&self.config.connection.uri)?;
         let body = CreateProjectRequest {
             repository_url,
+            group_name,
             default_label: None,
-            group_name: group,
             name: name.into(),
         };
         let response: CreateProjectResponse = self.post(url, body).await?;
@@ -279,18 +286,21 @@ impl PhylumApi {
     pub async fn update_project(
         &self,
         project_id: &str,
+        org: Option<String>,
         group: Option<String>,
         name: impl Into<String>,
         repository_url: Option<String>,
         default_label: Option<String>,
     ) -> Result<ProjectId> {
-        let url = endpoints::project(&self.config.connection.uri, project_id)?;
-        let body = UpdateProjectRequest {
-            repository_url,
-            default_label,
-            name: name.into(),
-            group_name: group,
+        let group_name = match (org, group) {
+            (Some(org), Some(group)) => Some(format!("{org}/{group}")),
+            (None, Some(group)) => Some(group),
+            (Some(_), None) | (None, None) => None,
         };
+
+        let url = endpoints::project(&self.config.connection.uri, project_id)?;
+        let body =
+            UpdateProjectRequest { repository_url, default_label, name: name.into(), group_name };
         let response: CreateProjectResponse = self.put(url, body).await?;
         Ok(response.id)
     }
@@ -312,14 +322,24 @@ impl PhylumApi {
     /// equivalent to filtering with [`str::contains`].
     pub async fn get_projects(
         &self,
+        org: Option<&str>,
         group: Option<&str>,
         name_filter: Option<&str>,
     ) -> Result<Vec<ProjectListEntry>> {
         let mut uri = endpoints::projects(&self.config.connection.uri)?;
 
         // Add filter query parameters.
-        if let Some(group) = group {
-            uri.query_pairs_mut().append_pair("filter.group", group);
+        match (org, group) {
+            (Some(org), Some(group)) => {
+                uri.query_pairs_mut().append_pair("filter.group", &format!("{org}/{group}"));
+            },
+            (Some(org), None) => {
+                uri.query_pairs_mut().append_pair("filter.organization", org);
+            },
+            (None, Some(group)) => {
+                uri.query_pairs_mut().append_pair("filter.group", group);
+            },
+            (None, None) => (),
         }
         if let Some(name_filter) = name_filter {
             uri.query_pairs_mut().append_pair("filter.name", name_filter);
@@ -415,19 +435,11 @@ impl PhylumApi {
     pub async fn get_project_history(
         &self,
         project_name: &str,
+        org_name: Option<&str>,
         group_name: Option<&str>,
     ) -> Result<Vec<HistoryJob>> {
-        let project_id = self.get_project_id(project_name, group_name).await?.to_string();
-
-        let url = match group_name {
-            Some(group_name) => endpoints::get_group_project_history(
-                &self.config.connection.uri,
-                &project_id,
-                group_name,
-            )?,
-            None => endpoints::get_project_history(&self.config.connection.uri, &project_id)?,
-        };
-
+        let project_id = self.get_project_id(project_name, org_name, group_name).await?.to_string();
+        let url = endpoints::get_project_history(&self.config.connection.uri, &project_id)?;
         self.get(url).await
     }
 
@@ -435,9 +447,10 @@ impl PhylumApi {
     pub async fn get_project_id(
         &self,
         project_name: &str,
+        org_name: Option<&str>,
         group_name: Option<&str>,
     ) -> Result<ProjectId> {
-        let projects = self.get_projects(group_name, Some(project_name)).await?;
+        let projects = self.get_projects(org_name, group_name, Some(project_name)).await?;
 
         projects
             .iter()

--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -596,16 +596,6 @@ pub enum Group {
 }
 
 impl Group {
-    /// Create a new group.
-    fn new(org: String, group: String) -> Self {
-        Self::Org(OrgGroup { org, name: group })
-    }
-
-    /// Create a group without organization.
-    fn new_legacy(group: String) -> Self {
-        Self::Legacy(group)
-    }
-
     /// Create a group from an optional group name.
     pub fn try_new<O, G>(org: Option<O>, group: Option<G>) -> Option<Self>
     where
@@ -613,8 +603,8 @@ impl Group {
         G: Into<String>,
     {
         group.map(|group| match org {
-            Some(org) => Self::new(org.into(), group.into()),
-            None => Self::new_legacy(group.into()),
+            Some(org) => Self::Org(OrgGroup { org: org.into(), name: group.into() }),
+            None => Self::Legacy(group.into()),
         })
     }
 

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -135,13 +135,14 @@ async fn handle_commands() -> CommandResult {
         "parse-sandboxed" => parse::handle_parse_sandboxed(sub_matches),
         "ping" => handle_ping(Spinner::wrap(api).await?).await,
         "project" => {
-            project::handle_project(&Spinner::wrap(api).await?, app_helper, sub_matches).await
+            project::handle_project(&Spinner::wrap(api).await?, app_helper, sub_matches, config)
+                .await
         },
         "package" => packages::handle_get_package(&Spinner::wrap(api).await?, sub_matches).await,
-        "history" => jobs::handle_history(&Spinner::wrap(api).await?, sub_matches).await,
+        "history" => jobs::handle_history(&Spinner::wrap(api).await?, sub_matches, config).await,
         "group" => group::handle_group(&Spinner::wrap(api).await?, sub_matches, config).await,
-        "analyze" => jobs::handle_analyze(&Spinner::wrap(api).await?, sub_matches).await,
-        "init" => init::handle_init(&Spinner::wrap(api).await?, sub_matches).await,
+        "analyze" => jobs::handle_analyze(&Spinner::wrap(api).await?, sub_matches, config).await,
+        "init" => init::handle_init(&Spinner::wrap(api).await?, sub_matches, config).await,
         "status" => status::handle_status(sub_matches).await,
         "org" => org::handle_org(&Spinner::wrap(api).await?, sub_matches, config).await,
 

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -24,7 +24,7 @@ use phylum_types::types::package::{PackageDescriptor, PackageDescriptorAndLockfi
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
-use crate::api::{Group, PhylumApiError, ResponseError};
+use crate::api::{PhylumApiError, ResponseError};
 use crate::auth::UserInfo;
 use crate::commands::extensions::state::ExtensionState;
 use crate::commands::parse;
@@ -175,8 +175,7 @@ async fn analyze(
 
     let (project, group) = match (project, group) {
         (Some(project), group) => {
-            let org_group = Group::try_new(organization, group);
-            (api.get_project_id(&project, org_group).await?, None)
+            (api.get_project_id(&project, organization.as_deref(), group.as_deref()).await?, None)
         },
         (None, _) => {
             if let Some(p) = phylum_project::get_current_project() {
@@ -369,13 +368,11 @@ async fn create_project(
     // Retrieve the id if the project already exists, otherwise return the id or the
     // error.
     match api.create_project(&name, organization.as_deref(), group.clone(), repository_url).await {
-        Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-            let org_group = Group::try_new(organization, group);
-            api.get_project_id(&name, org_group)
-                .await
-                .map(|id| CreatedProject { id, status: CreatedProjectStatus::Exists })
-                .map_err(|e| e.into())
-        },
+        Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => api
+            .get_project_id(&name, organization.as_deref(), group.as_deref())
+            .await
+            .map(|id| CreatedProject { id, status: CreatedProjectStatus::Exists })
+            .map_err(|e| e.into()),
         Err(e) => Err(e.into()),
         Ok(id) => Ok(CreatedProject { id, status: CreatedProjectStatus::Created }),
     }
@@ -392,8 +389,7 @@ async fn delete_project(
     let state = ExtensionState::from(op_state);
     let api = state.api().await?;
 
-    let org_group = Group::try_new(organization, group);
-    let project_id = api.get_project_id(&name, org_group).await?;
+    let project_id = api.get_project_id(&name, organization.as_deref(), group.as_deref()).await?;
     api.delete_project(project_id).await.map_err(|e| e.into())
 }
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -12,7 +12,7 @@ use phylum_lockfile::LockfileFormat;
 use phylum_project::{DepfileConfig, ProjectConfig, PROJ_CONF_FILE};
 use reqwest::StatusCode;
 
-use crate::api::{PhylumApi, PhylumApiError, ResponseError};
+use crate::api::{Group, PhylumApi, PhylumApiError, ResponseError};
 use crate::commands::{project, CommandResult, ExitCode};
 use crate::config::{self, Config};
 use crate::{print_user_success, print_user_warning};
@@ -64,8 +64,9 @@ pub async fn handle_init(api: &PhylumApi, matches: &ArgMatches, config: Config) 
     let mut project_config = match result {
         // If project already exists, try looking it up to link to it.
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
+            let org_group = Group::try_new(org, group.clone());
             let uuid = api
-                .get_project_id(&project, org, group.as_deref())
+                .get_project_id(&project, org_group)
                 .await
                 .context(format!("Could not find project {project:?}"))?;
             ProjectConfig::new(uuid, project, group)

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -12,7 +12,7 @@ use phylum_lockfile::LockfileFormat;
 use phylum_project::{DepfileConfig, ProjectConfig, PROJ_CONF_FILE};
 use reqwest::StatusCode;
 
-use crate::api::{Group, PhylumApi, PhylumApiError, ResponseError};
+use crate::api::{PhylumApi, PhylumApiError, ResponseError};
 use crate::commands::{project, CommandResult, ExitCode};
 use crate::config::{self, Config};
 use crate::{print_user_success, print_user_warning};
@@ -64,9 +64,8 @@ pub async fn handle_init(api: &PhylumApi, matches: &ArgMatches, config: Config) 
     let mut project_config = match result {
         // If project already exists, try looking it up to link to it.
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
-            let org_group = Group::try_new(org, group.clone());
             let uuid = api
-                .get_project_id(&project, org_group)
+                .get_project_id(&project, org, group.as_deref())
                 .await
                 .context(format!("Could not find project {project:?}"))?;
             ProjectConfig::new(uuid, project, group)

--- a/cli/src/commands/jobs.rs
+++ b/cli/src/commands/jobs.rs
@@ -14,7 +14,7 @@ use reqwest::StatusCode;
 #[cfg(feature = "vulnreach")]
 use vulnreach_types::{Job, JobPackage};
 
-use crate::api::{Group, PhylumApi};
+use crate::api::PhylumApi;
 #[cfg(feature = "vulnreach")]
 use crate::auth::jwt::RealmRole;
 use crate::commands::{parse, CommandResult, ExitCode};
@@ -71,9 +71,8 @@ pub async fn handle_history(
         return print_job_status(api, &job_id, [], pretty_print).await;
     } else if let Some(project) = matches.get_one::<String>("project") {
         let group = matches.get_one::<String>("group").map(String::as_str);
-        let org_group = Group::try_new(config.org(), group);
 
-        let history = api.get_project_history(project, org_group).await?;
+        let history = api.get_project_history(project, config.org(), group).await?;
 
         history.write_stdout(pretty_print);
     } else {
@@ -276,8 +275,8 @@ impl JobsProject {
             Some(project_name) => {
                 let group = matches.get_one::<String>("group").cloned();
 
-                let org_group = Group::try_new(config.org(), group.clone());
-                let project = api.get_project_id(project_name, org_group).await?;
+                let project =
+                    api.get_project_id(project_name, config.org(), group.as_deref()).await?;
 
                 Ok(Self { project_id: project, group, depfiles })
             },

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -252,7 +252,7 @@ async fn handle_update_project(
 
     api.update_project(
         &project_id,
-        None,
+        org.map(String::from),
         group_name.clone(),
         name.clone(),
         repository_url.clone(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -89,8 +89,8 @@ impl Config {
     }
 
     /// Check target organization.
-    pub fn org(&self) -> Option<&String> {
-        self.org_cli.as_ref().or(self.org.as_ref())
+    pub fn org(&self) -> Option<&str> {
+        self.org_cli.as_ref().or(self.org.as_ref()).map(|org| org.as_str())
     }
 
     /// Update the config organization.

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -176,8 +176,19 @@ impl Format for Vec<ProjectListEntry> {
             let _ = writeln!(writer, "{table}");
         } else {
             let table = format_table::<fn(&ProjectListEntry) -> String, _>(self, &[
+                ("Organization Name", |project| {
+                    match project.group_name.as_deref().unwrap_or("").split_once('/') {
+                        Some((org_name, _)) => {
+                            print::truncate(org_name, MAX_NAME_WIDTH).into_owned()
+                        },
+                        None => String::new(),
+                    }
+                }),
                 ("Group Name", |project| {
-                    let group_name = project.group_name.as_deref().unwrap_or("");
+                    let org_and_group = project.group_name.as_deref().unwrap_or("");
+                    let group_name = org_and_group
+                        .split_once('/')
+                        .map_or(org_and_group, |(_, group_name)| group_name);
                     print::truncate(group_name, MAX_NAME_WIDTH).into_owned()
                 }),
                 ("Project Name", |project| {

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -524,11 +524,11 @@ pub struct GetProjectResponse {
 /// Response body for Phylum's GET /organizations/<org>/groups endpoint.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct OrgGroupsResponse {
-    pub groups: Vec<OrgGroup>,
+    pub groups: Vec<ApiOrgGroup>,
 }
 
 /// Group returned by Phylum's GET /organizations/<org>/groups endpoint.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
-pub struct OrgGroup {
+pub struct ApiOrgGroup {
     pub name: String,
 }

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -239,7 +239,7 @@ pub async fn create_project() -> &'static str {
 
     // Attempt to create the project, ignoring conflicts.
     let api = PhylumApi::new(config, None).await.unwrap();
-    match api.create_project(PROJECT_NAME, None, None).await {
+    match api.create_project(PROJECT_NAME, None, None, None).await {
         Ok(_) | Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
         },
         err @ Err(_) => {

--- a/doc_templates/phylum_history.md
+++ b/doc_templates/phylum_history.md
@@ -13,4 +13,7 @@ $ phylum history 338ea79f-0e82-4422-9769-4e583a84599f
 
 # View a list of analysis runs for the `sample` project
 $ phylum history --project sample
+
+# Show analysis runs for the `sample` project of the `demo` group under the `test` org
+$ phylum history --org test --group demo --project sample
 ```

--- a/doc_templates/phylum_init.md
+++ b/doc_templates/phylum_init.md
@@ -10,4 +10,7 @@ $ phylum init
 
 # Create the `demo` project with a yarn lockfile and no associated group.
 $ phylum init --dependency-file yarn.lock --type yarn demo
+
+# Create the `demo` project in the `sample` group of the `test` organization.
+$ phylum init --org test --group sample demo
 ```

--- a/doc_templates/phylum_project_list.md
+++ b/doc_templates/phylum_project_list.md
@@ -13,4 +13,7 @@ $ phylum project list --json
 
 # List all existing projects for the `sample` group
 $ phylum project list -g sample
+
+# List all existing projects for the `demo` organization
+$ phylum project list --organization demo
 ```

--- a/docs/commands/phylum_history.md
+++ b/docs/commands/phylum_history.md
@@ -45,4 +45,7 @@ $ phylum history 338ea79f-0e82-4422-9769-4e583a84599f
 
 # View a list of analysis runs for the `sample` project
 $ phylum history --project sample
+
+# Show analysis runs for the `sample` project of the `demo` group under the `test` org
+$ phylum history --org test --group demo --project sample
 ```

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -49,4 +49,7 @@ $ phylum init
 
 # Create the `demo` project with a yarn lockfile and no associated group.
 $ phylum init --dependency-file yarn.lock --type yarn demo
+
+# Create the `demo` project in the `sample` group of the `test` organization.
+$ phylum init --org test --group sample demo
 ```

--- a/docs/commands/phylum_project_list.md
+++ b/docs/commands/phylum_project_list.md
@@ -40,4 +40,7 @@ $ phylum project list --json
 
 # List all existing projects for the `sample` group
 $ phylum project list -g sample
+
+# List all existing projects for the `demo` organization
+$ phylum project list --organization demo
 ```

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- `organization?` parameter for the following endpoints:
+    - `PhylumApi::analyze`
+    - `PhylumApi::getProjects`
+    - `PhylumApi::createProject`
+    - `PhylumApi::deleteProject`
+
 ### Changed
 
 - Group projects are included in `PhylumApi::getProjects` with no group specified

--- a/extensions/phylum.d.ts
+++ b/extensions/phylum.d.ts
@@ -104,6 +104,7 @@ declare namespace Phylum {
    * @param project - Project name. If undefined, the `.phylum_project` file will be used
    * @param group - Group name
    * @param label - Analysis label for this job
+   * @param organization - Phylum organization which owns the group
    *
    * @returns Analyze Job ID, which can later be queried with `getJobStatus`.
    */

--- a/extensions/phylum.d.ts
+++ b/extensions/phylum.d.ts
@@ -112,6 +112,7 @@ declare namespace Phylum {
     project?: string,
     group?: string,
     label?: string,
+    organization?: string,
   ): Promise<string>;
 
   /**
@@ -281,7 +282,7 @@ declare namespace Phylum {
    * ]
    * ```
    */
-  function getProjects(group?: string): Promise<Record<string, unknown>[]>;
+  function getProjects(group?: string, organization?: string): Promise<Record<string, unknown>[]>;
 
   /**
    * Create a project.
@@ -292,6 +293,7 @@ declare namespace Phylum {
     name: string,
     group?: string,
     repository_url?: string,
+    organization?: string,
   ): Promise<{ id: string; status: "Created" | "Exists" }>;
 
   /**
@@ -299,7 +301,7 @@ declare namespace Phylum {
    *
    * Throws an error if unsuccessful.
    */
-  function deleteProject(name: string, group?: string): Promise<void>;
+  function deleteProject(name: string, group?: string, organization?: string): Promise<void>;
 
   /**
    * Get analysis results for a single package.

--- a/extensions/phylum.d.ts
+++ b/extensions/phylum.d.ts
@@ -282,7 +282,10 @@ declare namespace Phylum {
    * ]
    * ```
    */
-  function getProjects(group?: string, organization?: string): Promise<Record<string, unknown>[]>;
+  function getProjects(
+    group?: string,
+    organization?: string,
+  ): Promise<Record<string, unknown>[]>;
 
   /**
    * Create a project.
@@ -301,7 +304,11 @@ declare namespace Phylum {
    *
    * Throws an error if unsuccessful.
    */
-  function deleteProject(name: string, group?: string, organization?: string): Promise<void>;
+  function deleteProject(
+    name: string,
+    group?: string,
+    organization?: string,
+  ): Promise<void>;
 
   /**
    * Get analysis results for a single package.


### PR DESCRIPTION
This patch uses the `Config::org` function to add support for org
support in all subcommands that were still missing org support.

Generally when an org is linked, the org mode is always preferred. Only
in scenarios where no group is present at all, like `phylum project
delete <NAME>`, the personal projects will be used instead.

Since this could potentially lead to a lot of confusion with the project
management subcommands, all project subcommands have been changed to
print projects in a fixed format that lists the corresponding org and
group:

```
✅ Successfully deleted project cli (org: phylum, group: org-group)
```

```
✅ Successfully deleted project demo (org: -, group: -)
```

Closes https://github.com/phylum-dev/cli/issues/1482.