### PR TITLE
Remove unneeded install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
-        run: brew install cmake protobuf
+        run: brew install protobuf
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc


### PR DESCRIPTION
Installing `cmake` is unnecessary and just causes [warnings][1] on our release workflow. The patch removes it from the workflow.

[1]: https://github.com/phylum-dev/cli/actions/runs/10798611911