### PR TITLE
Update `yarn` extension sandbox exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Organization support for existing subcommands
 - `phylum project update --default-label` option to set a project's default label
 - `phylum project list --no-group` flag to only show personal projects
+- Full sandbox write access to project directory for building with `yarn` extension
 
 ### Fixed
 

--- a/extensions/bundle/README.md
+++ b/extensions/bundle/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI] extension that checks your [bundle] dependencies through [Phylum]
 before installing them.
 
+[Phylum CLI]: https://github.com/phylum-dev/cli
+[bundle]: https://bundler.io
+[Phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -42,6 +46,40 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[Phylum CLI]: https://github.com/phylum-dev/cli
-[Phylum]: https://phylum.io
-[bundle]: https://bundler.io
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
+
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/cargo/README.md
+++ b/extensions/cargo/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI] extension that checks your [cargo] dependencies through [Phylum]
 before installing them.
 
+[Phylum CLI]: https://github.com/phylum-dev/cli
+[cargo]: https://doc.rust-lang.org/cargo
+[Phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -42,6 +46,40 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[Phylum CLI]: https://github.com/phylum-dev/cli
-[Phylum]: https://phylum.io
-[cargo]: https://doc.rust-lang.org/cargo
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
+
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI][phylum-cli] extension that checks your [npm][npm] dependencies
 through [Phylum][phylum] before installing them.
 
+[phylum-cli]: https://github.com/phylum-dev/cli
+[npm]: https://www.npmjs.com/
+[phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -42,6 +46,40 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[phylum]: https://phylum.io
-[phylum-cli]: https://github.com/phylum-dev/cli
-[npm]: https://www.npmjs.com/
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
+
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/npm/main.ts
+++ b/extensions/npm/main.ts
@@ -164,7 +164,7 @@ if (!output.success) {
       red(
         "phylum",
       )
-    }] Please submit your lockfile to Phylum should this error persist.`,
+    }] Please submit your dependency file(s) to Phylum if this error persists.`,
   );
 
   await abort(output.code ?? 255);

--- a/extensions/pip/README.md
+++ b/extensions/pip/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI][phylum-cli] extension that checks your [pip] dependencies through
 [Phylum][phylum] before installing them.
 
+[phylum-cli]: https://github.com/phylum-dev/cli
+[pip]: https://pip.pypa.io
+[phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -48,6 +52,40 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[phylum-cli]: https://github.com/phylum-dev/cli
-[phylum]: https://phylum.io
-[pip]: https://pip.pypa.io
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
+
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/poetry/README.md
+++ b/extensions/poetry/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI][phylum-cli] extension that checks your Python [Poetry][poetry]
 dependencies through [Phylum][phylum] before installing them.
 
+[phylum-cli]: https://github.com/phylum-dev/cli
+[poetry]: https://python-poetry.org/
+[phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -42,6 +46,40 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[phylum]: https://phylum.io
-[phylum-cli]: https://github.com/phylum-dev/cli
-[poetry]: https://python-poetry.org/
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
+
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -3,6 +3,10 @@
 A [Phylum CLI][phylum-cli] extension that checks your [yarn][yarn] dependencies
 through [Phylum][phylum] before installing them.
 
+[phylum-cli]: https://github.com/phylum-dev/cli
+[yarn]: https://yarnpkg.com/
+[phylum]: https://phylum.io
+
 ## Installation
 
 This is a pre-installed extension and may be available without any additional
@@ -42,6 +46,39 @@ In cases where Phylum still needs to process some of the packages, the command
 will exit with a warning **without** installing the packages. Once the analysis
 is complete, another attempt can be made.
 
-[phylum]: https://phylum.io
-[phylum-cli]: https://github.com/phylum-dev/cli
-[yarn]: https://yarnpkg.com/
+## Troubleshooting
+
+There are some common reasons this extension may fail.
+
+### Sandbox violations
+
+The underlying package manager may fail due to operating within the Phylum
+sandbox. These errors are usually displayed in the output and say something
+about not being able to access a particular file or network resource.
+
+One possibility is that this is a valid sandbox violation that has not been
+accounted for with an exception. If you believe this is the case, please
+[submit an issue][issue] or [contact us][contact] to discuss adding exceptions.
+
+Another possibility is that a malicious action was taken by one of the packages.
+Blocking such malicious actions is a primary goal for using this extension but
+it may be hard to know what is malicious and what is not. If you need help
+making that determination, please [contact us][contact] and provide the log
+output along with any other relevant details.
+
+[issue]: https://github.com/phylum-dev/cli/issues/new/choose
+[contact]: https://docs.phylum.io/support/contact_us
+
+### Package violations
+
+Packages analyzed by this extension may not pass the
+[Phylum default policy][policy]. When this happens the extension will prevent
+the requested action and instead print a list of policy violations.
+
+There is not currently a method for allowing policy violations discovered by
+this extension. Instead, inspect the findings and determine if the offending
+entries are truly necessary. If not, update your project dependencies and try
+again. If they are, then the only recourse is to try the action again without
+the Phylum package manager extension.
+
+[policy]: https://docs.phylum.io/knowledge_base/policy

--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -53,18 +53,19 @@ There are some common reasons this extension may fail.
 ### Sandbox violations
 
 The underlying package manager may fail due to operating within the Phylum
-sandbox. These errors are usually displayed in the output and say something
-about not being able to access a particular file or network resource.
+sandbox. These errors may be displayed in the output and say something about not
+being able to access a particular resource.
 
 One possibility is that this is a valid sandbox violation that has not been
-accounted for with an exception. If you believe this is the case, please
-[submit an issue][issue] or [contact us][contact] to discuss adding exceptions.
+accounted for with an exception. Another possibility is that a malicious action
+was taken by one of the packages. Blocking such malicious actions is a primary
+goal for using this extension and failures of this sort are a warning to not
+proceed without the protection of a sandbox.
 
-Another possibility is that a malicious action was taken by one of the packages.
-Blocking such malicious actions is a primary goal for using this extension but
-it may be hard to know what is malicious and what is not. If you need help
-making that determination, please [contact us][contact] and provide the log
-output along with any other relevant details.
+It can be hard to know what is malicious and what is not. If you aren't sure
+what to do, please [contact us][contact] and provide the log output along with
+any other relevant details. If you believe an exception is needed for the
+sandbox, please [submit an issue][issue].
 
 [issue]: https://github.com/phylum-dev/cli/issues/new/choose
 [contact]: https://docs.phylum.io/support/contact_us

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -166,7 +166,7 @@ if (!output.success) {
       red(
         "phylum",
       )
-    }] Please submit your lockfile to Phylum should this error persist.`,
+    }] Please submit your dependency file(s) to Phylum if this error persists.`,
   );
 
   await abort(output.code ?? 255);

--- a/extensions/yarn/main.ts
+++ b/extensions/yarn/main.ts
@@ -139,7 +139,7 @@ const output = Phylum.runSandboxed({
   cmd: "yarn",
   args: ["install", "--immutable", "--immutable-cache"],
   exceptions: {
-    write: ["/tmp", "./.yarn"],
+    write: ["/tmp", "./"],
     read: true,
     run: true,
     net: false,


### PR DESCRIPTION
This change allows for local project directory write access
for the building stage of the `yarn` extension. This brings
it into parity with the rest of the package manager extensions.

The need for this change was discovered by a community edition
user who reported in Discord how the extension was failing due
to a sandbox access violation:

```
Error: EROFS: read-only file system, rmdir '/home/sum/DEV/ETH/YD/yd-marketplace/node_modules/.store'
```

The same user also noted their confusion over the language
provided by the extension after this failure:

> Please submit your lockfile to Phylum should this error persist.

They did not have a lockfile present (just a `package.json` manifest)
and noted that the extension did not create a `yarn.lock` lockfile
for them to submit.

Therefore, the language of this message has been updated to be less
specific about lockfiles and more about "dependency files."

Finally, a troubleshooting section was added to the `yarn` extension's
documentation. This is an attempt to better prepare users for what to
do when the extension fails. After the language is ironed out here for
this extension, the plan is to add it to each of the other package
manager extensions by updating this review.