### PR TITLE
Bump to v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 7.0.0 - 2024-09-17
+
 ### Added
 
 - Organization management under the `phylum org` subcommand

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "6.6.6"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "6.6.6"
+version = "7.0.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 7.0.0 - 2024-09-17
+
 ### Added
 
 - `organization?` parameter for the following endpoints:


### PR DESCRIPTION
## 7.0.0 - 2024-09-17

### Added

- Organization management under the `phylum org` subcommand
- Organization support for existing subcommands
- `phylum project update --default-label` option to set a project's default label
- `phylum project list --no-group` flag to only show personal projects
- Full sandbox write access to project directory for building with `yarn` extension

### Fixed

- Lockfile parsing of bun-generated yarn lockfiles
- Maven lockfile generation on Windows

### Removed

- `phylum batch` subcommand