### PR TITLE
Enable extensions for Windows release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             extension: .exe
-            flags: --no-default-features
+            flags: --no-default-features -F extensions
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -71,6 +71,10 @@ jobs:
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
         run: sudo apt update && sudo apt install -y protobuf-compiler
+
+      - if: ${{ runner.os == 'Windows' }}
+        name: Install protoc
+        run: choco install protoc
 
       - if: ${{ runner.os == 'Windows' }}
         name: Install Rust toolchain
@@ -191,7 +195,7 @@ jobs:
         env:
           OPENSSL_KEY: ${{ secrets.OPENSSL_KEY }}
         run: |
-          for archive in phylum-*.zip;
+          for archive in phylum-*.zip phylum-*.exe;
           do
             openssl dgst -sha256 -sign <(printf "%s" "$OPENSSL_KEY") -out "${archive}.signature" "${archive}"
           done
@@ -230,7 +234,7 @@ jobs:
         # Reference: https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset
         run: |
           API_URL=$(printf "%s" "$UPLOAD_URL" | cut -d '{' -f 1)
-          for asset in phylum-*.zip* phylum-*.exe;
+          for asset in phylum-*.zip* phylum-*.exe*;
           do
             curl \
               -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
         env:
           OPENSSL_KEY: ${{ secrets.OPENSSL_KEY }}
         run: |
-          for archive in phylum-*.zip phylum-*.exe;
+          for archive in phylum-*.zip;
           do
             openssl dgst -sha256 -sign <(printf "%s" "$OPENSSL_KEY") -out "${archive}.signature" "${archive}"
           done
@@ -234,7 +234,7 @@ jobs:
         # Reference: https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset
         run: |
           API_URL=$(printf "%s" "$UPLOAD_URL" | cut -d '{' -f 1)
-          for asset in phylum-*.zip* phylum-*.exe*;
+          for asset in phylum-*.zip* phylum-*.exe;
           do
             curl \
               -X POST \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,21 +33,27 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            protoc: sudo apt install -y protobuf-compiler
             flags: --all-features
           - os: macos-14
-            protoc: brew install protobuf
             flags: --all-features
           - os: windows-latest
-            protoc: choco install protoc
             flags: --no-default-features -F extensions
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Install protoc
-        run: ${{ matrix.protoc }}
+      - if: ${{ runner.os == 'macOS' }}
+        name: Install protoc
+        run: brew install protobuf
+
+      - if: ${{ runner.os == 'Linux' }}
+        name: Install protoc
+        run: sudo apt install -y protobuf-compiler
+
+      - if: ${{ runner.os == 'Windows' }}
+        name: Install protoc
+        run: choco install protoc
 
       - name: Install Rust toolchain
         run: rustup toolchain install --no-self-update stable --profile minimal -c clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,25 +31,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14]
+        include:
+          - os: ubuntu-20.04
+            protoc: sudo apt install -y protobuf-compiler
+            flags: --all-features
+          - os: macos-14
+            protoc: brew install protobuf
+            flags: --all-features
+          - os: windows-latest
+            protoc: choco install protoc
+            flags: --no-default-features -F extensions
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - if: ${{ runner.os == 'macOS' }}
-        name: Install protoc
-        run: brew install protobuf
-
-      - if: ${{ runner.os == 'Linux' }}
-        name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+      - name: Install protoc
+        run: ${{ matrix.protoc }}
 
       - name: Install Rust toolchain
         run: rustup toolchain install --no-self-update stable --profile minimal -c clippy
 
       - name: Clippy
-        run: cargo +stable clippy --locked --all-features --all-targets -- -D warnings
+        run: cargo +stable clippy --locked ${{ matrix.flags }} --all-targets -- -D warnings
 
   test-matrix:
     strategy:
@@ -85,7 +89,7 @@ jobs:
   oldstable:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-20.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -98,6 +102,10 @@ jobs:
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
         run: sudo apt install -y protobuf-compiler
+
+      - if: ${{ runner.os == 'Windows' }}
+        name: Install protoc
+        run: choco install protoc
 
       - name: Oldstable
         run: |
@@ -164,7 +172,7 @@ jobs:
   # to update those settings every time the test jobs are updated.
   test:
     if: always()
-    needs: [rustfmt, clippy, test-matrix, oldstable, all-features, deno-checks, shellcheck]
+    needs: [clippy, test-matrix, oldstable, all-features]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
-        run: brew install cmake protobuf
+        run: brew install protobuf
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
 
   oldstable:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -108,6 +109,7 @@ jobs:
         run: choco install protoc
 
       - name: Oldstable
+        shell: bash
         run: |
           oldstable=$(grep rust-version ./cli/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
           rustup toolchain install --profile minimal "${oldstable}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,6 @@ on:
     - cron: '30 5 * * 1'
 
 jobs:
-  windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Install Rust toolchain
-        run: rustup toolchain install --no-self-update stable --profile minimal
-
-      - name: Test
-        run: cargo +stable test --locked --no-default-features
-
   rustfmt:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
@@ -51,7 +39,7 @@ jobs:
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
-        run: brew install cmake protobuf
+        run: brew install protobuf
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
@@ -68,6 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14]
+        include:
+          - os: windows-latest
+            flags: --no-default-features -F extensions
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -81,11 +72,15 @@ jobs:
         name: Install protoc
         run: sudo apt install -y protobuf-compiler
 
+      - if: ${{ runner.os == 'Windows' }}
+        name: Install protoc
+        run: choco install protoc
+
       - name: Install Rust toolchain
         run: rustup toolchain install --no-self-update stable --profile minimal
 
       - name: Test
-        run: cargo +stable test --locked
+        run: cargo +stable test --locked ${{ matrix.flags }}
 
   oldstable:
     strategy:
@@ -98,7 +93,7 @@ jobs:
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
-        run: brew install cmake protobuf
+        run: brew install protobuf
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
@@ -106,9 +101,9 @@ jobs:
 
       - name: Oldstable
         run: |
-          oldstable=$(cat "./cli/Cargo.toml" | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
-          rustup toolchain install --profile minimal "$oldstable"
-          cargo "+$oldstable" check
+          oldstable=$(grep rust-version ./cli/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          rustup toolchain install --profile minimal "${oldstable}"
+          cargo "+${oldstable}" check
 
   all-features:
     # Skip this job when the secret is unavailable
@@ -123,7 +118,7 @@ jobs:
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
-        run: brew install cmake protobuf
+        run: brew install protobuf
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
@@ -142,26 +137,34 @@ jobs:
     runs-on: ubuntu-latest
     container: denoland/deno
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: deno fmt
         run: deno fmt --check
+
       - name: deno lint
         run: deno lint
+
       - name: deno check
         run: deno check --no-lock extensions/**/*.ts
 
   shellcheck:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Script Style Check
-        if: github.event_name != 'schedule'
-        run: shellcheck -o all -S style -s sh $(find . -iname "*.sh")
+      - name: Checkout the repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-  # This job reports the results of the matrixes above
+      - name: Script Style Check
+        run: find . -iname "*.sh" -print0 | xargs -0 shellcheck -o all -S style -s sh
+
+  # This job reports the results of the test jobs above and is used
+  # to enforce status checks in the repo settings without needing
+  # to update those settings every time the test jobs are updated.
   test:
     if: always()
-    needs: [windows, clippy, test-matrix, all-features, oldstable]
+    needs: [rustfmt, clippy, test-matrix, oldstable, all-features, deno-checks, shellcheck]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Extensions for Windows release artifacts
+
 ## 7.0.0 - 2024-09-17
 
 ### Added

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -40,7 +40,7 @@ printf "\nFiles to be added and committed with message: \"%s\"\n\n" "${commit_me
 git status
 
 printf "Press enter to proceed with the commit..."
-read -r
+read -r _
 
 git commit -F - <<EOF
 ${commit_message}

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -95,7 +95,7 @@ fn correct_sandbox_run_permission_fail_on_windows() {
         .success();
 
     test_cli
-        .run(&["correct-run-perms"])
+        .run(["correct-run-perms"])
         .failure()
         .stderr(predicate::str::contains("Extension sandboxing is not supported on this platform"));
 }

--- a/xtask/src/gendocs.rs
+++ b/xtask/src/gendocs.rs
@@ -66,6 +66,7 @@ fn pages() -> Result<Vec<(PathBuf, String)>> {
     Ok(pages)
 }
 
+#[cfg(feature = "full-docs")]
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -73,7 +74,6 @@ mod tests {
     use super::*;
 
     /// Ensure the generate CLI docs are always up-to-date.
-    #[cfg(feature = "full-docs")]
     #[test]
     fn docs_up_to_date() {
         // Move to project root.


### PR DESCRIPTION
This change enables the extensions feature when building Windows release artifacts. Doing so will enable the `phylum-ci` tool to continue to operate with its extension-based analysis for the coming Windows standalone binary. Additional changes include:

* Consolidate `windows` job in `Test` workflow with `test-matrix` job
* Add Windows runner to `clippy` and `oldstable` `Test` workflow jobs
  * Fix Windows clippy findings
* Remove extraneous `cmake` installs on macOS runners
* Fix `shellcheck` and `actionlint` findings
* Format throughout
