### PR TITLE
Switch to new org endpoint format

### DIFF
--- a/cli/src/api/mod.rs
+++ b/cli/src/api/mod.rs
@@ -444,8 +444,8 @@ impl PhylumApi {
             .iter()
             .find(|project| {
                 project.name == project_name
-                    && project.organization_name.as_ref().map(|o| o.as_str()) == org
-                    && project.group_name.as_ref().map(|g| g.as_str()) == group
+                    && project.organization_name.as_deref() == org
+                    && project.group_name.as_deref() == group
             })
             .ok_or_else(|| anyhow!("No project found with name {:?}", project_name).into())
             .map(|project| project.id)

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -367,7 +367,7 @@ async fn create_project(
 
     // Retrieve the id if the project already exists, otherwise return the id or the
     // error.
-    match api.create_project(&name, organization.as_deref(), group.clone(), repository_url).await {
+    match api.create_project(&name, organization.clone(), group.clone(), repository_url).await {
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => api
             .get_project_id(&name, organization.as_deref(), group.as_deref())
             .await

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -59,7 +59,14 @@ pub async fn handle_init(api: &PhylumApi, matches: &ArgMatches, config: Config) 
     let depfiles = prompt_depfiles(cli_depfiles, cli_depfile_type)?;
 
     // Attempt to create the project.
-    let result = project::create_project(api, &project, org, group.clone(), repository_url).await;
+    let result = project::create_project(
+        api,
+        &project,
+        org.map(|org| org.into()),
+        group.clone(),
+        repository_url,
+    )
+    .await;
 
     let mut project_config = match result {
         // If project already exists, try looking it up to link to it.

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -37,7 +37,7 @@ pub async fn handle_project(
 pub async fn create_project(
     api: &PhylumApi,
     project: &str,
-    org: Option<&str>,
+    org: Option<String>,
     group: Option<String>,
     repository_url: Option<String>,
 ) -> Result<ProjectConfig, PhylumApiError> {
@@ -114,9 +114,10 @@ async fn handle_create_project(
 
     log::info!("Initializing new project: `{}`", project);
 
-    let project_config = match create_project(api, project, org, group.clone(), repository_url)
-        .await
-    {
+    let project_config =
+        create_project(api, project, org.map(|org| org.into()), group.clone(), repository_url)
+            .await;
+    let project_config = match project_config {
         Ok(project) => project,
         Err(PhylumApiError::Response(ResponseError { code: StatusCode::CONFLICT, .. })) => {
             let formatted_project = format_project_reference(org, group.as_deref(), project, None);

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -177,19 +177,12 @@ impl Format for Vec<ProjectListEntry> {
         } else {
             let table = format_table::<fn(&ProjectListEntry) -> String, _>(self, &[
                 ("Organization Name", |project| {
-                    match project.group_name.as_deref().unwrap_or("").split_once('/') {
-                        Some((org_name, _)) => {
-                            print::truncate(org_name, MAX_NAME_WIDTH).into_owned()
-                        },
-                        None => String::new(),
-                    }
+                    let org_name = project.organization_name.as_deref().unwrap_or("");
+                    print::truncate(org_name, MAX_NAME_WIDTH).into_owned()
                 }),
                 ("Group Name", |project| {
-                    let org_and_group = project.group_name.as_deref().unwrap_or("");
-                    let group_name = org_and_group
-                        .split_once('/')
-                        .map_or(org_and_group, |(_, group_name)| group_name);
-                    print::truncate(group_name, MAX_NAME_WIDTH).into_owned()
+                    let group_name = project.group_name.as_deref().unwrap_or("");
+                    print::truncate(&group_name, MAX_NAME_WIDTH).into_owned()
                 }),
                 ("Project Name", |project| {
                     print::truncate(&project.name, MAX_NAME_WIDTH).into_owned()

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -182,7 +182,7 @@ impl Format for Vec<ProjectListEntry> {
                 }),
                 ("Group Name", |project| {
                     let group_name = project.group_name.as_deref().unwrap_or("");
-                    print::truncate(&group_name, MAX_NAME_WIDTH).into_owned()
+                    print::truncate(group_name, MAX_NAME_WIDTH).into_owned()
                 }),
                 ("Project Name", |project| {
                     print::truncate(&project.name, MAX_NAME_WIDTH).into_owned()

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -478,6 +478,8 @@ pub struct AddOrgUserRequest {
 pub struct CreateProjectRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub group_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository_url: Option<String>,
@@ -493,6 +495,7 @@ pub struct ProjectListEntry {
     pub updated_at: DateTime<Utc>,
     pub name: String,
     pub ecosystems: Vec<PackageType>,
+    pub organization_name: Option<String>,
     pub group_name: Option<String>,
 }
 


### PR DESCRIPTION
This switches all relevant endpoints from the combined "org/group" group name format to separate org and group name fields.