### PR TITLE
Fix Windows depfile paths in Phylum project files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,7 @@ jobs:
     # Skip this job when the secret is unavailable
     if: github.secret_source == 'Actions'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14]
     runs-on: ${{ matrix.os }}

--- a/.phylum_project
+++ b/.phylum_project
@@ -1,7 +1,7 @@
 id: d84b0bb3-fb64-43cb-a473-dc96b54db662
 name: cli
-created_at: 2023-01-26T20:02:11.276987834+01:00
+created_at: 2024-09-20T12:27:33.762071-05:00
 group_name: integrations
-lockfiles:
-- path: Cargo.lock
+depfiles:
+- path: ./Cargo.lock
   type: cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Extensions for Windows release artifacts
 
+### Fixed
+
+- Phylum project file paths on Windows
+
 ## 7.0.0 - 2024-09-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ name = "phylum_project"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "dunce",
  "log",
  "phylum_types",
  "serde",

--- a/phylum_project/Cargo.toml
+++ b/phylum_project/Cargo.toml
@@ -9,11 +9,12 @@ edition = "2021"
 rust-version = "1.64.0"
 
 [dependencies]
-phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
+dunce = "1.0.5"
+log = "0.4.6"
+phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_yaml = "0.9.2"
-log = "0.4.6"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/phylum_project/src/lib.rs
+++ b/phylum_project/src/lib.rs
@@ -51,8 +51,7 @@ impl ProjectConfig {
                 .iter()
                 .map(|depfile| {
                     let path = self.root.join(&depfile.path);
-                    let dunce_path = dunce::simplified(&path);
-                    DepfileConfig::new(dunce_path, depfile.depfile_type.clone())
+                    DepfileConfig::new(dunce::simplified(&path), depfile.depfile_type.clone())
                 })
                 .collect();
         }
@@ -109,8 +108,7 @@ pub fn find_project_conf(
     // If `path` is like `.`, `path.parent()` is `None`.
     // Convert to a canonicalized path so removing components navigates up the
     // directory hierarchy.
-    let mut path = starting_directory.as_ref().canonicalize().ok()?;
-    path = dunce::simplified(&path).to_path_buf();
+    let mut path = dunce::canonicalize(starting_directory.as_ref()).ok()?;
 
     for _ in 0..max_depth {
         let conf_path = path.join(PROJ_CONF_FILE);


### PR DESCRIPTION
The changes made here are emulating those made in #1496, but for the `phylum_project` crate. This allows for more natural paths on Windows systems. Other changes made include:

* Update `.phylum_project` file for this repo
  * Include the output/format from the current `phylum init` command
* Ensure `all-features` job in `Test` workflow has matching strategy


## Testing

Output from a *nix system (macOS):

```
## Latest released version
❯ phylum --version
phylum v7.0.0

❯ phylum status
Project: cli
Group: integrations
Project Root: /Users/maxrake/dev/phylum/localdev/cli
Dependency Files:
 - path: /Users/maxrake/dev/phylum/localdev/cli/./Cargo.lock
   type: cargo

## Version made from the changes in this PR
❯ target/debug/phylum --version
phylum v7.0.0-3-g35f1873

❯ target/debug/phylum status
Project: cli
Group: integrations
Project Root: /Users/maxrake/dev/phylum/localdev/cli
Dependency Files:
 - path: /Users/maxrake/dev/phylum/localdev/cli/./Cargo.lock
   type: cargo
```

Output from a Windows system:

```
## Latest released version
C:\Users\maxrake\Downloads\phylum\phylum-ci>phylum --version
phylum v7.0.0

C:\Users\maxrake\Downloads\phylum\phylum-ci>phylum status
Project: phylum-ci
Group: phylum_bot
Project Root: \\?\C:\Users\maxrake\Downloads\phylum\phylum-ci
Dependency Files:
 - path: \\?\C:\Users\maxrake\Downloads\phylum\phylum-ci\poetry.lock
   type: poetry
   
## Version made from the changes in this PR
C:\Users\maxrake\Downloads\phylum\phylum-ci>phylum --version
phylum v7.0.0-3-g35f1873

C:\Users\maxrake\Downloads\phylum\phylum-ci>phylum status
Project: phylum-ci
Group: phylum_bot
Project Root: C:\Users\maxrake\Downloads\phylum\phylum-ci
Dependency Files:
 - path: C:\Users\maxrake\Downloads\phylum\phylum-ci\./poetry.lock
   type: poetry
```

While the output for both OS types is less than ideal, with the inclusion of the final relative path component, it doesn't affect the operation of `phylum-ci`, which makes use of the output of this command to populate dependency file paths.

Ideally,
`/Users/maxrake/dev/phylum/localdev/cli/./Cargo.lock`
would show as
`/Users/maxrake/dev/phylum/localdev/cli/Cargo.lock`
and
`C:\Users\maxrake\Downloads\phylum\phylum-ci\./poetry.lock`
would show as
`C:\Users\maxrake\Downloads\phylum\phylum-ci\poetry.lock`.

It is simply a visual nuisance and the paths still resolve correctly so pursuing a "fix" to this will be left to another time.