### PR TITLE
Use pre-installed rustup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,19 +76,11 @@ jobs:
         name: Install protoc
         run: choco install protoc
 
-      - if: ${{ runner.os == 'Windows' }}
-        name: Install Rust toolchain
+      - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
 
-      - if: ${{ runner.os != 'Windows' }}
-        name: Install Rust toolchain
-        run: |
-          curl https://sh.rustup.rs -sSf \
-            | sh -s -- -y --default-toolchain stable --profile minimal --target ${{ matrix.target }}
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
       - name: Build Distributions
-        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.flags }}
+        run: cargo +stable build --release --target ${{ matrix.target }} ${{ matrix.flags }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0


### PR DESCRIPTION
All of our runners (including self-hosted runners) now have rustup available. So this patch removes the use of curl to install it.