### PR TITLE
Fix pipeline failures showing up as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Package subcommand failing to parse API responses
+- Packages which cannot be analyzed showing up as having no issues
 
 ## 7.1.0 - 2024-09-24
 

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -170,6 +170,9 @@ pub struct Package {
     pub complete: bool,
     pub release_data: Option<PackageReleaseData>,
     pub repo_url: Option<String>,
+    pub hash: Option<String>,
+    pub pipeline_error: Option<String>,
+    pub pipeline_status: Option<PipelineStatus>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -243,25 +246,14 @@ pub enum IgnoredReason {
     Other,
 }
 
-/// One of the authors of a package.
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Author {
-    pub name: String,
-    pub avatar_url: String,
-    pub email: String,
-    pub profile_url: String,
-}
-
-/// Stats about how responsive the maintainers of a package are.
-#[derive(Serialize, Deserialize)]
-pub struct DeveloperResponsiveness {
-    pub open_issue_count: Option<usize>,
-    pub total_issue_count: Option<usize>,
-    pub open_issue_avg_duration: Option<u32>,
-    pub open_pull_request_count: Option<usize>,
-    pub total_pull_request_count: Option<usize>,
-    pub open_pull_request_avg_duration: Option<u32>,
+/// Package status in the analysis pipeline.
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum PipelineStatus {
+    Submitted,
+    Downloading,
+    Processing,
+    Analyzing,
+    Complete,
 }
 
 /// Information about when package releases have happened.


### PR DESCRIPTION
This fixes an issue where packages would show up as passing Phylum's
analysis if they failed at any point of the pipeline.

Closes https://github.com/phylum-dev/cli/issues/351.

---

Depends on https://github.com/phylum-dev/cli/pull/1517.