### PR TITLE
Bump to v7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 7.1.2 - 2024-10-11
+
 ### Fixed
 
 - `phylum package` subcommand showing unprocessed packages as complete
+- Packages which cannot be analyzed showing up as having no issues
 
 ## 7.1.1 - 2024-10-09
 
@@ -21,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Package subcommand failing to parse API responses
-- Packages which cannot be analyzed showing up as having no issues
 
 ## 7.1.0 - 2024-09-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "phylum-cli"
-version = "7.1.1"
+version = "7.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylum-cli"
-version = "7.1.1"
+version = "7.1.2"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 7.1.2 - 2024-10-11
+
 ## 7.1.1 - 2024-10-09
 
 ### Changed

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## 7.1.2 - 2024-10-11
-
 ## 7.1.1 - 2024-10-09
 
 ### Changed


### PR DESCRIPTION
Also moved an errant CHANGELOG entry.

Release-Version: v7.1.2
