### PR TITLE
Allow whitespace in `pip` requirement specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- `pip` parser failing with whitespace around `==` in requirement specifier
+
 ## 7.1.3 - 2024-10-29
 
 ### Fixed

--- a/lockfile/src/parsers/pypi.rs
+++ b/lockfile/src/parsers/pypi.rs
@@ -187,7 +187,7 @@ fn package_version(input: &str) -> IResult<&str, &str> {
     let (input, _) = tag("==")(input)?;
 
     // Take all valid semver character.
-    recognize(many1(alt((alphanumeric1, tag(".")))))(input)
+    recognize(many1(alt((alphanumeric1, tag(".")))))(input.trim())
 }
 
 /// Parse local version specifiers.

--- a/tests/fixtures/requirements-locked.txt
+++ b/tests/fixtures/requirements-locked.txt
@@ -11,7 +11,8 @@ amqp==5.0.9 --hash=sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115
     --hash=sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
     # via kombu
 
-attrs==20.2.0   # This is an inline comment
+# Whitespace is allowed in requirement specifiers
+attrs == 20.2.0   # This is an inline comment
 
 # The requirement specifier does not have to be at the beginning of the line
     flask==2.2.2


### PR DESCRIPTION
A bug was discovered recently when attempting to parse a `pip` lockfile. That is, a `requirements*.txt` file containing exact versions (i.e., `==`) in all of it's requirement specifiers. Such a file should parse as a lockfile and not fall back to lockfile generation. However, if whitespace is included around the `==`, the parsing fails.

Whitespace is allowed in requirement specifiers. This change accounts for that. It also updates the test fixture to prevent regressions.

Ref: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
