### PR TITLE
Add `organization` parameters to `Phylum` object

### DIFF
--- a/cli/js/api.js
+++ b/cli/js/api.js
@@ -63,12 +63,14 @@ export function analyze(
   project,
   group,
   label,
+  organization,
 ) {
   return op_analyze(
     packages,
     project,
     group,
     label,
+    organization,
   );
 }
 
@@ -116,20 +118,21 @@ export function getGroups() {
   return get_groups();
 }
 
-export function getProjects(group) {
-  return get_projects(group);
+export function getProjects(group, organization) {
+  return get_projects(group, organization);
 }
 
 export function createProject(
   name,
   group,
   repository_url,
+  organization,
 ) {
-  return create_project(name, group, repository_url);
+  return create_project(name, group, repository_url, organization);
 }
 
-export function deleteProject(name, group) {
-  return delete_project(name, group);
+export function deleteProject(name, group, organization) {
+  return delete_project(name, group, organization);
 }
 
 export function getPackageDetails(

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Add missing `organization` parameters to global `Phylum` object endpoints
+
 ## 7.1.1 - 2024-10-09
 
 ### Changed


### PR DESCRIPTION
## Overview

This change fixes an oversight from when org support was first added to the extension API. The new `organization` parameters were added to `extensions/phylum.d.ts` but not exposed for consumers in `cli/js/api.js`.

[See commit `f890fea`](https://github.com/phylum-dev/cli/commit/f890fea) or PR #1490

## Testing

The changes from this PR were confirmed to work by using them in the `ci` extension for `phylum-ci` (after updating it to account for organizations).

## Additional Information

A review of the default and community extensions revealed only one use of one of these changed API calls:

* `snyk-import`, for `createProject`
  * https://github.com/phylum-dev/community-extensions/blob/4c878e27930a9cdd332d65b066e514b778ef9a9a/snyk-import/main.ts#L69
  * https://github.com/phylum-dev/community-extensions/issues/46
