### PR TITLE
Fix return type for `PhylumApi::getJobStatusRaw`

### DIFF
--- a/cli/js/api.js
+++ b/cli/js/api.js
@@ -13,6 +13,7 @@ import {
   get_current_project,
   get_groups,
   get_job_status,
+  get_job_status_raw,
   get_package_details,
   get_projects,
   get_refresh_token,
@@ -107,7 +108,7 @@ export function getJobStatusRaw(
   jobId,
   ignoredPackages,
 ) {
-  return get_job_status(jobId, ignoredPackages);
+  return get_job_status_raw(jobId, ignoredPackages);
 }
 
 export function getCurrentProject() {

--- a/extensions/CHANGELOG.md
+++ b/extensions/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Incorrect return type for `PhylumApi::getJobStatusRaw` endpoint
+
 ## 7.1.4 - 2024-11-07
 
 ### Fixed


### PR DESCRIPTION
This change corrects an oversight in the extensions API where the `getJobStatusRaw` endpoint was returning the results as if the `getJobStatus` endpoint was called instead. The return types are indeed different.
