### PR TITLE
Fix PNPM v5 version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- `pnpm` version 5 parser including metadata in package versions
+
 ## 7.1.4 - 2024-11-07
 
 ### Fixed

--- a/tests/fixtures/pnpm-lock-v5.yaml
+++ b/tests/fixtures/pnpm-lock-v5.yaml
@@ -6,5 +6,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+  /use-sync-external-store/1.2.2_react@18.3.1:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
+
+  /@types/eslint__js/8.42.3:
+    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
+    dependencies:
+      '@types/eslint': 9.6.1
+    dev: true
 specifiers:
   lodash: ^4.17.21

--- a/tests/fixtures/pnpm-lock.yaml
+++ b/tests/fixtures/pnpm-lock.yaml
@@ -483,3 +483,11 @@ packages:
     resolution: {directory: projects/workspace_member, type: directory}
     name: workspace_member
     dev: false
+
+  /@emotion/use-insertion-effect-with-fallbacks@1.1.0(react@18.3.1):
+    resolution: {integrity: sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.3.1
+    dev: false


### PR DESCRIPTION
This fixes an issue with the lockfile parser of PNPM v5 lockfiles which would incorrectly include metadata in the package version.

Closes #1538.