### PR TITLE
Add C# *.packages.config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Support for C#'s `*.packages.config` lockfile type
+- Support for C#'s `packages.*.config` lockfile type
 
 ## 7.1.5 - 2024-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Support for C#'s `*.packages.config` lockfile type
+
 ## 7.1.5 - 2024-11-26
 
 ### Fixed

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -193,7 +193,7 @@ impl<'a> TestExtension<'a> {
 }
 
 #[cfg(feature = "extensions")]
-impl<'a> Drop for TestExtension<'a> {
+impl Drop for TestExtension<'_> {
     fn drop(&mut self) {
         self.test_cli.run(["extension", "uninstall", "test-ext"]).success();
         fs::remove_dir_all(&self.extension_path).unwrap();

--- a/docs/commands/phylum_analyze.md
+++ b/docs/commands/phylum_analyze.md
@@ -27,7 +27,7 @@ Usage: phylum analyze [OPTIONS] [DEPENDENCY_FILE]...
 
 `-t`, `--type` `<TYPE>`
 &emsp; Dependency file type used for all lockfiles (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `nugetconfig`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `--skip-sandbox`
 &emsp; Run lockfile generation without sandbox protection

--- a/docs/commands/phylum_init.md
+++ b/docs/commands/phylum_init.md
@@ -21,7 +21,7 @@ Usage: phylum init [OPTIONS] [PROJECT_NAME]
 
 `-t`, `--type` `<TYPE>`
 &emsp; Dependency file type used for all lockfiles (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `nugetconfig`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `-f`, `--force`
 &emsp; Overwrite existing configurations without confirmation

--- a/docs/commands/phylum_parse.md
+++ b/docs/commands/phylum_parse.md
@@ -15,7 +15,7 @@ Usage: phylum parse [OPTIONS] [DEPENDENCY_FILE]...
 
 `-t`, `--type` `<TYPE>`
 &emsp; Dependency file type used for all lockfiles (default: auto)
-&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
+&emsp; Accepted values: `npm`, `yarn`, `pnpm`, `gem`, `pip`, `poetry`, `pipenv`, `mvn`, `gradle`, `msbuild`, `nugetlock`, `nugetconfig`, `gomod`, `go`, `cargo`, `spdx`, `cyclonedx`, `auto`
 
 `--skip-sandbox`
 &emsp; Run lockfile generation without sandbox protection

--- a/docs/supported_lockfiles.md
+++ b/docs/supported_lockfiles.md
@@ -13,6 +13,7 @@ The Phylum CLI supports processing many different lockfiles:
 | `gem`         | `Gemfile.lock`                                                         |
 | `msbuild`     | `*.csproj`                                                             |
 | `nugetlock`   | `packages.lock.json` <br /> `packages.*.lock.json`                     |
+| `nugetconfig` | `packages.config` <br /> `packages.*.config`                           |
 | `mvn`         | `effective-pom.xml`                                                    |
 | `gradle`      | `gradle.lockfile` <br /> `gradle/dependency-locks/*.lockfile`          |
 | `go`          | `go.sum`                                                               |

--- a/lockfile/src/csharp.rs
+++ b/lockfile/src/csharp.rs
@@ -158,7 +158,7 @@ impl Parse for CSProj {
 pub struct PackagesConfig;
 
 impl Parse for PackagesConfig {
-    /// Parses `*.packages.config` files into a [`Vec`] of packages.
+    /// Parses `packages.*.config` files into a [`Vec`] of packages.
     fn parse(&self, data: &str) -> anyhow::Result<Vec<Package>> {
         let data = data.trim_start_matches(UTF8_BOM);
         let parsed: PackagesConfigXml = quick_xml::de::from_str(data)?;
@@ -180,7 +180,7 @@ impl Parse for PackagesConfig {
     }
 }
 
-/// XML format of the `*.packages.config` file.
+/// XML format of the `packages.*.config` file.
 #[derive(Deserialize)]
 struct PackagesConfigXml {
     #[serde(rename = "package", default)]
@@ -201,7 +201,7 @@ impl From<PackagesConfigXml> for Vec<Package> {
     }
 }
 
-/// Package entry in a `*.packages.config` file.
+/// Package entry in a `packages.*.config` file.
 #[derive(Deserialize)]
 struct PackagesConfigXmlPackage {
     #[serde(alias = "@id")]

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -137,18 +137,7 @@ impl LockfileFormat {
     }
 
     /// Iterate over all supported lockfile formats.
-    pub fn iter() -> LockfileFormatIter {
-        LockfileFormatIter(0)
-    }
-}
-
-/// An iterator of all supported lockfile formats.
-pub struct LockfileFormatIter(usize);
-
-impl Iterator for LockfileFormatIter {
-    type Item = LockfileFormat;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    pub fn iter() -> impl Iterator<Item = LockfileFormat> {
         // NOTE: Without explicit override, the lockfile generator will always pick the
         // first matching format for the manifest. To ensure best possible support,
         // common formats should be returned **before** less common ones (i.e. NPM
@@ -173,9 +162,7 @@ impl Iterator for LockfileFormatIter {
             LockfileFormat::CycloneDX,
         ];
 
-        let format = FORMATS.get(self.0)?;
-        self.0 += 1;
-        Some(*format)
+        FORMATS.iter().copied()
     }
 }
 

--- a/lockfile/src/lib.rs
+++ b/lockfile/src/lib.rs
@@ -512,7 +512,7 @@ mod tests {
             ("packages.lock.json", LockfileFormat::NugetLock),
             ("packages.project.lock.json", LockfileFormat::NugetLock),
             ("packages.config", LockfileFormat::NugetConfig),
-            ("project.packages.config", LockfileFormat::NugetConfig),
+            ("packages.project.config", LockfileFormat::NugetConfig),
             ("gradle.lockfile", LockfileFormat::Gradle),
             ("default.lockfile", LockfileFormat::Gradle),
             ("effective-pom.xml", LockfileFormat::Maven),

--- a/tests/fixtures/packages.config
+++ b/tests/fixtures/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AddressParser" version="0.0.20" targetFramework="net471" />
+  <package id="JetBrains.ReSharper.SDK" version="8.2.921-EAP" targetFramework="net35" />
+  <package id="boost" version="1.78.0" targetFramework="native" developmentDependency="true" />
+  <package id="noversion" />
+</packages>


### PR DESCRIPTION
This adds support for `packages.config` files for the C# ecosystem under the new `NugetConfig` lockfile name.

The file format itself seems to be relatively simple, with just a list of package names and optional versions. The current test fixture is based on examples of this lockfile found on <https://github.com>.

Both `packages.config` on its own and `*.packages.config` are supported as valid names. Since this seems to be a lockfile there is no need for lockfile generation.
