### PR TITLE
Fix certificate check option naming

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -51,9 +51,10 @@ pub fn app() -> Command {
                 .long("timeout")
                 .value_name("TIMEOUT")
                 .help("Set the timeout (in seconds) for requests to the Phylum api"),
-            Arg::new("no-check-certificate")
+            Arg::new("ignore-certs")
                 .action(ArgAction::SetTrue)
-                .long("no-check-certificate")
+                .long("ignore-certs")
+                .alias("no-check-certificate")
                 .help("Don't validate the server certificate when performing api requests"),
             Arg::new("org")
                 .short('o')

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -103,7 +103,7 @@ async fn handle_commands() -> CommandResult {
 
     let mut config = config::load_config(&matches)?;
 
-    config.set_ignore_certs_cli(matches.get_flag("no-check-certificate"));
+    config.set_ignore_certs_cli(matches.get_flag("ignore-certs"));
     if config.ignore_certs() {
         log::warn!("Ignoring TLS server certificate verification per user request.");
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -83,7 +83,7 @@ impl Config {
         self.ignore_certs_cli || self.ignore_certs
     }
 
-    /// Set the CLI `--no-check-certificate` override value.
+    /// Set the CLI `--ignore-certs` override value.
     pub fn set_ignore_certs_cli(&mut self, ignore_certs_cli: bool) {
         self.ignore_certs_cli = ignore_certs_cli;
     }

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -193,7 +193,7 @@ impl<'a> TestExtension<'a> {
 }
 
 #[cfg(feature = "extensions")]
-impl<'a> Drop for TestExtension<'a> {
+impl Drop for TestExtension<'_> {
     fn drop(&mut self) {
         self.test_cli.run(["extension", "uninstall", "test-ext"]).success();
         fs::remove_dir_all(&self.extension_path).unwrap();


### PR DESCRIPTION
This fixes an inconsistency between the `ignore_certs` configuration option and the `--no-check-certificate` CLI flag by changing the CLI flag to be `--ignore-certs` with an alias for the old version.

Closes #480.
