### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/cli/src/auth/oidc.rs
+++ b/cli/src/auth/oidc.rs
@@ -283,7 +283,7 @@ pub async fn acquire_tokens(
 
         // Provide additional detail when user requires activation.
         if serde_json::from_str::<ResponseError>(&body)
-            .map_or(false, |response| response.error == "not_allowed")
+            .is_ok_and(|response| response.error == "not_allowed")
         {
             err = err.context(
                 "Your account is not authorized to perform this action. Please contact Phylum \

--- a/cli/src/commands/extensions/api.rs
+++ b/cli/src/commands/extensions/api.rs
@@ -499,7 +499,7 @@ fn run_sandboxed(
         .output()?;
 
     // Return explicit error when process start failed
-    if output.status.code().map_or(false, |code| code == i32::from(&ExitCode::SandboxStart)) {
+    if output.status.code().is_some_and(|code| code == i32::from(&ExitCode::SandboxStart)) {
         return Err(anyhow!("Process {cmd:?} failed to start"));
     }
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -245,7 +245,7 @@ fn prompt_depfile_names() -> dialoguer::Result<Vec<String>> {
         let mut files_index = 0;
         depfiles.retain(|_| {
             // Check if index is in the selected indices.
-            let retain = indices.peek().map_or(false, |index| **index <= files_index);
+            let retain = indices.peek().is_some_and(|index| **index <= files_index);
 
             // Go to next selection index if current index was found.
             if retain {

--- a/cli/src/permissions.rs
+++ b/cli/src/permissions.rs
@@ -70,7 +70,7 @@ impl Permission {
 
     /// Check if access to resource is permitted.
     pub fn validate(&self, resource: &String, resource_type: &str) -> Result<()> {
-        if self.get().map_or(false, |allowed| allowed.contains(resource)) {
+        if self.get().is_some_and(|allowed| allowed.contains(resource)) {
             Ok(())
         } else {
             Err(anyhow!("Requires {resource_type} access to {resource:?}"))

--- a/cli/src/update/unix.rs
+++ b/cli/src/update/unix.rs
@@ -231,7 +231,7 @@ impl ApplicationUpdater {
         let public_key = RsaPublicKey::from_public_key_pem(PUBKEY).expect("invalid public key");
         let verifying_key = VerifyingKey::<Sha256>::new(public_key);
 
-        Signature::try_from(sig).map_or(false, |sig| verifying_key.verify(bin, &sig).is_ok())
+        Signature::try_from(sig).is_ok_and(|sig| verifying_key.verify(bin, &sig).is_ok())
     }
 }
 

--- a/lockfile/src/cyclonedx.rs
+++ b/lockfile/src/cyclonedx.rs
@@ -190,7 +190,7 @@ impl Parse for CycloneDX {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name()
             .and_then(OsStr::to_str)
-            .map_or(false, |name| name.ends_with("bom.json") || name.ends_with("bom.xml"))
+            .is_some_and(|name| name.ends_with("bom.json") || name.ends_with("bom.xml"))
     }
 
     fn is_path_manifest(&self, _path: &Path) -> bool {

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -33,7 +33,7 @@ impl Parse for GradleLock {
     fn is_path_lockfile(&self, path: &Path) -> bool {
         path.file_name()
             .and_then(|f| f.to_str())
-            .map_or(false, |file_name| file_name.ends_with(".lockfile"))
+            .is_some_and(|file_name| file_name.ends_with(".lockfile"))
     }
 
     fn is_path_manifest(&self, path: &Path) -> bool {

--- a/lockfile/src/javascript.rs
+++ b/lockfile/src/javascript.rs
@@ -172,7 +172,7 @@ impl Parse for YarnLock {
         for package in yaml_v2
             .iter()
             // Filter lockfile data fields like "__metadata".
-            .filter(|(k, _v)| k.as_str().map_or(false, |k| !k.starts_with('_')))
+            .filter(|(k, _v)| k.as_str().is_some_and(  |k| !k.starts_with('_')))
             .flat_map(|(_k, v)| v.as_mapping())
         {
             let resolution = package

--- a/lockfile/src/parsers/go_mod.rs
+++ b/lockfile/src/parsers/go_mod.rs
@@ -161,7 +161,7 @@ fn require_spec(input: &str) -> IResult<&str, Module> {
     let (input, comments) = opt(preceded(tag("//"), take_till1(|c: char| c == '\n')))(input)?;
 
     // Determine if the comment indicates the module is indirect.
-    let indirect = comments.map_or(false, |s: &str| s.trim().eq("indirect"));
+    let indirect = comments.is_some_and(|s: &str| s.trim().eq("indirect"));
     let (input, _) = take_while(|c: char| c != '\n')(input)?;
 
     Ok((input, Module { path: module_path.to_string(), version: version.to_string(), indirect }))

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -25,7 +25,7 @@ pub struct Poetry;
 
 /// Check if filename is `requirements*.txt`
 fn is_requirements_file(path: &Path) -> bool {
-    path.file_name().and_then(|f| f.to_str()).map_or(false, |file_name| {
+    path.file_name().and_then(|f| f.to_str()).is_some_and(|file_name| {
         file_name.starts_with("requirements") && file_name.ends_with(".txt")
     })
 }

--- a/lockfile/src/spdx.rs
+++ b/lockfile/src/spdx.rs
@@ -192,8 +192,8 @@ impl Parse for Spdx {
             .relationships
             .into_iter()
             .filter_map(|r| {
-                if r.relationship_type.as_ref().map_or(false, |t| t == "DESCRIBES")
-                    && r.spdx_element_id.as_ref().map_or(false, |t| t == &spdx_info.spdx_id)
+                if r.relationship_type.as_deref() == Some("DESCRIBES")
+                    && r.spdx_element_id.as_ref() == Some(&spdx_info.spdx_id)
                 {
                     r.related_spdx_element
                 } else {
@@ -225,7 +225,7 @@ impl Parse for Spdx {
     }
 
     fn is_path_lockfile(&self, path: &Path) -> bool {
-        path.file_name().and_then(OsStr::to_str).map_or(false, |name| {
+        path.file_name().and_then(OsStr::to_str).is_some_and(|name| {
             name.ends_with(".spdx.json")
                 || name.ends_with(".spdx.yaml")
                 || name.ends_with(".spdx.yml")
@@ -513,7 +513,7 @@ mod tests {
             Created: 2024-04-01T00:28:13Z
             CreatorComment: <text>This document has been automatically generated.</text>
             DocumentDescribes: SPDXRef-Package1, SPDXRef-Package2
-            ##### 
+            #####
 
             PackageName: cve-bin-tool
             SPDXID: SPDXRef-Package-1-cve-bin-tool
@@ -529,7 +529,7 @@ mod tests {
             PackageSummary: <text>CVE Binary Checker Tool</text>
             ExternalRef: PACKAGE_MANAGER purl pkg:pypi/cve-bin-tool@3.3rc2
             ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.3rc2:*:*:*:*:*:*:*
-            ##### 
+            #####
 
             PackageName: aiohttp
             SPDXID: SPDXRef-Package-2-aiohttp
@@ -576,7 +576,7 @@ mod tests {
             ExternalRef: SECURITY cpe23Type cpe:2.3:a:\@discoveryjs\/json:\@discoveryjs\/json-ext:0.5.6:*:*:*:*:*:*:*
             ExternalRef: SECURITY cpe23Type cpe:2.3:a:\@discoveryjs\/json:\@discoveryjs\/json_ext:0.5.6:*:*:*:*:*:*:*
             ExternalRef: PACKAGE-MANAGER purl pkg:npm/%40discoveryjs/json-ext@0.5.6
-            
+
             Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
             Relationship: SPDXRef-Package-1-cve-bin-tool DEPENDS_ON SPDXRef-Package-2-aiohttp
             "##;


### PR DESCRIPTION
This fixes nightly clippy warnings, mainly the new suggestion to prefer `Option::is_some_and`/`Result::is_ok_and` over `.map_or(false, …)`. Despite these warnings not being stable yet, they are good suggestions to improve the code quality.