### PR TITLE
Fix Windows Gradle manifests incorrectly retained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Gradle manifests used on Windows when legacy lockfiles exist
+- Gradle manifests incorrectly retained on Windows
 
 ## 7.1.5 - 2024-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for C#'s `packages.*.config` lockfile type
 - `phylum firewall log` command to browse firewall activity log
 
+### Fixed
+
+- Gradle manifests used on Windows when legacy lockfiles exist
+
 ## 7.1.5 - 2024-11-26
 
 ### Fixed

--- a/lockfile/src/java.rs
+++ b/lockfile/src/java.rs
@@ -26,7 +26,7 @@ impl Parse for GradleLock {
         let (_, entries) = gradle_dep::parse(data)
             .finish()
             .map_err(|e| anyhow!(convert_error(data, e)))
-            .context("Failed to parse requirements file")?;
+            .context("Failed to parse gradle lockfile")?;
         Ok(entries)
     }
 


### PR DESCRIPTION
This change fixes a bug that is specific to Windows systems. When legacy Gradle (prior to v7.0.0) lockfiles exist (e.g.,
`gradle/dependency-locks/*.lockfile`) along with a manifest at a higher level, the manifest is meant to be ignored when finding dependency files to analyze. However, on Windows systems this was not the case before this change. Instead, both the manifest and the lockfiles were retained. After this change, only the lockfiles are retained when both are present.

A failing test was added first to confirm the incorrect behavior. Then, a change was made to handle paths as `Path` objects instead of strings. That way, the generic `/` path separator character will be used correctly regardless of the runtime system.

Additionally, an error message was updated to reflect the correct dependency file language for Gradle parsing errors.
