### PR TITLE
Add phylum exception subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- `phylum exception` subcommand for managing suppressions
+
 ## 7.2.0 - 2024-12-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,6 +4506,7 @@ dependencies = [
  "git2",
  "home",
  "ignore",
+ "indexmap",
  "lazy_static",
  "libc",
  "log",
@@ -4948,13 +4949,14 @@ dependencies = [
 
 [[package]]
 name = "purl"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14fe28c8495f7eaf77a6e6106966f95211c0a2404b9da50d248fc32af3a3f14"
+checksum = "f112b0e2a9bca03924c39166775b74fec9a831f7d4d8fa539dee0e565f403a0e"
 dependencies = [
  "hex",
  "percent-encoding",
  "phf",
+ "serde",
  "smartstring",
  "thiserror 1.0.69",
  "unicase",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "7.2.0"
 authors = ["Phylum, Inc. <engineering@phylum.io>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 autotests = false
 
 [[test]]
@@ -48,7 +48,7 @@ phylum_lockfile = { path = "../lockfile", features = ["generator"] }
 phylum_project = { path = "../phylum_project" }
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 prettytable-rs = "0.10.0"
-purl = "0.1.1"
+purl = { version = "0.1.5", features = ["serde"] }
 rand = "0.8.4"
 regex = "1.5.5"
 reqwest = { version = "0.12.7", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-webpki-roots"], default-features = false }
@@ -70,6 +70,7 @@ vuln-reach = { git = "https://github.com/phylum-dev/vuln-reach", optional = true
 vulnreach_types = { path = "../vulnreach_types", optional = true }
 walkdir = "2.3.2"
 zip = { version = "2.1.0", default-features = false, features = ["deflate"] }
+indexmap = "2.7.0"
 
 [target.'cfg(unix)'.dependencies]
 birdcage = { version = "0.8.1" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,6 +38,7 @@ git2 = { version = "0.19.0", default-features = false }
 git-version = "0.3.5"
 home = "0.5.3"
 ignore = { version = "0.4.20", optional = true }
+indexmap = "2.7.0"
 lazy_static = "1.4.0"
 libc = "0.2.135"
 log = "0.4.6"
@@ -70,7 +71,6 @@ vuln-reach = { git = "https://github.com/phylum-dev/vuln-reach", optional = true
 vulnreach_types = { path = "../vulnreach_types", optional = true }
 walkdir = "2.3.2"
 zip = { version = "2.1.0", default-features = false, features = ["deflate"] }
-indexmap = "2.7.0"
 
 [target.'cfg(unix)'.dependencies]
 birdcage = { version = "0.8.1" }

--- a/cli/src/api/endpoints.rs
+++ b/cli/src/api/endpoints.rs
@@ -197,6 +197,119 @@ pub fn firewall_log(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_firewall_path(api_uri)?.join("activity")?)
 }
 
+/// GET /organizations/<orgName>/groups/<groupName>/preferences.
+pub fn org_group_preferences(
+    api_uri: &str,
+    org_name: &str,
+    group_name: &str,
+) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "organizations",
+        org_name,
+        "groups",
+        group_name,
+        "preferences",
+    ]);
+    Ok(url)
+}
+
+/// GET /preferences/group/<groupName>
+pub fn group_preferences(api_uri: &str, group_name: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["preferences", "group", group_name]);
+    Ok(url)
+}
+
+/// GET /preferences/project/<projectId>
+pub fn project_preferences(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend(["preferences", "project", project_id]);
+    Ok(url)
+}
+
+/// POST /organizations/<orgName>/groups/<groupName>/suppress.
+pub fn org_group_suppress(
+    api_uri: &str,
+    org_name: &str,
+    group_name: &str,
+) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "organizations",
+        org_name,
+        "groups",
+        group_name,
+        "suppress",
+    ]);
+    Ok(url)
+}
+
+/// POST /preferences/group/<groupName>/suppress.
+pub fn group_suppress(api_uri: &str, group_name: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "preferences",
+        "group",
+        group_name,
+        "suppress",
+    ]);
+    Ok(url)
+}
+
+/// POST /preferences/project/<projectId>/suppress.
+pub fn project_suppress(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "preferences",
+        "project",
+        project_id,
+        "suppress",
+    ]);
+    Ok(url)
+}
+
+/// POST /organizations/<orgName>/groups/<groupName>/unsuppress.
+pub fn org_group_unsuppress(
+    api_uri: &str,
+    org_name: &str,
+    group_name: &str,
+) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "organizations",
+        org_name,
+        "groups",
+        group_name,
+        "unsuppress",
+    ]);
+    Ok(url)
+}
+
+/// POST /preferences/group/<groupName>/unsuppress.
+pub fn group_unsuppress(api_uri: &str, group_name: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "preferences",
+        "group",
+        group_name,
+        "unsuppress",
+    ]);
+    Ok(url)
+}
+
+/// POST /preferences/project/<projectId>/unsuppress.
+pub fn project_unsuppress(api_uri: &str, project_id: &str) -> Result<Url, BaseUriError> {
+    let mut url = get_api_path(api_uri)?;
+    url.path_segments_mut().unwrap().pop_if_empty().extend([
+        "preferences",
+        "project",
+        project_id,
+        "unsuppress",
+    ]);
+    Ok(url)
+}
+
 /// GET /.well-known/openid-configuration
 pub fn oidc_discovery(api_uri: &str) -> Result<Url, BaseUriError> {
     Ok(get_api_path(api_uri)?.join(".well-known/openid-configuration")?)

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,5 +1,5 @@
 use clap::builder::PossibleValuesParser;
-use clap::{Arg, ArgAction, Command, ValueHint};
+use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
 use git_version::git_version;
 use lazy_static::lazy_static;
 
@@ -655,6 +655,142 @@ pub fn add_subcommands(command: Command) -> Command {
                             .default_value("10")
                             .value_parser(1..=10_000),
                     ]),
+                ),
+        )
+        .subcommand(
+            Command::new("exception")
+                .about("Manage analysis exceptions")
+                .arg_required_else_help(true)
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("list")
+                        .about("List active analysis exceptions")
+                        .group(ArgGroup::new("subject").args(["group", "project"]).required(true))
+                        .args(&[
+                            Arg::new("json")
+                                .action(ArgAction::SetTrue)
+                                .short('j')
+                                .long("json")
+                                .help("Produce output in json format (default: false)"),
+                            Arg::new("group")
+                                .short('g')
+                                .long("group")
+                                .value_name("GROUP_NAME")
+                                .help("Group to list exceptions for"),
+                            Arg::new("project")
+                                .short('p')
+                                .long("project")
+                                .value_name("PROJECT_NAME")
+                                .help("Project to list exceptions for"),
+                        ]),
+                )
+                .subcommand(
+                    Command::new("add")
+                        .about("Add a new analysis exception")
+                        .group(ArgGroup::new("subject").args(["group", "project"]).required(true))
+                        .args(&[
+                            Arg::new("group")
+                                .short('g')
+                                .long("group")
+                                .value_name("GROUP_NAME")
+                                .help("Group to add exception to"),
+                            Arg::new("project")
+                                .short('p')
+                                .long("project")
+                                .value_name("PROJECT_NAME")
+                                .help("Project to add exceptions to"),
+                            Arg::new("ecosystem")
+                                .short('e')
+                                .long("ecosystem")
+                                .value_name("ECOSYSTEM")
+                                .help("Ecosystem of the package to add an exception for")
+                                .value_parser([
+                                    "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
+                                ]),
+                            Arg::new("name")
+                                .short('n')
+                                .long("name")
+                                .value_name("PACKAGE_NAME")
+                                .help(
+                                    "Name and optional namespace of the package to add an \
+                                     exception for",
+                                ),
+                            Arg::new("version")
+                                .long("version")
+                                .value_name("VERSION")
+                                .help("Version of the package to add an exception for"),
+                            Arg::new("purl")
+                                .long("purl")
+                                .value_name("PURL")
+                                .help("Package in PURL format")
+                                .conflicts_with_all(["ecosystem", "name", "version"]),
+                            Arg::new("reason")
+                                .short('r')
+                                .long("reason")
+                                .value_name("REASON")
+                                .help("Reason for adding this exception"),
+                            Arg::new("no-suggestions")
+                                .short('s')
+                                .long("no-suggestions")
+                                .action(ArgAction::SetTrue)
+                                .help("Do not query package firewall to make suggestions"),
+                        ]),
+                )
+                .subcommand(
+                    Command::new("remove")
+                        .about("Remove an existing analysis exception")
+                        .group(ArgGroup::new("subject").args(["group", "project"]).required(true))
+                        .group(
+                            ArgGroup::new("package")
+                                .args(["ecosystem", "name", "version", "purl"])
+                                .conflicts_with("issue"),
+                        )
+                        .group(ArgGroup::new("issue").args(["id", "tag"]))
+                        .args(&[
+                            Arg::new("group")
+                                .short('g')
+                                .long("group")
+                                .value_name("GROUP_NAME")
+                                .help("Group to add exception to"),
+                            Arg::new("project")
+                                .short('p')
+                                .long("project")
+                                .value_name("PROJECT_NAME")
+                                .help("Project to add exceptions to"),
+                            Arg::new("ecosystem")
+                                .short('e')
+                                .long("ecosystem")
+                                .value_name("ECOSYSTEM")
+                                .help("Ecosystem of the exception which should be removed")
+                                .value_parser([
+                                    "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
+                                ]),
+                            Arg::new("name")
+                                .short('n')
+                                .long("name")
+                                .value_name("PACKAGE_NAME")
+                                .help(
+                                    "Package name and optional namespace of the exception which \
+                                     should be removed",
+                                ),
+                            Arg::new("version")
+                                .long("version")
+                                .value_name("VERSION")
+                                .help("Package version of the exception which should be removed"),
+                            Arg::new("purl")
+                                .long("purl")
+                                .value_name("PURL")
+                                .help("Package in PURL format")
+                                .conflicts_with_all(["ecosystem", "name", "version"]),
+                            Arg::new("id")
+                                .long("id")
+                                .value_name("ISSUE_ID")
+                                .help("Issue ID of the exception which should be removed"),
+                            Arg::new("tag")
+                                .long("tag")
+                                .value_name("ISSUE_TAG")
+                                .help("Issue tag of the exception which should be removed"),
+                        ]),
                 ),
         );
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -712,8 +712,7 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("name")
                                 .value_name("PACKAGE_NAME")
                                 .help(
-                                    "Name and optional namespace of the package to add an \
-                                     exception for",
+                                    "Fully qualified name of the package to add an exception for",
                                 ),
                             Arg::new("version")
                                 .long("version")
@@ -751,12 +750,12 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .short('g')
                                 .long("group")
                                 .value_name("GROUP_NAME")
-                                .help("Group to add exception to"),
+                                .help("Group to remove exception from"),
                             Arg::new("project")
                                 .short('p')
                                 .long("project")
                                 .value_name("PROJECT_NAME")
-                                .help("Project to add exceptions to"),
+                                .help("Project to remove exceptions from"),
                             Arg::new("ecosystem")
                                 .short('e')
                                 .long("ecosystem")
@@ -770,8 +769,8 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("name")
                                 .value_name("PACKAGE_NAME")
                                 .help(
-                                    "Package name and optional namespace of the exception which \
-                                     should be removed",
+                                    "Fully qualified package name of the exception which should \
+                                     be removed",
                                 ),
                             Arg::new("version")
                                 .long("version")

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -610,53 +610,51 @@ pub fn add_subcommands(command: Command) -> Command {
                 .arg_required_else_help(true)
                 .subcommand_required(true)
                 .subcommand(
-                    Command::new("log")
-                        .about("Show firewall activity log")
-                        .args(&[Arg::new("json")
+                    Command::new("log").about("Show firewall activity log").args(&[
+                        Arg::new("json")
                             .action(ArgAction::SetTrue)
                             .short('j')
                             .long("json")
-                            .help("Produce output in json format (default: false)")])
-                        .args(&[
-                            Arg::new("group")
-                                .value_name("GROUP_NAME")
-                                .help("Specify a group to use for analysis")
-                                .required(true),
-                            Arg::new("ecosystem")
-                                .long("ecosystem")
-                                .value_name("ECOSYSTEM")
-                                .help("Only show logs matching this ecosystem")
-                                .value_parser([
-                                    "npm", "rubygems", "pypi", "maven", "nuget", "cargo",
-                                ]),
-                            Arg::new("package")
-                                .long("package")
-                                .value_name("PURL")
-                                .help("Only show logs matching this PURL")
-                                .conflicts_with("ecosystem"),
-                            Arg::new("action")
-                                .long("action")
-                                .value_name("ACTION")
-                                .help("Only show logs matching this log action")
-                                .value_parser([
-                                    "Download",
-                                    "AnalysisSuccess",
-                                    "AnalysisFailure",
-                                    "AnalysisWarning",
-                                ]),
-                            Arg::new("before").long("before").value_name("TIMESTAMP").help(
-                                "Only show logs created before this timestamp (RFC3339 format)",
-                            ),
-                            Arg::new("after").long("after").value_name("TIMESTAMP").help(
-                                "Only show logs created after this timestamp (RFC3339 format)",
-                            ),
-                            Arg::new("limit")
-                                .long("limit")
-                                .value_name("COUNT")
-                                .help("Maximum number of log entries to show")
-                                .default_value("10")
-                                .value_parser(1..=10_000),
-                        ]),
+                            .help("Produce output in json format (default: false)"),
+                        Arg::new("group")
+                            .value_name("GROUP_NAME")
+                            .help("Firewall group to list log activity for")
+                            .required(true),
+                        Arg::new("ecosystem")
+                            .long("ecosystem")
+                            .value_name("ECOSYSTEM")
+                            .help("Only show logs matching this ecosystem")
+                            .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "cargo"]),
+                        Arg::new("package")
+                            .long("package")
+                            .value_name("PURL")
+                            .help("Only show logs matching this PURL")
+                            .conflicts_with("ecosystem"),
+                        Arg::new("action")
+                            .long("action")
+                            .value_name("ACTION")
+                            .help("Only show logs matching this log action")
+                            .value_parser([
+                                "Download",
+                                "AnalysisSuccess",
+                                "AnalysisFailure",
+                                "AnalysisWarning",
+                            ]),
+                        Arg::new("before")
+                            .long("before")
+                            .value_name("TIMESTAMP")
+                            .help("Only show logs created before this timestamp (RFC3339 format)"),
+                        Arg::new("after")
+                            .long("after")
+                            .value_name("TIMESTAMP")
+                            .help("Only show logs created after this timestamp (RFC3339 format)"),
+                        Arg::new("limit")
+                            .long("limit")
+                            .value_name("COUNT")
+                            .help("Maximum number of log entries to show")
+                            .default_value("10")
+                            .value_parser(1..=10_000),
+                    ]),
                 ),
         );
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -620,16 +620,16 @@ pub fn add_subcommands(command: Command) -> Command {
                             .value_name("GROUP_NAME")
                             .help("Firewall group to list log activity for")
                             .required(true),
-                        Arg::new("ecosystem")
-                            .long("ecosystem")
-                            .value_name("ECOSYSTEM")
-                            .help("Only show logs matching this ecosystem")
-                            .value_parser(["npm", "rubygems", "pypi", "maven", "nuget", "cargo"]),
-                        Arg::new("package")
-                            .long("package")
+                        Arg::new("package-type")
+                            .long("package-type")
+                            .value_name("PACKAGE_TYPE")
+                            .help("Only show logs matching this package type")
+                            .value_parser(["npm", "gem", "pypi", "maven", "nuget", "cargo"]),
+                        Arg::new("purl")
+                            .long("purl")
                             .value_name("PURL")
                             .help("Only show logs matching this PURL")
-                            .conflicts_with("ecosystem"),
+                            .conflicts_with("package-type"),
                         Arg::new("action")
                             .long("action")
                             .value_name("ACTION")
@@ -699,13 +699,12 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("project")
                                 .value_name("PROJECT_NAME")
                                 .help("Project to add exceptions to"),
-                            Arg::new("ecosystem")
-                                .short('e')
-                                .long("ecosystem")
-                                .value_name("ECOSYSTEM")
-                                .help("Ecosystem of the package to add an exception for")
+                            Arg::new("package-type")
+                                .long("package-type")
+                                .value_name("PACKAGE_TYPE")
+                                .help("Package type of the package to add an exception for")
                                 .value_parser([
-                                    "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
+                                    "npm", "gem", "pypi", "maven", "nuget", "golang", "cargo",
                                 ]),
                             Arg::new("name")
                                 .short('n')
@@ -722,7 +721,7 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("purl")
                                 .value_name("PURL")
                                 .help("Package in PURL format")
-                                .conflicts_with_all(["ecosystem", "name", "version"]),
+                                .conflicts_with_all(["package-type", "name", "version"]),
                             Arg::new("reason")
                                 .short('r')
                                 .long("reason")
@@ -741,7 +740,7 @@ pub fn add_subcommands(command: Command) -> Command {
                         .group(ArgGroup::new("subject").args(["group", "project"]).required(true))
                         .group(
                             ArgGroup::new("package")
-                                .args(["ecosystem", "name", "version", "purl"])
+                                .args(["package-type", "name", "version", "purl"])
                                 .conflicts_with("issue"),
                         )
                         .group(ArgGroup::new("issue").args(["id", "tag"]))
@@ -756,13 +755,12 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("project")
                                 .value_name("PROJECT_NAME")
                                 .help("Project to remove exceptions from"),
-                            Arg::new("ecosystem")
-                                .short('e')
-                                .long("ecosystem")
-                                .value_name("ECOSYSTEM")
-                                .help("Ecosystem of the exception which should be removed")
+                            Arg::new("package-type")
+                                .long("package-type")
+                                .value_name("PACKAGE_TYPE")
+                                .help("Package type of the exception which should be removed")
                                 .value_parser([
-                                    "npm", "rubygems", "pypi", "maven", "nuget", "golang", "cargo",
+                                    "npm", "gem", "pypi", "maven", "nuget", "golang", "cargo",
                                 ]),
                             Arg::new("name")
                                 .short('n')
@@ -780,7 +778,7 @@ pub fn add_subcommands(command: Command) -> Command {
                                 .long("purl")
                                 .value_name("PURL")
                                 .help("Package in PURL format")
-                                .conflicts_with_all(["ecosystem", "name", "version"]),
+                                .conflicts_with_all(["package-type", "name", "version"]),
                             Arg::new("id")
                                 .long("id")
                                 .value_name("ISSUE_ID")

--- a/cli/src/bin/phylum.rs
+++ b/cli/src/bin/phylum.rs
@@ -14,8 +14,8 @@ use phylum_cli::commands::sandbox;
 #[cfg(feature = "selfmanage")]
 use phylum_cli::commands::uninstall;
 use phylum_cli::commands::{
-    auth, find_dependency_files, firewall, group, init, jobs, org, packages, parse, project,
-    status, CommandResult, ExitCode,
+    auth, exception, find_dependency_files, firewall, group, init, jobs, org, packages, parse,
+    project, status, CommandResult, ExitCode,
 };
 use phylum_cli::config::{self, Config};
 use phylum_cli::spinner::Spinner;
@@ -147,6 +147,9 @@ async fn handle_commands() -> CommandResult {
         "org" => org::handle_org(&Spinner::wrap(api).await?, sub_matches, config).await,
         "firewall" => {
             firewall::handle_firewall(&Spinner::wrap(api).await?, sub_matches, config).await
+        },
+        "exception" => {
+            exception::handle_exception(&Spinner::wrap(api).await?, sub_matches, config).await
         },
 
         #[cfg(feature = "selfmanage")]

--- a/cli/src/commands/exception.rs
+++ b/cli/src/commands/exception.rs
@@ -74,10 +74,6 @@ pub async fn handle_add(api: &PhylumApi, matches: &ArgMatches, config: Config) -
         None => purl_from_components(api, ecosystem, name, group, org, !no_suggestions).await?,
     };
 
-    // TODO: Show short description of the issues for each version.
-    //  => Create issue.
-    //  => Maybe also provide full list while prompting for reason?
-    //
     // Get suggested versions from Aviary if no argument was supplied.
     let version = purl.version().or(version.map(String::as_str));
     let mut suggested_versions = IndexSet::new();

--- a/cli/src/commands/exception.rs
+++ b/cli/src/commands/exception.rs
@@ -1,0 +1,365 @@
+//! Subcommand `phylum exception`.
+
+use std::borrow::Cow;
+use std::str::FromStr;
+
+use clap::ArgMatches;
+use console::Term;
+use dialoguer::{FuzzySelect, Input};
+use indexmap::IndexSet;
+use purl::{PackageType, Purl};
+
+use crate::api::PhylumApi;
+use crate::commands::{CommandResult, ExitCode};
+use crate::config::Config;
+use crate::format::Format;
+use crate::print_user_success;
+use crate::spinner::Spinner;
+use crate::types::{
+    FirewallAction, FirewallLogFilter, IgnoredIssue, IgnoredPackage, Preferences, Suppression,
+};
+
+/// Maximum number of package names or versions proposed for exceptions.
+const MAX_SUGGESTIONS: usize = 25;
+
+/// Handle `phylum exception` subcommand.
+pub async fn handle_exception(
+    api: &PhylumApi,
+    matches: &ArgMatches,
+    config: Config,
+) -> CommandResult {
+    match matches.subcommand() {
+        Some(("list", matches)) => handle_list(api, matches, config).await,
+        Some(("add", matches)) => handle_add(api, matches, config).await,
+        Some(("remove", matches)) => handle_remove(api, matches, config).await,
+        _ => unreachable!("invalid clap configuration"),
+    }
+}
+
+/// Handle `phylum exception list` subcommand.
+pub async fn handle_list(api: &PhylumApi, matches: &ArgMatches, config: Config) -> CommandResult {
+    let group = matches.get_one::<String>("group");
+    let org = config.org();
+
+    let exceptions = match matches.get_one::<String>("project") {
+        Some(project_name) => {
+            let group = group.map(String::as_str);
+            let project_id = api.get_project_id(project_name, org, group).await?.to_string();
+            api.project_preferences(&project_id).await?
+        },
+        None => api.group_preferences(config.org(), group.unwrap()).await?,
+    };
+
+    let pretty = !matches.get_flag("json");
+    exceptions.write_stdout(pretty);
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum exception add` subcommand.
+pub async fn handle_add(api: &PhylumApi, matches: &ArgMatches, config: Config) -> CommandResult {
+    let no_suggestions = matches.get_flag("no-suggestions");
+    let ecosystem = matches.get_one::<String>("ecosystem");
+    let project = matches.get_one::<String>("project");
+    let version = matches.get_one::<String>("version");
+    let reason = matches.get_one::<String>("reason");
+    let group = matches.get_one::<String>("group");
+    let name = matches.get_one::<String>("name");
+    let purl = matches.get_one::<String>("purl");
+    let org = config.org();
+
+    // Parse PURL argument or assemble it from its components.
+    let mut purl = match purl {
+        Some(purl) => Purl::from_str(purl)?,
+        None => purl_from_components(api, ecosystem, name, group, org, !no_suggestions).await?,
+    };
+
+    // TODO: Show short description of the issues for each version.
+    //  => Create issue.
+    //  => Maybe also provide full list while prompting for reason?
+    //
+    // Get suggested versions from Aviary if no argument was supplied.
+    let version = purl.version().or(version.map(String::as_str));
+    let mut suggested_versions = IndexSet::new();
+    if let Some(group) = group.filter(|_| !no_suggestions && version.is_none()) {
+        let spinner = Spinner::new();
+
+        let filter = FirewallLogFilter {
+            ecosystem: Some(*purl.package_type()),
+            action: Some(FirewallAction::AnalysisFailure),
+            namespace: purl.namespace(),
+            name: Some(purl.name()),
+            ..Default::default()
+        };
+        if let Ok(logs) = api.firewall_log(org, group, filter).await {
+            suggested_versions = logs.data.into_iter().map(|log| log.package.version).collect();
+        }
+
+        spinner.stop().await;
+    }
+
+    // Prompt for version if it wasn't supplied as an argument.
+    let version = match version {
+        Some(version) => version.to_string().into(),
+        None => prompt_version(&suggested_versions)?,
+    };
+    purl = purl.into_builder().with_version(version).build()?;
+
+    // Prompt for exception reason. if it wasn't supplied as an argument.
+    let reason = match reason {
+        Some(reason) => reason.into(),
+        None => prompt_reason()?,
+    };
+
+    // Build suppression API object.
+    let suppressions = vec![Suppression::Package(IgnoredPackage {
+        purl: Cow::Owned(purl.to_string()),
+        reason: Cow::Borrowed(&reason),
+    })];
+
+    match project {
+        Some(project_name) => {
+            let group = group.map(String::as_str);
+            let project_id = api.get_project_id(project_name, org, group).await?.to_string();
+            api.project_suppress(&project_id, &suppressions).await?;
+        },
+        None => api.group_suppress(org, group.unwrap(), &suppressions).await?,
+    }
+
+    print_user_success!("Successfully added suppression for {}", purl.to_string());
+
+    Ok(ExitCode::Ok)
+}
+
+/// Handle `phylum exception remove` subcommand.
+pub async fn handle_remove(api: &PhylumApi, matches: &ArgMatches, config: Config) -> CommandResult {
+    let ecosystem = matches.get_one::<String>("ecosystem");
+    let project = matches.get_one::<String>("project");
+    let version = matches.get_one::<String>("version");
+    let group = matches.get_one::<String>("group");
+    let name = matches.get_one::<String>("name");
+    let purl = matches.get_one::<String>("purl");
+    let tag = matches.get_one::<String>("tag");
+    let id = matches.get_one::<String>("id");
+    let org = config.org();
+
+    let mut exceptions = match matches.get_one::<String>("project") {
+        Some(project_name) => {
+            let group = group.map(String::as_str);
+            let project_id = api.get_project_id(project_name, org, group).await?.to_string();
+            api.project_preferences(&project_id).await?
+        },
+        None => api.group_preferences(config.org(), group.unwrap()).await?,
+    };
+
+    // Filter issue suppressions with CLI args.
+    if tag.is_some() || id.is_some() {
+        exceptions.ignored_issues.retain(|issue| {
+            id.is_none_or(|id| id == &issue.id) && tag.is_none_or(|tag| tag == &issue.tag)
+        });
+    }
+
+    // Filter package suppressions with CLI args.
+    if ecosystem.is_some() || name.is_some() || version.is_some() || purl.is_some() {
+        let purl = purl.map(|purl| Purl::from_str(purl));
+        let (ecosystem, namespace, name, version) = match purl {
+            Some(Ok(ref purl)) => {
+                let package_type = Cow::Owned(purl.package_type().to_string());
+                (Some(package_type), purl.namespace(), Some(purl.name()), purl.version())
+            },
+            Some(Err(err)) => return Err(err.into()),
+            None => (
+                ecosystem.map(Cow::Borrowed),
+                None,
+                name.map(String::as_str),
+                version.map(String::as_str),
+            ),
+        };
+
+        exceptions.ignored_packages.retain(|pkg| {
+            let purl = match Purl::from_str(&pkg.purl) {
+                Ok(purl) => purl,
+                Err(_) => return false,
+            };
+
+            let package_type = purl.package_type().to_string();
+            ecosystem.as_ref().is_none_or(|ecosystem| **ecosystem == package_type)
+                && namespace.is_none_or(|namespace| Some(namespace) == purl.namespace())
+                && name.is_none_or(|name| name == purl.name())
+                && version.is_none_or(|version| Some(version) == purl.version())
+        });
+    }
+
+    let unsuppressions = vec![prompt_removal(&exceptions)?];
+
+    match project {
+        Some(project_name) => {
+            let group = group.map(String::as_str);
+            let project_id = api.get_project_id(project_name, org, group).await?.to_string();
+            api.project_unsuppress(&project_id, &unsuppressions).await?;
+        },
+        None => api.group_unsuppress(org, group.unwrap(), &unsuppressions).await?,
+    }
+
+    match &unsuppressions[0] {
+        Suppression::Package(IgnoredPackage { purl, .. }) => {
+            print_user_success!("Successfully removed suppression for package {purl:?}");
+        },
+        Suppression::Issue(IgnoredIssue { id, tag, .. }) => {
+            print_user_success!("Successfully removed suppression for issue {tag:?} [{id}]");
+        },
+    }
+
+    Ok(ExitCode::Ok)
+}
+
+/// Creat a PURL from its individual components.
+async fn purl_from_components(
+    api: &PhylumApi,
+    cli_ecosystem: Option<&String>,
+    cli_name: Option<&String>,
+    group: Option<&String>,
+    org: Option<&str>,
+    suggestions: bool,
+) -> anyhow::Result<Purl> {
+    // Prompt for ecosystem if it wasn't supplied as an argument.
+    let ecosystem = match cli_ecosystem {
+        Some(ecosystem) => ecosystem.into(),
+        None => Cow::Owned(prompt_ecosystem()?),
+    };
+    let ecosystem = PackageType::from_str(&ecosystem).unwrap();
+
+    // Get suggested names from Aviary if no argument was supplied.
+    let mut suggested_names: IndexSet<Purl> = IndexSet::new();
+    if let Some(group) = group.filter(|_| suggestions && cli_name.is_none()) {
+        let spinner = Spinner::new();
+
+        let filter = FirewallLogFilter {
+            ecosystem: Some(ecosystem),
+            action: Some(FirewallAction::AnalysisFailure),
+            ..Default::default()
+        };
+        if let Ok(logs) = api.firewall_log(org, group, filter).await {
+            for log in logs.data {
+                let purl = Purl::builder(ecosystem, log.package.name)
+                    .with_namespace(log.package.namespace)
+                    .build()?;
+                suggested_names.insert(purl);
+            }
+        }
+
+        spinner.stop().await;
+    }
+
+    // Prompt for name if it wasn't supplied as an argument.
+    let purl = match cli_name {
+        Some(name) => Purl::builder_with_combined_name(ecosystem, name).build()?,
+        None => prompt_name(ecosystem, &suggested_names)?,
+    };
+
+    Ok(purl)
+}
+
+/// Ask for an ecosystem.
+fn prompt_ecosystem() -> dialoguer::Result<String> {
+    let ecosystems = ["cargo", "gem", "golang", "maven", "npm", "nuget", "pypi"];
+
+    let prompt = "[ENTER] Select and Confirm\nSelect ecosystem";
+    let index = FuzzySelect::new().with_prompt(prompt).items(&ecosystems).interact()?;
+
+    println!();
+
+    Ok(ecosystems[index].to_owned())
+}
+
+/// Ask for a package name.
+fn prompt_name(ecosystem: PackageType, suggestions: &'_ IndexSet<Purl>) -> anyhow::Result<Purl> {
+    // Get space available for suggestions.
+    let term_size = Term::stdout().size_checked().unwrap_or((u16::MAX, u16::MAX));
+    let max_suggestions = (term_size.0 as usize - 3).min(MAX_SUGGESTIONS);
+
+    let mut prompt = "[ENTER] Confirm\nSpecify package name";
+
+    // Suggest possible names.
+    if !suggestions.is_empty() {
+        prompt = "[ENTER] Confirm\nEnter number or specify package name";
+
+        for (i, suggestion) in suggestions.iter().take(max_suggestions).enumerate().rev() {
+            println!("({i}) {}", suggestion.combined_name());
+        }
+        println!();
+    }
+
+    let input: String = Input::new().with_prompt(prompt).interact_text()?;
+
+    let purl = match usize::from_str(&input) {
+        Ok(index) if index < suggestions.len() && index < MAX_SUGGESTIONS => {
+            suggestions[index].clone()
+        },
+        _ => Purl::builder_with_combined_name(ecosystem, &input).build()?,
+    };
+
+    println!("Using package {}\n", purl.combined_name());
+
+    Ok(purl)
+}
+
+/// Ask for a package version.
+fn prompt_version(suggestions: &'_ IndexSet<String>) -> dialoguer::Result<Cow<'_, str>> {
+    // Get space available for suggestions.
+    let term_size = Term::stdout().size_checked().unwrap_or((u16::MAX, u16::MAX));
+    let max_suggestions = (term_size.0 as usize - 3).min(MAX_SUGGESTIONS);
+
+    let mut prompt = "[ENTER] Confirm\nSpecify package version";
+
+    // Suggest possible names.
+    if !suggestions.is_empty() {
+        prompt = "[ENTER] Confirm\nEnter number or specify package name";
+
+        for (i, suggestion) in suggestions.iter().take(max_suggestions).enumerate().rev() {
+            println!("({i}) {suggestion}");
+        }
+        println!();
+    }
+
+    let input: String = Input::new().with_prompt(prompt).interact_text()?;
+
+    let version: Cow<'_, str> = match usize::from_str(&input) {
+        Ok(index) if index < suggestions.len() && index < MAX_SUGGESTIONS => {
+            Cow::Borrowed(&suggestions[index])
+        },
+        _ => Cow::Owned(input),
+    };
+
+    println!("Using version {version:?}\n");
+
+    Ok(version)
+}
+
+/// Ask for suppression reason.
+fn prompt_reason() -> dialoguer::Result<String> {
+    let prompt = "[ENTER] Confirm\nEnter reason for this exception";
+    let reason: String = Input::new().with_prompt(prompt).interact_text()?;
+    println!("Using reason {reason:?}\n");
+    Ok(reason)
+}
+
+/// Ask for suppression reason.
+fn prompt_removal<'a>(preferences: &'a Preferences<'a>) -> dialoguer::Result<Suppression<'a>> {
+    let ignored_packages = preferences.ignored_packages.iter().map(|pkg| Cow::Borrowed(&*pkg.purl));
+    let ignored_issues = preferences
+        .ignored_issues
+        .iter()
+        .map(|issue| Cow::Owned(format!("[{}] {}", issue.tag, issue.id)));
+    let exceptions: Vec<_> = ignored_packages.chain(ignored_issues).collect();
+
+    let prompt = "[ENTER] Select and Confirm\nSelect exception";
+    let index = FuzzySelect::new().with_prompt(prompt).items(&exceptions).interact()?;
+
+    println!();
+
+    match index.checked_sub(preferences.ignored_packages.len()) {
+        Some(index) => Ok(Suppression::from(&preferences.ignored_issues[index])),
+        None => Ok(Suppression::from(&preferences.ignored_packages[index])),
+    }
+}

--- a/cli/src/commands/exception.rs
+++ b/cli/src/commands/exception.rs
@@ -165,7 +165,7 @@ pub async fn handle_remove(api: &PhylumApi, matches: &ArgMatches, config: Config
             Some(Err(err)) => return Err(err.into()),
             None => {
                 let package_type = match package_type {
-                    Some(package_type) => Some(PackageType::from_str(&package_type)?),
+                    Some(package_type) => Some(PackageType::from_str(package_type)?),
                     None => None,
                 };
                 let name = name.map(|name| Cow::Borrowed(name.as_str()));

--- a/cli/src/commands/exception.rs
+++ b/cli/src/commands/exception.rs
@@ -108,7 +108,7 @@ pub async fn handle_add(api: &PhylumApi, matches: &ArgMatches, config: Config) -
     };
 
     // Build suppression API object.
-    let suppressions = vec![Suppression::Package(IgnoredPackage {
+    let suppressions = [Suppression::Package(IgnoredPackage {
         purl: Cow::Owned(purl.to_string()),
         reason: Cow::Borrowed(&reason),
     })];
@@ -122,7 +122,7 @@ pub async fn handle_add(api: &PhylumApi, matches: &ArgMatches, config: Config) -
         None => api.group_suppress(org, group.unwrap(), &suppressions).await?,
     }
 
-    print_user_success!("Successfully added suppression for {}", purl.to_string());
+    print_user_success!("Successfully added suppression for {}", purl);
 
     Ok(ExitCode::Ok)
 }
@@ -186,7 +186,7 @@ pub async fn handle_remove(api: &PhylumApi, matches: &ArgMatches, config: Config
         });
     }
 
-    let unsuppressions = vec![prompt_removal(&exceptions)?];
+    let unsuppressions = [prompt_removal(&exceptions)?];
 
     match project {
         Some(project_name) => {
@@ -199,7 +199,7 @@ pub async fn handle_remove(api: &PhylumApi, matches: &ArgMatches, config: Config
 
     match &unsuppressions[0] {
         Suppression::Package(IgnoredPackage { purl, .. }) => {
-            print_user_success!("Successfully removed suppression for package {purl:?}");
+            print_user_success!("Successfully removed suppression for package {purl}");
         },
         Suppression::Issue(IgnoredIssue { id, tag, .. }) => {
             print_user_success!("Successfully removed suppression for issue {tag:?} [{id}]");

--- a/cli/src/commands/firewall.rs
+++ b/cli/src/commands/firewall.rs
@@ -1,17 +1,16 @@
 //! Subcommand `phylum firewall`.
 
-use std::borrow::Cow;
 use std::str::FromStr;
 
 use clap::ArgMatches;
-use purl::Purl;
+use purl::{PackageType, Purl};
 
 use crate::api::PhylumApi;
 use crate::commands::{CommandResult, ExitCode};
 use crate::config::Config;
 use crate::format::Format;
 use crate::print_user_failure;
-use crate::types::FirewallLogFilter;
+use crate::types::{FirewallAction, FirewallLogFilter};
 
 /// Handle `phylum firewall` subcommand.
 pub async fn handle_firewall(
@@ -33,7 +32,7 @@ pub async fn handle_log(api: &PhylumApi, matches: &ArgMatches, config: Config) -
     // Get log filter args.
     let ecosystem = matches.get_one::<String>("ecosystem");
     let purl = matches.get_one::<String>("package");
-    let action = matches.get_one::<String>("action");
+    let action = matches.get_one::<FirewallAction>("action");
     let before = matches.get_one::<String>("before");
     let after = matches.get_one::<String>("after");
     let limit = matches.get_one::<i64>("limit").unwrap();
@@ -42,26 +41,28 @@ pub async fn handle_log(api: &PhylumApi, matches: &ArgMatches, config: Config) -
     let parsed_purl = purl.map(|purl| Purl::from_str(purl));
     let (ecosystem, namespace, name, version) = match &parsed_purl {
         Some(Ok(purl)) => {
-            let ecosystem = Cow::Owned(purl.package_type().to_string());
-            (Some(ecosystem), purl.namespace(), Some(purl.name()), purl.version())
+            (Some(*purl.package_type()), purl.namespace(), Some(purl.name()), purl.version())
         },
         Some(Err(err)) => {
             print_user_failure!("Could not parse purl {purl:?}: {err}");
             return Ok(ExitCode::Generic);
         },
-        None => (ecosystem.map(Cow::Borrowed), None, None, None),
+        None => {
+            let ecosystem = ecosystem.and_then(|ecosystem| PackageType::from_str(ecosystem).ok());
+            (ecosystem, None, None, None)
+        },
     };
 
     // Construct the filter.
     let filter = FirewallLogFilter {
-        ecosystem: ecosystem.as_ref().map(|e| e.as_str()),
+        ecosystem,
         namespace,
-        name,
         version,
-        action: action.map(String::as_str),
+        name,
         before: before.map(String::as_str),
         after: after.map(String::as_str),
         limit: Some(*limit as i32),
+        action: action.copied(),
     };
 
     let response = api.firewall_log(org, group, filter).await?;

--- a/cli/src/commands/firewall.rs
+++ b/cli/src/commands/firewall.rs
@@ -30,16 +30,16 @@ pub async fn handle_log(api: &PhylumApi, matches: &ArgMatches, config: Config) -
     let group = matches.get_one::<String>("group").unwrap();
 
     // Get log filter args.
-    let ecosystem = matches.get_one::<String>("ecosystem");
-    let purl = matches.get_one::<String>("package");
+    let package_type = matches.get_one::<String>("package-type");
     let action = matches.get_one::<FirewallAction>("action");
     let before = matches.get_one::<String>("before");
     let after = matches.get_one::<String>("after");
+    let purl = matches.get_one::<String>("purl");
     let limit = matches.get_one::<i64>("limit").unwrap();
 
     // Parse PURL filter.
     let parsed_purl = purl.map(|purl| Purl::from_str(purl));
-    let (ecosystem, namespace, name, version) = match &parsed_purl {
+    let (package_type, namespace, name, version) = match &parsed_purl {
         Some(Ok(purl)) => {
             (Some(*purl.package_type()), purl.namespace(), Some(purl.name()), purl.version())
         },
@@ -48,20 +48,20 @@ pub async fn handle_log(api: &PhylumApi, matches: &ArgMatches, config: Config) -
             return Ok(ExitCode::Generic);
         },
         None => {
-            let ecosystem = ecosystem.and_then(|ecosystem| PackageType::from_str(ecosystem).ok());
-            (ecosystem, None, None, None)
+            let package_type = package_type.and_then(|pt| PackageType::from_str(pt).ok());
+            (package_type, None, None, None)
         },
     };
 
     // Construct the filter.
     let filter = FirewallLogFilter {
-        ecosystem,
         namespace,
         version,
         name,
         before: before.map(String::as_str),
         after: after.map(String::as_str),
         limit: Some(*limit as i32),
+        ecosystem: package_type,
         action: action.copied(),
     };
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use std::process;
 
 pub mod auth;
+pub mod exception;
 #[cfg(feature = "extensions")]
 pub mod extensions;
 pub mod find_dependency_files;

--- a/docs/commands/phylum.md
+++ b/docs/commands/phylum.md
@@ -39,6 +39,7 @@ Usage: phylum [OPTIONS] [COMMAND]
 
 * [phylum analyze](./phylum_analyze.md)
 * [phylum auth](./phylum_auth.md)
+* [phylum exception](./phylum_exception.md)
 * [phylum extension](./phylum_extension.md)
 * [phylum firewall](./phylum_firewall.md)
 * [phylum group](./phylum_group.md)

--- a/docs/commands/phylum_exception.md
+++ b/docs/commands/phylum_exception.md
@@ -1,0 +1,27 @@
+# phylum exception
+
+Manage analysis exceptions
+
+```sh
+Usage: phylum exception [OPTIONS] <COMMAND>
+```
+
+## Options
+
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help
+
+## Commands
+
+* [phylum exception add](./phylum_exception_add.md)
+* [phylum exception list](./phylum_exception_list.md)
+* [phylum exception remove](./phylum_exception_remove.md)

--- a/docs/commands/phylum_exception_add.md
+++ b/docs/commands/phylum_exception_add.md
@@ -1,0 +1,46 @@
+# phylum exception add
+
+Add a new analysis exception
+
+```sh
+Usage: phylum exception add [OPTIONS] <--group <GROUP_NAME>|--project <PROJECT_NAME>>
+```
+
+## Options
+
+`-g`, `--group` `<GROUP_NAME>`
+&emsp; Group to add exception to
+
+`-p`, `--project` `<PROJECT_NAME>`
+&emsp; Project to add exceptions to
+
+`-e`, `--ecosystem` `<ECOSYSTEM>`
+&emsp; Ecosystem of the package to add an exception for
+&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
+
+`-n`, `--name` `<PACKAGE_NAME>`
+&emsp; Name and optional namespace of the package to add an exception for
+
+`--version` `<VERSION>`
+&emsp; Version of the package to add an exception for
+
+`--purl` `<PURL>`
+&emsp; Package in PURL format
+
+`-r`, `--reason` `<REASON>`
+&emsp; Reason for adding this exception
+
+`-s`, `--no-suggestions`
+&emsp; Do not query package firewall to make suggestions
+
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help

--- a/docs/commands/phylum_exception_add.md
+++ b/docs/commands/phylum_exception_add.md
@@ -14,12 +14,12 @@ Usage: phylum exception add [OPTIONS] <--group <GROUP_NAME>|--project <PROJECT_N
 `-p`, `--project` `<PROJECT_NAME>`
 &emsp; Project to add exceptions to
 
-`-e`, `--ecosystem` `<ECOSYSTEM>`
-&emsp; Ecosystem of the package to add an exception for
-&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
+`--package-type` `<PACKAGE_TYPE>`
+&emsp; Package type of the package to add an exception for
+&emsp; Accepted values: `npm`, `gem`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
 
 `-n`, `--name` `<PACKAGE_NAME>`
-&emsp; Name and optional namespace of the package to add an exception for
+&emsp; Fully qualified name of the package to add an exception for
 
 `--version` `<VERSION>`
 &emsp; Version of the package to add an exception for

--- a/docs/commands/phylum_exception_list.md
+++ b/docs/commands/phylum_exception_list.md
@@ -1,0 +1,30 @@
+# phylum exception list
+
+List active analysis exceptions
+
+```sh
+Usage: phylum exception list [OPTIONS] <--group <GROUP_NAME>|--project <PROJECT_NAME>>
+```
+
+## Options
+
+`-j`, `--json`
+&emsp; Produce output in json format (default: false)
+
+`-g`, `--group` `<GROUP_NAME>`
+&emsp; Group to list exceptions for
+
+`-p`, `--project` `<PROJECT_NAME>`
+&emsp; Project to list exceptions for
+
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help

--- a/docs/commands/phylum_exception_remove.md
+++ b/docs/commands/phylum_exception_remove.md
@@ -1,0 +1,46 @@
+# phylum exception remove
+
+Remove an existing analysis exception
+
+```sh
+Usage: phylum exception remove [OPTIONS] <--group <GROUP_NAME>|--project <PROJECT_NAME>>
+```
+
+## Options
+
+`-g`, `--group` `<GROUP_NAME>`
+&emsp; Group to add exception to
+
+`-p`, `--project` `<PROJECT_NAME>`
+&emsp; Project to add exceptions to
+
+`-e`, `--ecosystem` `<ECOSYSTEM>`
+&emsp; Ecosystem of the exception which should be removed
+&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
+
+`-n`, `--name` `<PACKAGE_NAME>`
+&emsp; Package name and optional namespace of the exception which should be removed
+
+`--version` `<VERSION>`
+&emsp; Package version of the exception which should be removed
+
+`--purl` `<PURL>`
+&emsp; Package in PURL format
+
+`--id` `<ISSUE_ID>`
+&emsp; Issue ID of the exception which should be removed
+
+`--tag` `<ISSUE_TAG>`
+&emsp; Issue tag of the exception which should be removed
+
+`-o`, `--org` `<ORG>`
+&emsp; Phylum organization
+
+`-v`, `--verbose`...
+&emsp; Increase the level of verbosity (the maximum is -vvv)
+
+`-q`, `--quiet`...
+&emsp; Reduce the level of verbosity (the maximum is -qq)
+
+`-h`, `--help`
+&emsp; Print help

--- a/docs/commands/phylum_exception_remove.md
+++ b/docs/commands/phylum_exception_remove.md
@@ -9,17 +9,17 @@ Usage: phylum exception remove [OPTIONS] <--group <GROUP_NAME>|--project <PROJEC
 ## Options
 
 `-g`, `--group` `<GROUP_NAME>`
-&emsp; Group to add exception to
+&emsp; Group to remove exception from
 
 `-p`, `--project` `<PROJECT_NAME>`
-&emsp; Project to add exceptions to
+&emsp; Project to remove exceptions from
 
-`-e`, `--ecosystem` `<ECOSYSTEM>`
-&emsp; Ecosystem of the exception which should be removed
-&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
+`--package-type` `<PACKAGE_TYPE>`
+&emsp; Package type of the exception which should be removed
+&emsp; Accepted values: `npm`, `gem`, `pypi`, `maven`, `nuget`, `golang`, `cargo`
 
 `-n`, `--name` `<PACKAGE_NAME>`
-&emsp; Package name and optional namespace of the exception which should be removed
+&emsp; Fully qualified package name of the exception which should be removed
 
 `--version` `<VERSION>`
 &emsp; Package version of the exception which should be removed

--- a/docs/commands/phylum_firewall_log.md
+++ b/docs/commands/phylum_firewall_log.md
@@ -9,7 +9,7 @@ Usage: phylum firewall log [OPTIONS] <GROUP_NAME>
 ## Arguments
 
 `<GROUP_NAME>`
-&emsp; Specify a group to use for analysis
+&emsp; Firewall group to list log activity for
 
 ## Options
 

--- a/docs/commands/phylum_firewall_log.md
+++ b/docs/commands/phylum_firewall_log.md
@@ -16,11 +16,11 @@ Usage: phylum firewall log [OPTIONS] <GROUP_NAME>
 `-j`, `--json`
 &emsp; Produce output in json format (default: false)
 
-`--ecosystem` `<ECOSYSTEM>`
-&emsp; Only show logs matching this ecosystem
-&emsp; Accepted values: `npm`, `rubygems`, `pypi`, `maven`, `nuget`, `cargo`
+`--package-type` `<PACKAGE_TYPE>`
+&emsp; Only show logs matching this package type
+&emsp; Accepted values: `npm`, `gem`, `pypi`, `maven`, `nuget`, `cargo`
 
-`--package` `<PURL>`
+`--purl` `<PURL>`
 &emsp; Only show logs matching this PURL
 
 `--action` `<ACTION>`


### PR DESCRIPTION
This patch adds a new `phylum exception` subcommand, with the three
`add`, `remove`, and `list` commands under it. These new subcommands
allow managing package exceptions to remove friction with Phylum's
firewall.

The add and remove subcommands are targeted at interactive use, pulling
logs from the package firewall and existing exceptions to suggest what
is most likely to be used for adding/removing an exception.

While currently firewall logs are pulled for adding exceptions, the
individual analysis results for each version are not listed in the
suggestions.

The `list` and `remove` subcommand allow managing both package and issue
suppressions, however `add` currently only supports adding package
exceptions.

Closes https://github.com/phylum-dev/cli/issues/1552.

---

This got a lot bigger than I initially anticipated, but it should provide a pretty nice user experience for firewall users.