### PR TITLE
Fix `msbuild` parser allowing missing versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `phylum exception` subcommand for managing suppressions
 
+### Fixed
+
+- `msbuild` lockfile parser allowing missing names and versions
+
 ## 7.2.0 - 2024-12-10
 
 ### Added

--- a/tests/fixtures/sample.csproj
+++ b/tests/fixtures/sample.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
@@ -20,6 +21,7 @@
     <PackageReference Include="System.Collections.Immutable">
       <version>1.5.0</version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change updates the `msbuild` lockfile parser so that it will not allow for missing names and or versions. Before this change, a `*.csproj` file parsed as a lockfile (e.g., with type of `msbuild`) would show entries with missing name or version as an empty string. This causes analysis failures when submitting to the API since a valid package descriptor requires a non-empty `version` field.

Dependency management in NuGet's "Central Package Management" (CPM) allows for `*.csproj` files containing `PackageReference` elements without a `Version` attribute. Those versions will be included, along with the fully transitive set, in the `packages.lock.json` lockfile generated by NuGet. When both files are present in the same directory, the changes in this patch will correctly parse both. For more about CPM, see this reference:

https://devblogs.microsoft.com/nuget/introducing-central-package-management/

The `sample.csproj` test fixture was updated to include an entry with neither a name or version and another entry with a name but no version.
