### PR TITLE
Fix test failure to to phylum.io redirect

### DIFF
--- a/cli/src/permissions.rs
+++ b/cli/src/permissions.rs
@@ -264,7 +264,7 @@ impl From<&Permissions> for PermissionsOptions {
 
         let mut allow_net = value.net.clone();
 
-        // Add net exceptions to phylum.io's domains by default.
+        // Add net exceptions to Veracode's domains by default.
         allow_net.allow_resource("api.staging.phylum.io".into());
         allow_net.allow_resource("api.phylum.io".into());
 

--- a/cli/tests/extensions/permissions.rs
+++ b/cli/tests/extensions/permissions.rs
@@ -70,7 +70,7 @@ fn incorrect_net_permission_unsuccessful_run() {
     test_cli
         .run(["incorrect-net-perms"])
         .failure()
-        .stderr("❗ Error: Requires net access to \"phylum.io:443\"\n");
+        .stderr("❗ Error: Requires net access to \"veracode.com:443\"\n");
 }
 
 #[test]

--- a/cli/tests/fixtures/extensions/permissions/correct-net-perms/PhylumExt.toml
+++ b/cli/tests/fixtures/extensions/permissions/correct-net-perms/PhylumExt.toml
@@ -3,4 +3,4 @@ description = "An extension with correctly specified permissions"
 entry_point = "main.ts"
 
 [permissions]
-net = ["www.phylum.io"]
+net = ["www.veracode.com"]

--- a/cli/tests/fixtures/extensions/permissions/correct-net-perms/main.ts
+++ b/cli/tests/fixtures/extensions/permissions/correct-net-perms/main.ts
@@ -1,4 +1,4 @@
-let response = await fetch('https://www.phylum.io')
+let response = await fetch('https://www.veracode.com')
 let release = await response.text()
 
 console.log(release)

--- a/cli/tests/fixtures/extensions/permissions/incorrect-net-perms/PhylumExt.toml
+++ b/cli/tests/fixtures/extensions/permissions/incorrect-net-perms/PhylumExt.toml
@@ -3,4 +3,4 @@ description = "An extension with incorrectly specified permissions"
 entry_point = "main.ts"
 
 [permissions]
-net = ["phylum.dev"]
+net = ["veracode.dev"]

--- a/cli/tests/fixtures/extensions/permissions/incorrect-net-perms/main.ts
+++ b/cli/tests/fixtures/extensions/permissions/incorrect-net-perms/main.ts
@@ -1,4 +1,4 @@
-let response = await fetch('https://phylum.io')
+let response = await fetch('https://veracode.com')
 let release = await response.json()
 
 console.log(release)

--- a/lockfile/src/cargo.rs
+++ b/lockfile/src/cargo.rs
@@ -185,7 +185,7 @@ mod tests {
             Package {
                 name: "zstd-sys".into(),
                 version: PackageVersion::ThirdParty(ThirdPartyVersion {
-                    registry: "https://phylum.io/foreign-registry-example".into(),
+                    registry: "https://invalid.veracode.com/foreign-registry-example".into(),
                     version: "1.6.3+zstd.1.5.2".into(),
                 }),
                 package_type: PackageType::Cargo,

--- a/lockfile/src/python.rs
+++ b/lockfile/src/python.rs
@@ -304,7 +304,7 @@ mod tests {
             Package {
                 name: "other-registry-a".into(),
                 version: PackageVersion::ThirdParty(ThirdPartyVersion {
-                    registry: "https://mirror1.phylum.io/simple/".into(),
+                    registry: "https://mirror1.veracode.com/simple/".into(),
                     version: "3.2.1".into(),
                 }),
                 package_type: PackageType::PyPi,
@@ -312,7 +312,7 @@ mod tests {
             Package {
                 name: "other-registry".into(),
                 version: PackageVersion::ThirdParty(ThirdPartyVersion {
-                    registry: "https://mirror2.phylum.io/simple/".into(),
+                    registry: "https://mirror2.veracode.com/simple/".into(),
                     version: "1.2.3".into(),
                 }),
                 package_type: PackageType::PyPi,

--- a/tests/fixtures/Cargo_v3.lock
+++ b/tests/fixtures/Cargo_v3.lock
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "1.6.3+zstd.1.5.2"
-source = "registry+https://phylum.io/foreign-registry-example"
+source = "registry+https://invalid.veracode.com/foreign-registry-example"
 checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",

--- a/tests/fixtures/requirements-locked.txt
+++ b/tests/fixtures/requirements-locked.txt
@@ -36,9 +36,9 @@ tomli @ https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a25
 
 -e /tmp/editable ; python_version >= "3.7" and python_version < "3.12"
 
---index-url https://unused.phylum.io/simple/
---index-url=https://mirror1.phylum.io/simple/
+--index-url https://unused.veracode.com/simple/
+--index-url=https://mirror1.veracode.com/simple/
 other-registry-a==3.2.1
--ihttps://mirror2.phylum.io/simple/
---extra-index-url=https://mirror3.phylum.io/simple/
+-ihttps://mirror2.veracode.com/simple/
+--extra-index-url=https://mirror3.veracode.com/simple/
 other-registry==1.2.3


### PR DESCRIPTION
This fixes an issue caused by phylum.io redirecting to veracode.com, which caused our sandbox to complain that network access permissions to veracode.com were missing.

Some other tests also used `phylum.io` as dummy URIs. While these were never hit, they've been replaced for consistency and future-proofing.

There are still several instances referencing `api.phylum.io` or `docs.phylum.io`, which have been left unchanged since no Veracode alternative exists yet.
