### PR TITLE
add default exception for nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Nix store access to the default sandbox
+
 ### Fixed
 
 - Unclear error when running `phylum init` with an invalid organization

--- a/cli/src/permissions.rs
+++ b/cli/src/permissions.rs
@@ -310,6 +310,9 @@ pub fn default_sandbox() -> SandboxResult<Birdcage> {
     add_exception(&mut birdcage, Exception::ExecuteAndRead("/opt/homebrew".into()))?;
     add_exception(&mut birdcage, Exception::ExecuteAndRead("/usr/local".into()))?;
 
+    // NixOS stores all system files under /nix/store.
+    add_exception(&mut birdcage, Exception::ExecuteAndRead("/nix/store".into()))?;
+
     // Allow access to DNS list.
     //
     // While this is required to send DNS requests for network queries, this does


### PR DESCRIPTION
With Nix (including NixOS), software is installed into /nix/store and resolved using environment variables or configuration files or symbolic links. For example, if you install the jdk package your java installation will be somewhere like `/nix/store/3dhyjzr2j852wxgsaij64xgm74h6wgfp-openjdk-21.0.5+11/bin/java` and resolved using symbolic links or `PATH` depending on the installation method. Therefore, if `/nix/store` isn't readable and executable you won't be able to run anything installed using Nix (or practically anything at all on NixOS).

There is a chance that this allows a malicious package to read sensitive files under `/nix/store`. This should be uncommon. Users aren't supposed to put secrets directly into the Nix store because the files all have 0444 or 0555 permissions. However, it doesn't seem unlikely that a user might be using Nix to build private source code, which would leave a copy of that source code in the store where it would be made accessible by this change. I doubt it's a big enough deal that Nix support would require querying for and whitelisting specific packages.

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
