### PR TITLE
add Mac Java paths to depfile_parsing_sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Nix store access to the default sandbox
+- Mac OS's Library/Java/JavaVirtualMachines paths to the dependency parsing sandbox
 
 ### Fixed
 

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -473,6 +473,14 @@ fn depfile_parsing_sandbox(canonical_manifest_path: &Path) -> Result<Birdcage> {
         &mut birdcage,
         Exception::ExecuteAndRead("/etc/alternatives".into()),
     )?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::ExecuteAndRead("/Library/Java/JavaVirtualMachines".into()),
+    )?;
+    permissions::add_exception(
+        &mut birdcage,
+        Exception::ExecuteAndRead(home.join("Library/Java/JavaVirtualMachines")),
+    )?;
     permissions::add_exception(&mut birdcage, Exception::ExecuteAndRead("/etc/maven".into()))?;
     for jdk_path in jdk_paths()? {
         permissions::add_exception(&mut birdcage, Exception::Read(jdk_path))?;


### PR DESCRIPTION
MacOS normally installs JDKs in these locations: https://nanova.me/posts/macos-jdk-path

That page also references a `~/.jenv` directory which I did not add. I don't know if there's any reason not to add it.

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?
- [ ] Have you updated all affected documentation?
- [x] Have you updated CHANGELOG.md (or extensions/CHANGELOG.md), if applicable
