### PR TITLE
Update language for Veracode transition

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[engineering@phylum.io](mailto:engineering@phylum.io).
+[dl-phylum-engineering@veracode.com](mailto:dl-phylum-engineering@veracode.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Table of Contents:
    1. [Testing](#testing)
    2. [Documentation](#documentation)
    3. [Style](#style)
+      1. [Rust](#rust)
+      2. [Extensions](#extensions)
+      3. [Shell scripts](#shell-scripts)
 4. [Contact](#contact)
 
 ## Bug Reports
@@ -137,7 +140,7 @@ shellcheck -o all -S style -s sh $(find . -iname "*.sh")
 If there are any outstanding questions about contributing to the Phylum CLI,
 they can be asked on the [issue tracker].
 
-As an alternative, you can also contact <support@phylum.io> for issues with
-using the Phylum CLI.
+As an alternative, you can also contact `dl-phylum-engineering@veracode.com` for
+issues with using the Phylum CLI.
 
 [issue tracker]: https://github.com/phylum-dev/cli/issues

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Test Status](https://github.com/phylum-dev/cli/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/phylum-dev/cli/actions/workflows/test.yml)
 [![Docusaurus](https://img.shields.io/badge/docs-Docusaurus-blue)](https://docs.phylum.io)
 
-The Phylum command line interface (CLI) allows users to submit their project package dependencies to [Phylum's](https://phylum.io) API for analysis. Currently [pre-built binaries](https://github.com/phylum-dev/cli/releases) for Linux and macOS are available. On Windows, we recommend using the Linux binaries under [WSL](https://learn.microsoft.com/en-us/windows/wsl/). See the [alternate installation methods](https://docs.phylum.io/cli/alternate_install) for more options.
+The Phylum command line interface (CLI) allows users to submit their project package dependencies to [Phylum's](https://app.phylum.io) API for analysis. Currently [pre-built binaries](https://github.com/phylum-dev/cli/releases) for Linux and macOS are available. On Windows, we recommend using the Linux binaries under [WSL](https://learn.microsoft.com/en-us/windows/wsl/). See the [alternate installation methods](https://docs.phylum.io/cli/alternate_install) for more options.
 
 ## Install `phylum` CLI
 
@@ -101,7 +101,7 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/gpl.html> or write to
-`phylum@phylum.io` or `engineering@phylum.io`
+`phylum@veracode.com` or `dl-phylum-engineering@veracode.com`
 
 ---
 ## Discord
@@ -112,4 +112,4 @@ Join us on the [Phylum Community Discord](https://discord.gg/c9QnknWxm3)!
 
 Please contact Phylum with any questions or issues using the CLI tool.
 
-Email: <support@phylum.io>
+Email: `dl-phylum-engineering@veracode.com`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,6 @@ Phylum was founded by a team of security researchers at heart, and we take the s
 ## Reporting a Vulnerability
 
 We love coordinated disclosure!
-Please email [security@phylum.io](mailto:security@phylum.io) to start a conversation!
+Please email [phylum@veracode.com](mailto:phylum@veracode.com) to start a conversation!
 We'll coordinate a secure communication mechanism first, then evaluate the reported issue(s)
 and keep you apprised each step of the way.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylum-cli"
 version = "7.3.0"
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
 rust-version = "1.82.0"
@@ -23,7 +23,10 @@ anyhow = "1.0.44"
 axum = "0.7.4"
 base64 = "0.22.1"
 bytes = "1.1.0"
-chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
+chrono = { version = "^0.4", default-features = false, features = [
+    "serde",
+    "clock",
+] }
 cidr = "0.3.0"
 clap = { version = "4.0.9", features = ["string", "wrap_help"] }
 console = "0.15.2"
@@ -52,7 +55,13 @@ prettytable-rs = "0.10.0"
 purl = { version = "0.1.5", features = ["serde"] }
 rand = "0.8.4"
 regex = "1.5.5"
-reqwest = { version = "0.12.7", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "rustls-tls-webpki-roots"], default-features = false }
+reqwest = { version = "0.12.7", features = [
+    "blocking",
+    "json",
+    "rustls-tls",
+    "rustls-tls-native-roots",
+    "rustls-tls-webpki-roots",
+], default-features = false }
 rsa = { version = "0.9.2", features = ["sha2"] }
 serde_json = "1.0.85"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/cli/tests/extensions/mod.rs
+++ b/cli/tests/extensions/mod.rs
@@ -256,7 +256,7 @@ fn net_sandboxing_fail() {
             try {
                 const output = Phylum.runSandboxed({
                     cmd: 'curl',
-                    args: ['http://phylum.io'],
+                    args: ['http://veracode.com'],
                 });
                 Deno.exit(output.code);
             } catch (e) {
@@ -286,7 +286,7 @@ fn net_sandboxing_success() {
         .extension("
             const output = Phylum.runSandboxed({
                 cmd: 'curl',
-                args: ['http://phylum.io'],
+                args: ['http://veracode.com'],
                 exceptions: { env: true, run: true, net: true },
             });
             Deno.exit(output.code);

--- a/cli/tests/sandbox.rs
+++ b/cli/tests/sandbox.rs
@@ -95,9 +95,9 @@ fn default_deny_net() {
     let test_cli = TestCli::builder().build();
 
     test_cli
-        .run(["sandbox", "--allow-run", "/", "--allow-env", "--", "curl", "http://phylum.io"])
+        .run(["sandbox", "--allow-run", "/", "--allow-env", "--", "curl", "http://veracode.com"])
         .failure()
-        .stderr(predicate::str::contains("Could not resolve host: phylum.io"));
+        .stderr(predicate::str::contains("Could not resolve host: veracode.com"));
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn allow_net() {
             "--allow-env",
             "--allow-net",
             "curl",
-            "http://phylum.io",
+            "http://veracode.com",
         ])
         .success();
 }

--- a/doc_templates/phylum_group_member_add.md
+++ b/doc_templates/phylum_group_member_add.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Add user `demo@phylum.io` to the `sample` group
-$ phylum group member --group sample add demo@phylum.io
+# Add user `demo@veracode.com` to the `sample` group
+$ phylum group member --group sample add demo@veracode.com
 ```

--- a/doc_templates/phylum_group_member_remove.md
+++ b/doc_templates/phylum_group_member_remove.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group sample remove demo@phylum.io
+# Remove user `demo@veracode.com` from the `sample` group
+$ phylum group member --group sample remove demo@veracode.com
 ```

--- a/doc_templates/phylum_org_member_add.md
+++ b/doc_templates/phylum_org_member_add.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Add user `demo@phylum.io` to the `sample` organization
-$ phylum org -o sample member add demo@phylum.io
+# Add user `demo@veracode.com` to the `sample` organization
+$ phylum org -o sample member add demo@veracode.com
 ```

--- a/doc_templates/phylum_org_member_remove.md
+++ b/doc_templates/phylum_org_member_remove.md
@@ -5,6 +5,6 @@
 ## Examples
 
 ```sh
-# Remove user `demo@phylum.io` from the `sample` organization
-$ phylum org -o sample member remove demo@phylum.io
+# Remove user `demo@veracode.com` from the `sample` organization
+$ phylum org -o sample member remove demo@veracode.com
 ```

--- a/docs/commands/phylum_group_member_add.md
+++ b/docs/commands/phylum_group_member_add.md
@@ -28,6 +28,6 @@ Usage: phylum group member --group <GROUP> add [OPTIONS] <USER>...
 ## Examples
 
 ```sh
-# Add user `demo@phylum.io` to the `sample` group
-$ phylum group member --group sample add demo@phylum.io
+# Add user `demo@veracode.com` to the `sample` group
+$ phylum group member --group sample add demo@veracode.com
 ```

--- a/docs/commands/phylum_group_member_remove.md
+++ b/docs/commands/phylum_group_member_remove.md
@@ -28,6 +28,6 @@ Usage: phylum group member --group <GROUP> remove [OPTIONS] <USER>...
 ## Examples
 
 ```sh
-# Remove user `demo@phylum.io` from the `sample` group
-$ phylum group member --group sample remove demo@phylum.io
+# Remove user `demo@veracode.com` from the `sample` group
+$ phylum group member --group sample remove demo@veracode.com
 ```

--- a/docs/commands/phylum_org_member_add.md
+++ b/docs/commands/phylum_org_member_add.md
@@ -28,6 +28,6 @@ Usage: phylum org member add [OPTIONS] <USER>...
 ## Examples
 
 ```sh
-# Add user `demo@phylum.io` to the `sample` organization
-$ phylum org -o sample member add demo@phylum.io
+# Add user `demo@veracode.com` to the `sample` organization
+$ phylum org -o sample member add demo@veracode.com
 ```

--- a/docs/commands/phylum_org_member_remove.md
+++ b/docs/commands/phylum_org_member_remove.md
@@ -28,6 +28,6 @@ Usage: phylum org member remove [OPTIONS] <USER>...
 ## Examples
 
 ```sh
-# Remove user `demo@phylum.io` from the `sample` organization
-$ phylum org -o sample member remove demo@phylum.io
+# Remove user `demo@veracode.com` from the `sample` organization
+$ phylum org -o sample member remove demo@veracode.com
 ```

--- a/docs/extensions/extension_manifest.md
+++ b/docs/extensions/extension_manifest.md
@@ -205,7 +205,7 @@ array containing the allowed domains.
 ```toml
 [permissions]
 # ...
-net = ["www.phylum.io", "phylum.io"]
+net = ["www.veracode.com", "veracode.com"]
 ```
 
 ```toml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-The Phylum command line interface (CLI) allows users to submit their project package dependencies to [Phylum's](https://phylum.io) API for analysis. Currently [pre-built binaries](https://github.com/phylum-dev/cli/releases) for Linux and macOS are available. On Windows, we recommend using the Linux binaries under [WSL](https://learn.microsoft.com/en-us/windows/wsl/). See the [alternate installation methods](./alternate_install.md) for more options.
+The Phylum command line interface (CLI) allows users to submit their project package dependencies to [Phylum's](https://app.phylum.io) API for analysis. Currently [pre-built binaries](https://github.com/phylum-dev/cli/releases) for Linux and macOS are available. On Windows, we recommend using the Linux binaries under [WSL](https://learn.microsoft.com/en-us/windows/wsl/). See the [alternate installation methods](./alternate_install.md) for more options.
 
 ## Install `phylum` CLI
 
@@ -67,7 +67,7 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/gpl.html> or write to
-`phylum@phylum.io` or `engineering@phylum.io`
+`phylum@veracode.com` or `dl-phylum-engineering@veracode.com`
 
 ## Discord
 
@@ -77,4 +77,4 @@ Join us on the [Phylum Community Discord](https://discord.gg/c9QnknWxm3)!
 
 Please contact Phylum with any questions or issues using the CLI tool.
 
-Email: <support@phylum.io>
+Email: `dl-phylum-engineering@veracode.com`

--- a/extensions/bundle/README.md
+++ b/extensions/bundle/README.md
@@ -5,7 +5,7 @@ before installing them.
 
 [Phylum CLI]: https://github.com/phylum-dev/cli
 [bundle]: https://bundler.io
-[Phylum]: https://phylum.io
+[Phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/extensions/cargo/README.md
+++ b/extensions/cargo/README.md
@@ -5,7 +5,7 @@ before installing them.
 
 [Phylum CLI]: https://github.com/phylum-dev/cli
 [cargo]: https://doc.rust-lang.org/cargo
-[Phylum]: https://phylum.io
+[Phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -5,7 +5,7 @@ through [Phylum][phylum] before installing them.
 
 [phylum-cli]: https://github.com/phylum-dev/cli
 [npm]: https://www.npmjs.com/
-[phylum]: https://phylum.io
+[phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/extensions/phylum.d.ts
+++ b/extensions/phylum.d.ts
@@ -144,7 +144,7 @@ declare namespace Phylum {
    * User information object example:
    * ```
    * {
-   *   email: "user@phylum.io",
+   *   email: "user@veracode.com",
    *   sub: "af8b5c32-9966-496a-e5ae-9ca9ceb43294",
    *   name: "John Doe",
    *   given_name: "John",

--- a/extensions/pip/README.md
+++ b/extensions/pip/README.md
@@ -5,7 +5,7 @@ A [Phylum CLI][phylum-cli] extension that checks your [pip] dependencies through
 
 [phylum-cli]: https://github.com/phylum-dev/cli
 [pip]: https://pip.pypa.io
-[phylum]: https://phylum.io
+[phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/extensions/poetry/README.md
+++ b/extensions/poetry/README.md
@@ -5,7 +5,7 @@ dependencies through [Phylum][phylum] before installing them.
 
 [phylum-cli]: https://github.com/phylum-dev/cli
 [poetry]: https://python-poetry.org/
-[phylum]: https://phylum.io
+[phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/extensions/poetry/fixtures/pyproject.toml
+++ b/extensions/poetry/fixtures/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fixture"
 version = "0.1.0"
 description = ""
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/extensions/yarn/README.md
+++ b/extensions/yarn/README.md
@@ -5,7 +5,7 @@ through [Phylum][phylum] before installing them.
 
 [phylum-cli]: https://github.com/phylum-dev/cli
 [yarn]: https://yarnpkg.com/
-[phylum]: https://phylum.io
+[phylum]: https://app.phylum.io
 
 ## Installation
 

--- a/lockfile/Cargo.toml
+++ b/lockfile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "phylum_lockfile"
 description = "Package lockfile parsers used by Phylum"
 version = "0.1.0"
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 edition = "2021"
 rust-version = "1.70.0"
 
@@ -18,7 +18,11 @@ log = "0.4.6"
 nom = "7.1.1"
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }
 purl = "0.1.1"
-quick-xml = { version = "0.37.1", features = ["encoding", "overlapped-lists", "serialize"] }
+quick-xml = { version = "0.37.1", features = [
+    "encoding",
+    "overlapped-lists",
+    "serialize",
+] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 serde_yaml = "0.9.2"

--- a/lockfile_generator/Cargo.toml
+++ b/lockfile_generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lockfile_generator"
 version = "0.1.0"
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
 rust-version = "1.68.0"

--- a/phylum_project/Cargo.toml
+++ b/phylum_project/Cargo.toml
@@ -3,13 +3,16 @@ name = "phylum_project"
 description = "Phylum project configuration handling"
 repository = "https://github.com/phylum-dev/cli"
 version = "0.1.0"
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
 rust-version = "1.64.0"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["serde", "clock"] }
+chrono = { version = "^0.4", default-features = false, features = [
+    "serde",
+    "clock",
+] }
 dunce = "1.0.5"
 log = "0.4.6"
 phylum_types = { git = "https://github.com/phylum-dev/phylum-types", branch = "development" }

--- a/vulnreach_types/Cargo.toml
+++ b/vulnreach_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vulnreach_types"
 version = "0.1.0"
-authors = ["Phylum, Inc. <engineering@phylum.io>"]
+authors = ["Veracode, Inc. <dl-phylum-engineering@veracode.com>"]
 edition = "2021"
 rust-version = "1.65.0"
 


### PR DESCRIPTION
This change updates the `@phylum.io` emails to `@veracode.com` ones.

Related to phylum-dev/documentation#276
