### PR TITLE
Update workflow runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
         run: |
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
@@ -70,7 +70,7 @@ jobs:
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
-        run: sudo apt update && sudo apt install -y protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - if: ${{ runner.os == 'Windows' }}
         name: Install protoc
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install host dependencies
-        run: sudo apt install -yq zip
+        run: sudo apt-get install -yq zip
 
       - name: Checkout the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   rustfmt:
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             flags: --all-features
           - os: macos-14
             flags: --all-features
@@ -49,7 +49,7 @@ jobs:
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
 
       - if: ${{ runner.os == 'Windows' }}
         name: Install protoc
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-22.04, macos-14]
         include:
           - os: windows-latest
             flags: --no-default-features -F extensions
@@ -80,7 +80,7 @@ jobs:
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
 
       - if: ${{ runner.os == 'Windows' }}
         name: Install protoc
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -108,7 +108,7 @@ jobs:
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
 
       - if: ${{ runner.os == 'Windows' }}
         name: Install protoc
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -139,7 +139,7 @@ jobs:
 
       - if: ${{ runner.os == 'Linux' }}
         name: Install protoc
-        run: sudo apt install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
         run: rustup toolchain install --no-self-update stable --profile minimal


### PR DESCRIPTION
This change updates the workflow runners to move away from the soon to
be deprecated `ubuntu-20.04` image and use `ubuntu-22.04` instead. The
intention is to continue to use the oldest supported version to ensure
binaries can build and run on that version. `ubuntu-latest` is used for
the linting related jobs.

Additionally, uses of `apt` were changed to `apt-get` to silence
warnings in CI about how `apt` is not meant to be used in scripts.

Ref: https://github.com/actions/runner-images/issues/11101
