### PR TITLE
Add `Unreleased` section back to `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
 ## 7.5.0 - 2025-04-01
 
 ### Changed


### PR DESCRIPTION
This change fixes the `release` workflow. It has been broken since the v7.5.0 release, when the `CHANGELOG` was updated by hand instead of with the `bump_version.sh` script. That is, the `Unreleased` section was removed from the `CHANGELOG`, which caused the `Create release artifacts` step of the `release` workflow to fail for non-release branch runs because it looks for the `Unreleased` header and does not find it.

## Testing

The changes from this branch have been confirmed to work with this manual workflow run: https://github.com/phylum-dev/cli/actions/runs/14449883373/job/40520966209