### PR TITLE
Update workflows to current standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  # All GitHub actions should be pinned to an explicit SHA instead of a tag name.
+  # All untrusted GitHub actions should be pinned to an explicit SHA instead of a tag name.
   # Each pin should include a comment about the version of the action to which it corresponds.
   # Dependabot will update these comments at the same time that it updates the pin.
   - package-ecosystem: "github-actions"

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -3,40 +3,55 @@ name: Update Deps
 
 on:
   workflow_dispatch:
-  # Run every Monday
+  # Run every Monday at 0530 UTC
   schedule:
     - cron: '30 5 * * 1'
 
 jobs:
   cargo-update:
+    name: Update dependencies
     runs-on: ubuntu-latest
+    env:
+      UPDATE_BRANCH_NAME: auto-cargo-update
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: Cargo update
         run: cargo update
 
       - name: Commit changes
         id: commit
+        # There may not be any updates to commit/push
         continue-on-error: true
         run: |
           git config user.name 'phylum-bot'
           git config user.email '69485888+phylum-bot@users.noreply.github.com'
           git commit -a -m "Bump dependencies"
-          git push --force origin HEAD:auto-cargo-update
+          git push --force origin HEAD:${{ env.UPDATE_BRANCH_NAME }}
 
       - name: Create Pull Request
+        id: pr
         if: ${{ steps.commit.outcome == 'success' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        # The PR may already exist (e.g., created in previous week and not merged yet) so we
+        # allow it here and check in the next step so workflow failures will be extraordinary
+        continue-on-error: true
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
-            github.rest.pulls.create({
+            const response = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "auto-cargo-update",
+              head: "${{ env.UPDATE_BRANCH_NAME }}",
               base: context.ref,
               title: "Bump dependencies",
               body: "Bump dependencies for all SemVer-compatible updates.",
             });
+            console.log(response);
+
+      - name: Verify PR exists
+        if: ${{ steps.pr.outcome == 'failue' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr view ${{ env.UPDATE_BRANCH_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -32,7 +32,7 @@ jobs:
         run: cargo run --package xtask gencomp
 
       - name: Upload shell completions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: shell-completions
           path: ./target/completions/
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
         run: cargo +stable build --release --target ${{ matrix.target }} ${{ matrix.flags }}
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: phylum-${{ matrix.target }}
           path: ./target/${{ matrix.target }}/release/phylum${{ matrix.extension }}
@@ -99,12 +99,12 @@ jobs:
         run: sudo apt-get install -yq zip
 
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           path: cli
 
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@v4
 
       - name: Prep archives
         run: |
@@ -128,7 +128,7 @@ jobs:
           done
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: release-archives
           path: |
@@ -138,7 +138,7 @@ jobs:
           retention-days: 7
 
       - name: Create release notes
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require("node:fs");
@@ -160,7 +160,7 @@ jobs:
             fs.writeFileSync("RELEASE-NOTES.txt", releaseNotes);
 
       - name: Upload release notes
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: RELEASE-NOTES.txt
           path: RELEASE-NOTES.txt
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@v4
         with:
           name: release-archives
 
@@ -193,13 +193,13 @@ jobs:
           done
 
       - name: Download release notes
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@v4
         with:
           name: RELEASE-NOTES.txt
 
       - name: Create GitHub release
         id: create_release
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7
         with:
           # The response is explicitly returned here so it will be available for other steps
           script: |
@@ -242,7 +242,7 @@ jobs:
         # Don't trigger for pre-releases
         if: ${{ !contains(github.ref, 'rc') }}
         # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
@@ -258,7 +258,7 @@ jobs:
         # Don't trigger for pre-releases
         if: ${{ !contains(github.ref, 'rc') }}
         # Reference: https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-15
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             extension: .exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         include:
           - os: ubuntu-latest
             flags: --all-features
-          - os: macos-14
+          - os: macos-15
             flags: --all-features
           - os: windows-latest
             flags: --no-default-features -F extensions
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
         include:
           - os: windows-latest
             flags: --no-default-features -F extensions
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-15, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: Install Rust nightly toolchain
         run: rustup toolchain install --no-self-update nightly --profile minimal -c rustfmt
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
@@ -131,7 +131,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - if: ${{ runner.os == 'macOS' }}
         name: Install protoc
@@ -155,7 +155,7 @@ jobs:
     container: denoland/deno
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: deno fmt
         run: deno fmt --check
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: Script Style Check
         run: find . -iname "*.sh" -print0 | xargs -0 shellcheck -o all -S style -s sh


### PR DESCRIPTION
This change updates the `cargo-update` workflow to be more like the rest
of the repos in the `phylum-dev` org. That is, it will no longer fail if
an update PR already exists. Additional changes made include:

* Update macOS runners from `macos-14` to `macos-15`
* Use environment variable for the branch name to be DRY
* Allow major version tags when specifying trusted actions
* Update existing comments and add more comments

Resources:
* [Standard GitHub-hosted runners for public repos](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
* [Latest `macos-15` image release](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250714.1971)
* [SW included in latest `macos-15` image](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md)